### PR TITLE
v0.1: metrics, RTT, pull API, config reshape, tunable sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Portal assumes unified sampling — the robot captures state + frames at the sam
 ```python
 config.set_fps(30)            # unified capture rate (default: 30)
 config.set_slack(5)           # ticks of pipeline headroom (default: 5)
+config.set_tolerance(1.5)     # match window in tick units (default: 1.5)
 
 config.set_state_reliable(True)   # default: True
 config.set_action_reliable(True)  # default: True
@@ -83,9 +84,14 @@ config.set_action_reliable(True)  # default: True
 config.set_ping_ms(1000)      # RTT ping cadence; 0 disables (default: 1000)
 ```
 
-**`fps`** — the unified sampling rate. Derives `search_range = 1/(2·fps)`, so at 30fps a state matches a frame within ~16.6ms. Raise to 60 for high-rate robots.
+**`fps`** — unified sampling rate (use the video rate if video and state differ). Drives the match window with `tolerance`. Raise to 60 for high-rate robots.
 
-**`slack`** — ticks of pipeline headroom: the per-track video sync buffer, the state sync buffer, and the pull-side observation slot all use this. Larger values tolerate more network jitter and loss-detection latency at the cost of staleness. 5 ticks (≈83ms at 60fps) is comfortable; the minimum useful value is 2.
+**`slack`** — ticks of pipeline headroom: the per-track video sync buffer and the state sync buffer use this. Larger values tolerate more jitter and loss-detection latency at the cost of staleness. Minimum useful value is 2; default 5 ≈ 167ms at 30fps.
+
+**`tolerance`** — how far a state reaches when matching a frame, in tick units. `search_range = tolerance / fps`.
+- `0.5` (tight) — match only within half a tick. A single lost frame drops the observation. Best for real-time control.
+- `1.5` (default, widened) — state falls back to the ±1 neighbor frame if its native frame was lost. Preserves observations at the cost of ±1-tick misalignment. Best for data collection and lossy links. A fair-share check prevents earlier states from stealing neighbor frames.
+- `> 2.0` — allows T±2 matches. Higher recovery but the misalignment risk outweighs the benefit for most setups.
 
 **Reliability** — state and action use reliable (lossless, ordered) SCTP delivery by default. For high-frequency control where only the latest value matters, switch to unreliable to avoid head-of-line blocking under packet loss. Video is always unreliable (RTP).
 

--- a/README.md
+++ b/README.md
@@ -69,29 +69,25 @@ State and video frames are tagged with system time on the sender side. The recei
 
 Video frame timestamps are embedded using LiveKit's packet trailer feature, which survives the full WebRTC encode/decode pipeline.
 
-## Tuning the sync buffer
+## Tuning
 
-The defaults are tuned for 60fps video and state. All settings are on the config object before connecting.
-
-```python
-config.set_search_range_ms(10)    # max timestamp delta for a state-frame match (default: 10ms)
-config.set_video_buffer(5)        # frames buffered per video track (default: 5)
-config.set_state_buffer(5)        # states buffered for sync (default: 5)
-config.set_observation_buffer(3)  # synced observations buffered (default: 3)
-```
-
-**`search_range_ms`** — how close (in ms) a state timestamp and a video frame timestamp must be to pair. At 60fps, one frame is ~16.7ms. The default of 10ms is generous for same-loop-iteration sends but tight enough to never accidentally match a neighboring frame. Increase if your state and video are sent from different threads with more jitter.
-
-**`video_buffer`** / **`state_buffer`** — how many samples to hold while waiting for a match. At 60fps, 5 frames = ~83ms of headroom. If a match can't happen within that window, the state is dropped (and the drop callback fires). Increase if you have high network jitter or variable frame rates.
-
-**`observation_buffer`** — how many synced observations to hold before the oldest is evicted. If your model inference takes 50ms at 60fps, ~3 observations queue up. Increase if your consumer is bursty.
-
-**Data reliability** — state and action use reliable (lossless, ordered) delivery by default. For high-frequency inference where only the latest value matters, switch to unreliable to avoid head-of-line blocking under packet loss:
+Portal assumes unified sampling — the robot captures state + frames at the same tick. All sync parameters derive from a single `fps`, and all internal buffers share a single `slack` size.
 
 ```python
-config.set_state_reliable(False)   # default: True
-config.set_action_reliable(False)  # default: True
+config.set_fps(30)            # unified capture rate (default: 30)
+config.set_slack(5)           # ticks of pipeline headroom (default: 5)
+
+config.set_state_reliable(True)   # default: True
+config.set_action_reliable(True)  # default: True
+
+config.set_ping_ms(1000)      # RTT ping cadence; 0 disables (default: 1000)
 ```
+
+**`fps`** — the unified sampling rate. Derives `search_range = 1/(2·fps)`, so at 30fps a state matches a frame within ~16.6ms. Raise to 60 for high-rate robots.
+
+**`slack`** — ticks of pipeline headroom: the per-track video sync buffer, the state sync buffer, and the pull-side observation slot all use this. Larger values tolerate more network jitter and loss-detection latency at the cost of staleness. 5 ticks (≈83ms at 60fps) is comfortable; the minimum useful value is 2.
+
+**Reliability** — state and action use reliable (lossless, ordered) SCTP delivery by default. For high-frequency control where only the latest value matters, switch to unreliable to avoid head-of-line blocking under packet loss. Video is always unreliable (RTP).
 
 ## Language support
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,34 @@ config.set_ping_ms(1000)      # RTT ping cadence; 0 disables (default: 1000)
 - `1.5` (default, widened) — state falls back to the ±1 neighbor frame if its native frame was lost. Preserves observations at the cost of ±1-tick misalignment. Best for data collection and lossy links. A fair-share check prevents earlier states from stealing neighbor frames.
 - `> 2.0` — allows T±2 matches. Higher recovery but the misalignment risk outweighs the benefit for most setups.
 
+### Choosing `tolerance`
+
+| Use case | Pick | Why |
+|---|---|---|
+| Real-time inference / control | `0.5` | Misalignment (acting on a visibly different frame) is worse than dropping. A drop is an explicit signal; a misaligned observation is silently wrong. |
+| Data collection for VLA training | `1.5` | Every observation is a training sample. A ±1-tick misalignment (~16ms at 60fps) is usually invisible to a trained model; a dropped observation is lost data. |
+| Teleop viewer | `1.5` | Visual continuity matters more than frame-perfect state alignment. |
+| Clean local network (<1% loss) | either | Drops are already rare. Default is fine. |
+| Lossy / cellular / wireless | `1.5` | Widening materially reduces drop rate under real loss conditions. |
+| Strict-alignment datasets | `0.5` | If downstream tooling relies on exact state/frame pairing, drops are cheaper than mislabeled pairs. |
+
+### Asymmetric rates (video faster than state)
+
+The library handles video > state rates transparently — intervening frames between state ticks get drained at match time and don't pile up, **provided the buffer is large enough**. Two rules:
+
+1. **Set `fps` to the video rate**, not the state rate. The match window is measured in frame intervals, so it has to know the video cadence. Example: video 60fps, state 30Hz → `set_fps(60)`.
+2. **Set `slack ≥ ceil(video_rate / state_rate) + 1`**. Between consecutive state matches, roughly `video_rate / state_rate` frames accumulate per track; slack must cover that plus jitter headroom. At default slack=5 the library cleanly handles up to ~4× asymmetry. For 10× asymmetry (video 60fps, state 6Hz), bump to `slack=12` or so.
+
+Example: video 60fps, state 10Hz (asymmetric teleop with slow sensor):
+
+```python
+config.set_fps(60)
+config.set_slack(8)          # ceil(60/10) + 2 = 8
+config.set_tolerance(1.5)    # still measured in video-tick intervals (~16.6ms each)
+```
+
+One thing to note: under asymmetric rates, the overall drop rate is proportional to `state_rate × video_loss_rate`, not the video rate. Losing a video frame that happened to fall on a state tick costs one observation; losing a video frame between state ticks costs nothing (it would have been drained anyway).
+
 **Reliability** — state and action use reliable (lossless, ordered) SCTP delivery by default. For high-frequency control where only the latest value matters, switch to unreliable to avoid head-of-line blocking under packet loss. Video is always unreliable (RTP).
 
 ## Language support

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -73,13 +73,11 @@ impl PortalConfig {
         self.ping_ms = ms;
     }
 
-    /// Derived sync config used internally by the sync buffer and observation
-    /// sink. Not part of the public API.
+    /// Derived sync config used internally by the sync buffer. Not public.
     pub(crate) fn sync_config(&self) -> SyncConfig {
         SyncConfig {
             video_buffer_size: self.slack,
             state_buffer_size: self.slack,
-            observation_buffer_size: self.slack,
             search_range_us: 1_000_000 / (2 * self.fps as u64),
         }
     }

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -12,6 +12,7 @@ pub struct PortalConfig {
     pub(crate) action_reliable: bool,
     pub(crate) fps: u32,
     pub(crate) slack: u32,
+    pub(crate) tolerance: f32,
     pub(crate) ping_ms: u64,
 }
 
@@ -27,6 +28,7 @@ impl PortalConfig {
             action_reliable: true,
             fps: 30,
             slack: 5,
+            tolerance: 1.5,
             ping_ms: 1000,
         }
     }
@@ -43,11 +45,30 @@ impl PortalConfig {
         self.action_fields.extend(fields.iter().map(|s| s.to_string()));
     }
 
-    /// Unified observation rate. All sync parameters derive from this:
-    /// sender captures state + frames at this rate, and `search_range = 1/(2·fps)`.
+    /// Unified observation rate (set to the video capture rate if state and
+    /// video differ). Drives `search_range = tolerance/fps`.
     pub fn set_fps(&mut self, fps: u32) {
         assert!(fps > 0, "fps must be > 0");
         self.fps = fps;
+    }
+
+    /// How far (in tick intervals at `fps`) a state may reach when matching
+    /// a video frame. `search_range = tolerance / fps`.
+    ///
+    /// - `0.5` (tight): state only matches a frame within ±half a tick.
+    ///   One lost frame → one dropped observation. Lowest misalignment risk.
+    /// - `1.5` (default, widened): state matches its own frame, or falls
+    ///   back to T±1 if its native frame was lost. Preserves observations
+    ///   at the cost of occasional ±1-tick misalignment. A fair-share check
+    ///   prevents an earlier state from stealing a frame closer to a later
+    ///   state already in the buffer.
+    /// - `> 2.0`: state may match T±2 frames. Higher recovery, higher
+    ///   misalignment risk. Rarely worth it.
+    ///
+    /// Values must be in `(0, ∞)`. Defaults to `1.5`.
+    pub fn set_tolerance(&mut self, ticks: f32) {
+        assert!(ticks > 0.0, "tolerance must be > 0");
+        self.tolerance = ticks;
     }
 
     /// Ticks of pipeline headroom — how much jitter, loss-detection latency,
@@ -75,10 +96,11 @@ impl PortalConfig {
 
     /// Derived sync config used internally by the sync buffer. Not public.
     pub(crate) fn sync_config(&self) -> SyncConfig {
+        let search_range_us = (self.tolerance * 1_000_000.0 / self.fps as f32) as u64;
         SyncConfig {
             video_buffer_size: self.slack,
             state_buffer_size: self.slack,
-            search_range_us: 1_000_000 / (2 * self.fps as u64),
+            search_range_us,
         }
     }
 }

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -10,8 +10,9 @@ pub struct PortalConfig {
     pub(crate) action_fields: Vec<String>,
     pub(crate) state_reliable: bool,
     pub(crate) action_reliable: bool,
-    pub(crate) sync_config: SyncConfig,
-    pub(crate) ping_interval_ms: u64,
+    pub(crate) fps: u32,
+    pub(crate) slack: u32,
+    pub(crate) ping_ms: u64,
 }
 
 impl PortalConfig {
@@ -24,8 +25,9 @@ impl PortalConfig {
             action_fields: Vec::new(),
             state_reliable: true,
             action_reliable: true,
-            sync_config: SyncConfig::default(),
-            ping_interval_ms: 1000,
+            fps: 30,
+            slack: 5,
+            ping_ms: 1000,
         }
     }
 
@@ -41,20 +43,20 @@ impl PortalConfig {
         self.action_fields.extend(fields.iter().map(|s| s.to_string()));
     }
 
-    pub fn set_video_buffer(&mut self, size: u32) {
-        self.sync_config.video_buffer_size = size;
+    /// Unified observation rate. All sync parameters derive from this:
+    /// sender captures state + frames at this rate, and `search_range = 1/(2·fps)`.
+    pub fn set_fps(&mut self, fps: u32) {
+        assert!(fps > 0, "fps must be > 0");
+        self.fps = fps;
     }
 
-    pub fn set_state_buffer(&mut self, size: u32) {
-        self.sync_config.state_buffer_size = size;
-    }
-
-    pub fn set_search_range_ms(&mut self, ms: u64) {
-        self.sync_config.search_range_us = ms * 1000;
-    }
-
-    pub fn set_observation_buffer(&mut self, size: u32) {
-        self.sync_config.observation_buffer_size = size;
+    /// Ticks of pipeline headroom — how much jitter, loss-detection latency,
+    /// and consumer lag the pipeline tolerates before dropping. Applies to
+    /// the per-track video sync buffer, the state sync buffer, and the
+    /// pull-side observation buffer.
+    pub fn set_slack(&mut self, ticks: u32) {
+        assert!(ticks > 0, "slack must be > 0");
+        self.slack = ticks;
     }
 
     pub fn set_state_reliable(&mut self, reliable: bool) {
@@ -65,10 +67,20 @@ impl PortalConfig {
         self.action_reliable = reliable;
     }
 
-    /// RTT ping cadence in milliseconds. Set to `0` to disable active pinging
-    /// on this side; the pong echo path remains active regardless, so the peer
-    /// can still measure its own RTT. Default: 1000ms.
-    pub fn set_ping_interval_ms(&mut self, ms: u64) {
-        self.ping_interval_ms = ms;
+    /// RTT ping cadence. Set to `0` to disable active pinging on this side;
+    /// the pong echo path remains active so the peer can still measure.
+    pub fn set_ping_ms(&mut self, ms: u64) {
+        self.ping_ms = ms;
+    }
+
+    /// Derived sync config used internally by the sync buffer and observation
+    /// sink. Not part of the public API.
+    pub(crate) fn sync_config(&self) -> SyncConfig {
+        SyncConfig {
+            video_buffer_size: self.slack,
+            state_buffer_size: self.slack,
+            observation_buffer_size: self.slack,
+            search_range_us: 1_000_000 / (2 * self.fps as u64),
+        }
     }
 }

--- a/livekit-portal/src/data.rs
+++ b/livekit-portal/src/data.rs
@@ -101,7 +101,34 @@ impl Drop for DataPublisher {
 
 // --- Receiver (dispatches DataReceived events) ---
 
-pub(crate) type DataCb = Box<dyn Fn(HashMap<String, f64>) + Send + Sync>;
+pub(crate) type DataCb = Box<dyn Fn(&HashMap<String, f64>) + Send + Sync>;
+
+/// Push callback + latest-wins slot for a single data stream (state or action),
+/// paired so receivers and getters share one allocation.
+pub(crate) struct DataSlots {
+    pub cb: Mutex<Option<DataCb>>,
+    pub latest: Mutex<Option<HashMap<String, f64>>>,
+}
+
+impl DataSlots {
+    pub fn new() -> Self {
+        Self { cb: Mutex::new(None), latest: Mutex::new(None) }
+    }
+
+    /// Build the field map once, fire the callback by reference (no clone),
+    /// then hand ownership to the latest slot.
+    fn deliver(&self, fields: &[String], values: &[f64]) {
+        let map = to_field_map(fields, values);
+        if let Some(cb) = self.cb.lock().as_ref() {
+            cb(&map);
+        }
+        *self.latest.lock() = Some(map);
+    }
+
+    pub fn clear(&self) {
+        *self.latest.lock() = None;
+    }
+}
 
 /// Handle a `DataReceived` event. Pushes into the sync buffer if applicable and
 /// returns any observations/drops that resulted, for the caller to dispatch
@@ -113,10 +140,8 @@ pub(crate) fn handle_data_received(
     config_role: Role,
     action_fields: &[String],
     state_fields: &[String],
-    action_cb: &Mutex<Option<DataCb>>,
-    state_cb: &Mutex<Option<DataCb>>,
-    action_latest: &Mutex<Option<HashMap<String, f64>>>,
-    state_latest: &Mutex<Option<HashMap<String, f64>>>,
+    action: &DataSlots,
+    state: &DataSlots,
     sync_buffer: Option<&Arc<Mutex<SyncBuffer>>>,
     metrics: &MetricsRegistry,
     rtt: &RttService,
@@ -129,22 +154,14 @@ pub(crate) fn handle_data_received(
         (Role::Robot, "portal_action") => match deserialize_values(payload, action_fields.len()) {
             Ok((send_ts, values)) => {
                 metrics.record_action_received(send_ts, now_us());
-                let map = to_field_map(action_fields, &values);
-                if let Some(cb) = action_cb.lock().as_ref() {
-                    cb(map.clone());
-                }
-                *action_latest.lock() = Some(map);
+                action.deliver(action_fields, &values);
             }
             Err(e) => log::warn!("failed to deserialize action payload: {e}"),
         },
         (Role::Operator, "portal_state") => match deserialize_values(payload, state_fields.len()) {
             Ok((timestamp_us, values)) => {
                 metrics.record_state_received(timestamp_us, now_us());
-                let map = to_field_map(state_fields, &values);
-                if let Some(cb) = state_cb.lock().as_ref() {
-                    cb(map.clone());
-                }
-                *state_latest.lock() = Some(map);
+                state.deliver(state_fields, &values);
                 if let Some(sb) = sync_buffer {
                     return sb.lock().push_state(timestamp_us, values);
                 }

--- a/livekit-portal/src/data.rs
+++ b/livekit-portal/src/data.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use crate::error::{PortalError, PortalResult};
+use crate::error::PortalResult;
 use crate::metrics::{DataStream, MetricsRegistry};
 use crate::rtt::{RttService, RTT_TOPIC};
 use crate::serialization::{deserialize_values, serialize_values};
@@ -27,6 +27,11 @@ pub(crate) struct DataPublisher {
     task: Option<JoinHandle<()>>,
     metrics: Arc<MetricsRegistry>,
     stream: DataStream,
+    // Per-field snapshot of the last sent value. `send_map` carries these
+    // forward when a caller supplies only a subset of the declared fields,
+    // so partial updates stay consistent with the robot's actual state.
+    // Seeded with 0.0, so fields never sent resolve to 0.
+    last_values: Mutex<Vec<f64>>,
 }
 
 impl DataPublisher {
@@ -46,6 +51,7 @@ impl DataPublisher {
                 }
             }
         });
+        let last_values = Mutex::new(vec![0.0; fields.len()]);
         Self {
             fields,
             topic: topic.to_string(),
@@ -54,16 +60,23 @@ impl DataPublisher {
             task: Some(task),
             metrics,
             stream,
+            last_values,
         }
     }
 
-    pub fn send(&self, values: &[f64], timestamp_us: Option<u64>) -> PortalResult<()> {
-        if values.len() != self.fields.len() {
-            return Err(PortalError::WrongValueCount {
-                expected: self.fields.len(),
-                got: values.len(),
-            });
-        }
+    /// Send from a HashMap, reordering to declared field order. Missing fields
+    /// inherit their last sent value (0.0 if never sent) — partial updates
+    /// carry forward prior state instead of silently zeroing it.
+    pub fn send_map(
+        &self,
+        map: &HashMap<String, f64>,
+        timestamp_us: Option<u64>,
+    ) -> PortalResult<()> {
+        let values = resolve_with_carry_forward(&self.fields, &mut self.last_values.lock(), map);
+        self.dispatch(&values, timestamp_us)
+    }
+
+    fn dispatch(&self, values: &[f64], timestamp_us: Option<u64>) -> PortalResult<()> {
         let ts = timestamp_us.unwrap_or_else(now_us);
         let payload = serialize_values(ts, values);
         let packet = DataPacket {
@@ -77,18 +90,21 @@ impl DataPublisher {
         }
         Ok(())
     }
+}
 
-    /// Send from a HashMap, reordering to declared field order.
-    /// Missing keys default to 0.0 — callers should supply every declared field.
-    pub fn send_map(
-        &self,
-        map: &HashMap<String, f64>,
-        timestamp_us: Option<u64>,
-    ) -> PortalResult<()> {
-        let values: Vec<f64> =
-            self.fields.iter().map(|name| *map.get(name).unwrap_or(&0.0)).collect();
-        self.send(&values, timestamp_us)
+/// Update `last` in place with values from `map` for each declared field,
+/// leaving other slots untouched (carry-forward). Returns a copy for sending.
+fn resolve_with_carry_forward(
+    fields: &[String],
+    last: &mut [f64],
+    map: &HashMap<String, f64>,
+) -> Vec<f64> {
+    for (i, name) in fields.iter().enumerate() {
+        if let Some(&v) = map.get(name) {
+            last[i] = v;
+        }
     }
+    last.to_vec()
 }
 
 impl Drop for DataPublisher {
@@ -171,4 +187,47 @@ pub(crate) fn handle_data_received(
         _ => {}
     }
     SyncOutput::empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn carry_forward_fills_missing_fields() {
+        let fields =
+            vec!["j1".to_string(), "j2".to_string(), "j3".to_string()];
+        let mut last = vec![0.0; 3];
+
+        let m: HashMap<_, _> = [("j1".to_string(), 1.0)].into_iter().collect();
+        assert_eq!(
+            resolve_with_carry_forward(&fields, &mut last, &m),
+            vec![1.0, 0.0, 0.0],
+            "unsent fields start at seed (0.0)"
+        );
+
+        let m: HashMap<_, _> = [("j2".to_string(), 2.5)].into_iter().collect();
+        assert_eq!(
+            resolve_with_carry_forward(&fields, &mut last, &m),
+            vec![1.0, 2.5, 0.0],
+            "j1 carries forward; j2 updates; j3 still at seed"
+        );
+
+        let m: HashMap<_, _> =
+            [("j1".to_string(), -1.0), ("j3".to_string(), 7.0)].into_iter().collect();
+        assert_eq!(
+            resolve_with_carry_forward(&fields, &mut last, &m),
+            vec![-1.0, 2.5, 7.0],
+            "j2 carries forward when omitted; others update"
+        );
+    }
+
+    #[test]
+    fn unknown_fields_in_map_are_ignored() {
+        let fields = vec!["j1".to_string()];
+        let mut last = vec![0.0];
+        let m: HashMap<_, _> =
+            [("j1".to_string(), 3.0), ("unknown".to_string(), 99.0)].into_iter().collect();
+        assert_eq!(resolve_with_carry_forward(&fields, &mut last, &m), vec![3.0]);
+    }
 }

--- a/livekit-portal/src/data.rs
+++ b/livekit-portal/src/data.rs
@@ -115,6 +115,8 @@ pub(crate) fn handle_data_received(
     state_fields: &[String],
     action_cb: &Mutex<Option<DataCb>>,
     state_cb: &Mutex<Option<DataCb>>,
+    action_latest: &Mutex<Option<HashMap<String, f64>>>,
+    state_latest: &Mutex<Option<HashMap<String, f64>>>,
     sync_buffer: Option<&Arc<Mutex<SyncBuffer>>>,
     metrics: &MetricsRegistry,
     rtt: &RttService,
@@ -127,18 +129,22 @@ pub(crate) fn handle_data_received(
         (Role::Robot, "portal_action") => match deserialize_values(payload, action_fields.len()) {
             Ok((send_ts, values)) => {
                 metrics.record_action_received(send_ts, now_us());
+                let map = to_field_map(action_fields, &values);
                 if let Some(cb) = action_cb.lock().as_ref() {
-                    cb(to_field_map(action_fields, &values));
+                    cb(map.clone());
                 }
+                *action_latest.lock() = Some(map);
             }
             Err(e) => log::warn!("failed to deserialize action payload: {e}"),
         },
         (Role::Operator, "portal_state") => match deserialize_values(payload, state_fields.len()) {
             Ok((timestamp_us, values)) => {
                 metrics.record_state_received(timestamp_us, now_us());
+                let map = to_field_map(state_fields, &values);
                 if let Some(cb) = state_cb.lock().as_ref() {
-                    cb(to_field_map(state_fields, &values));
+                    cb(map.clone());
                 }
+                *state_latest.lock() = Some(map);
                 if let Some(sb) = sync_buffer {
                     return sb.lock().push_state(timestamp_us, values);
                 }

--- a/livekit-portal/src/error.rs
+++ b/livekit-portal/src/error.rs
@@ -14,9 +14,6 @@ pub enum PortalError {
     #[error("unknown video track: {name}")]
     UnknownVideoTrack { name: String },
 
-    #[error("wrong number of values: expected {expected}, got {got}")]
-    WrongValueCount { expected: usize, got: usize },
-
     #[error("wrong frame size: expected {expected} bytes, got {got}")]
     WrongFrameSize { expected: usize, got: usize },
 

--- a/livekit-portal/src/metrics.rs
+++ b/livekit-portal/src/metrics.rs
@@ -96,7 +96,7 @@ impl MetricsRegistry {
     pub fn new(video_tracks: &[String]) -> Self {
         let per_track: HashMap<String, Arc<TrackMetrics>> = video_tracks
             .iter()
-            .map(|n| (n.clone(), Arc::new(TrackMetrics::new(n.clone()))))
+            .map(|n| (n.clone(), Arc::new(TrackMetrics::new())))
             .collect();
         Self {
             track_order: video_tracks.to_vec(),
@@ -244,8 +244,6 @@ impl MetricsRegistry {
 }
 
 pub(crate) struct TrackMetrics {
-    #[allow(dead_code)]
-    pub name: String,
     pub frames_sent: AtomicU64,
     pub frames_received: AtomicU64,
     pub evictions: AtomicU64,
@@ -253,9 +251,8 @@ pub(crate) struct TrackMetrics {
 }
 
 impl TrackMetrics {
-    pub fn new(name: String) -> Self {
+    pub fn new() -> Self {
         Self {
-            name,
             frames_sent: AtomicU64::new(0),
             frames_received: AtomicU64::new(0),
             evictions: AtomicU64::new(0),

--- a/livekit-portal/src/metrics.rs
+++ b/livekit-portal/src/metrics.rs
@@ -46,12 +46,8 @@ pub struct TransportMetrics {
 pub struct BufferMetrics {
     pub video_fill: HashMap<String, usize>,
     pub state_fill: usize,
-    pub observation_fill: usize,
     /// Per-video-track cumulative evictions from overflow.
     pub evictions: HashMap<String, u64>,
-    /// Observations dropped from the pull-side buffer because the consumer
-    /// lagged behind — distinct from `sync.states_dropped` (sync failure).
-    pub observations_evicted: u64,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -85,7 +81,6 @@ pub(crate) struct MetricsRegistry {
     action_jitter: Mutex<JitterState>,
 
     observations_emitted: AtomicU64,
-    observations_evicted: AtomicU64,
     states_dropped: AtomicU64,
     match_deltas: Mutex<SampleRing>,
     last_blocker_track: Mutex<Option<String>>,
@@ -113,7 +108,6 @@ impl MetricsRegistry {
             state_jitter: Mutex::new(JitterState::default()),
             action_jitter: Mutex::new(JitterState::default()),
             observations_emitted: AtomicU64::new(0),
-            observations_evicted: AtomicU64::new(0),
             states_dropped: AtomicU64::new(0),
             match_deltas: Mutex::new(SampleRing::new(SAMPLE_RING_CAP)),
             last_blocker_track: Mutex::new(None),
@@ -150,10 +144,6 @@ impl MetricsRegistry {
         self.match_deltas.lock().push(worst_delta_us);
     }
 
-    pub fn record_observation_evicted(&self, n: u64) {
-        self.observations_evicted.fetch_add(n, Ordering::Relaxed);
-    }
-
     pub fn record_state_dropped(&self, n: u64) {
         self.states_dropped.fetch_add(n, Ordering::Relaxed);
     }
@@ -176,7 +166,6 @@ impl MetricsRegistry {
         &self,
         video_fill: HashMap<String, usize>,
         state_fill: usize,
-        observation_fill: usize,
     ) -> PortalMetrics {
         let n = self.track_order.len();
         let mut frames_sent = HashMap::with_capacity(n);
@@ -222,13 +211,7 @@ impl MetricsRegistry {
                 state_jitter_us: self.state_jitter.lock().jitter_us,
                 action_jitter_us: self.action_jitter.lock().jitter_us,
             },
-            buffers: BufferMetrics {
-                video_fill,
-                state_fill,
-                observation_fill,
-                evictions,
-                observations_evicted: self.observations_evicted.load(Ordering::Relaxed),
-            },
+            buffers: BufferMetrics { video_fill, state_fill, evictions },
             rtt: RttMetrics {
                 rtt_us_last,
                 rtt_us_mean: rtt_mean,
@@ -247,7 +230,6 @@ impl MetricsRegistry {
         *self.state_jitter.lock() = JitterState::default();
         *self.action_jitter.lock() = JitterState::default();
         self.observations_emitted.store(0, Ordering::Relaxed);
-        self.observations_evicted.store(0, Ordering::Relaxed);
         self.states_dropped.store(0, Ordering::Relaxed);
         self.match_deltas.lock().clear();
         *self.last_blocker_track.lock() = None;
@@ -421,7 +403,7 @@ mod tests {
         reg.track("cam1").unwrap().record_sent();
         reg.track("cam2").unwrap().record_received(0, 100);
 
-        let snap = reg.snapshot(HashMap::new(), 0, 0);
+        let snap = reg.snapshot(HashMap::new(), 0);
         assert_eq!(snap.transport.frames_sent["cam1"], 2);
         assert_eq!(snap.transport.frames_sent["cam2"], 0);
         assert_eq!(snap.transport.frames_received["cam2"], 1);
@@ -437,7 +419,7 @@ mod tests {
         reg.record_blocker("cam1");
 
         reg.reset();
-        let snap = reg.snapshot(HashMap::new(), 0, 0);
+        let snap = reg.snapshot(HashMap::new(), 0);
         assert_eq!(snap.transport.frames_sent["cam1"], 0);
         assert_eq!(snap.sync.observations_emitted, 0);
         assert!(snap.rtt.rtt_us_last.is_none());

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -7,16 +7,15 @@ use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
 use crate::config::PortalConfig;
-use crate::data::{handle_data_received, DataCb, DataPublisher};
+use crate::data::{handle_data_received, DataPublisher, DataSlots};
 use crate::error::{PortalError, PortalResult};
 use crate::metrics::{DataStream, MetricsRegistry, PortalMetrics};
 use crate::rtt::RttService;
 use crate::sync_buffer::{SyncBuffer, SyncOutput};
 use crate::types::*;
-use crate::video::{VideoPublisher, VideoReceiver};
+use crate::video::{VideoPublisher, VideoReceiver, VideoTrackSlots};
 
 type ObservationCb = Box<dyn Fn(&Observation) + Send + Sync>;
-type VideoCb = Box<dyn Fn(&str, &VideoFrameData) + Send + Sync>;
 type DropCb = Box<dyn Fn(Vec<HashMap<String, f64>>) + Send + Sync>;
 
 /// Drains the buffers returned by `SyncBuffer::push_*` and dispatches them to
@@ -95,7 +94,7 @@ pub struct Portal {
     config: PortalConfig,
 
     // Lifecycle state (connect/disconnect).
-    state: Mutex<ConnectionState>,
+    conn: Mutex<ConnectionState>,
 
     // Video receivers are spawned by the event loop (on TrackSubscribed) and
     // torn down by `disconnect`, so they live in an Arc shared with both.
@@ -111,32 +110,21 @@ pub struct Portal {
     sync_buffer: Mutex<Option<Arc<Mutex<SyncBuffer>>>>,
     obs_sink: Arc<ObservationSink>,
 
-    // Data callbacks (push API).
-    action_cb: Arc<Mutex<Option<DataCb>>>,
-    state_cb: Arc<Mutex<Option<DataCb>>>,
+    // Push callback + pull latest-wins slot, bundled per stream.
+    action: Arc<DataSlots>,
+    state: Arc<DataSlots>,
     // Fixed at construction (keyed by declared video_tracks) — no lock on the map itself.
-    video_cbs: HashMap<String, Arc<Mutex<Option<VideoCb>>>>,
-
-    // Latest-wins slots (pull API). Parallel to the callback slots — updated
-    // on every receive regardless of whether a callback is registered.
-    action_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
-    state_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
-    video_latest: HashMap<String, Arc<Mutex<Option<VideoFrameData>>>>,
+    video_tracks: HashMap<String, Arc<VideoTrackSlots>>,
 
     metrics: Arc<MetricsRegistry>,
 }
 
 impl Portal {
     pub fn new(config: PortalConfig) -> Self {
-        let video_cbs: HashMap<_, _> = config
+        let video_tracks: HashMap<_, _> = config
             .video_tracks
             .iter()
-            .map(|name| (name.clone(), Arc::new(Mutex::new(None))))
-            .collect();
-        let video_latest: HashMap<_, _> = config
-            .video_tracks
-            .iter()
-            .map(|name| (name.clone(), Arc::new(Mutex::new(None))))
+            .map(|name| (name.clone(), Arc::new(VideoTrackSlots::new())))
             .collect();
 
         let metrics = Arc::new(MetricsRegistry::new(&config.video_tracks));
@@ -144,25 +132,22 @@ impl Portal {
 
         Self {
             config,
-            state: Mutex::new(ConnectionState { room: None, event_task: None, rtt: None }),
+            conn: Mutex::new(ConnectionState { room: None, event_task: None, rtt: None }),
             video_receivers: Arc::new(Mutex::new(HashMap::new())),
             video_publishers: Mutex::new(HashMap::new()),
             state_publisher: Mutex::new(None),
             action_publisher: Mutex::new(None),
             sync_buffer: Mutex::new(None),
             obs_sink,
-            action_cb: Arc::new(Mutex::new(None)),
-            state_cb: Arc::new(Mutex::new(None)),
-            video_cbs,
-            action_latest: Arc::new(Mutex::new(None)),
-            state_latest: Arc::new(Mutex::new(None)),
-            video_latest,
+            action: Arc::new(DataSlots::new()),
+            state: Arc::new(DataSlots::new()),
+            video_tracks,
             metrics,
         }
     }
 
     pub async fn connect(&self, url: &str, token: &str) -> PortalResult<()> {
-        if self.state.lock().room.is_some() {
+        if self.conn.lock().room.is_some() {
             return Err(PortalError::AlreadyConnected);
         }
 
@@ -194,13 +179,10 @@ impl Portal {
             config: self.config.clone(),
             sync_buffer: self.sync_buffer.lock().clone(),
             obs_sink: self.obs_sink.clone(),
-            action_cb: self.action_cb.clone(),
-            state_cb: self.state_cb.clone(),
-            video_cbs: self.video_cbs.clone(),
+            action: self.action.clone(),
+            state: self.state.clone(),
+            video_tracks: self.video_tracks.clone(),
             video_receivers: self.video_receivers.clone(),
-            action_latest: self.action_latest.clone(),
-            state_latest: self.state_latest.clone(),
-            video_latest: self.video_latest.clone(),
             metrics: self.metrics.clone(),
             rtt: rtt.clone(),
         };
@@ -211,7 +193,7 @@ impl Portal {
             }
         });
 
-        let mut state = self.state.lock();
+        let mut state = self.conn.lock();
         state.room = Some(room);
         state.event_task = Some(event_handle);
         state.rtt = Some(rtt);
@@ -259,14 +241,14 @@ impl Portal {
     }
 
     pub async fn disconnect(&self) -> PortalResult<()> {
-        let room = self.state.lock().room.take();
+        let room = self.conn.lock().room.take();
         log::info!("disconnecting");
         if let Some(room) = room {
             room.close().await.map_err(|e| PortalError::Room(e.to_string()))?;
         }
 
         {
-            let mut state = self.state.lock();
+            let mut state = self.conn.lock();
             if let Some(task) = state.event_task.take() {
                 task.abort();
             }
@@ -288,10 +270,10 @@ impl Portal {
             sb.lock().clear();
         }
         self.obs_sink.clear();
-        *self.action_latest.lock() = None;
-        *self.state_latest.lock() = None;
-        for slot in self.video_latest.values() {
-            *slot.lock() = None;
+        self.action.clear();
+        self.state.clear();
+        for slots in self.video_tracks.values() {
+            slots.clear();
         }
 
         Ok(())
@@ -308,31 +290,31 @@ impl Portal {
 
     /// Clone of the latest action received (Robot side), or `None`.
     pub fn get_action(&self) -> Option<HashMap<String, f64>> {
-        self.action_latest.lock().clone()
+        self.action.latest.lock().clone()
     }
 
     /// Clone of the latest state received (Operator side), or `None`.
     pub fn get_state(&self) -> Option<HashMap<String, f64>> {
-        self.state_latest.lock().clone()
+        self.state.latest.lock().clone()
     }
 
     /// Clone of the latest frame received for `track_name`, or `None`.
     pub fn get_video_frame(&self, track_name: &str) -> Option<VideoFrameData> {
-        self.video_latest.get(track_name).and_then(|s| s.lock().clone())
+        self.video_tracks.get(track_name).and_then(|s| s.latest.lock().clone())
     }
 
     // --- Callback registration (push API) ---
 
-    pub fn on_action(&self, callback: impl Fn(HashMap<String, f64>) + Send + Sync + 'static) {
-        *self.action_cb.lock() = Some(Box::new(callback));
+    pub fn on_action(&self, callback: impl Fn(&HashMap<String, f64>) + Send + Sync + 'static) {
+        *self.action.cb.lock() = Some(Box::new(callback));
     }
 
     pub fn on_observation(&self, callback: impl Fn(&Observation) + Send + Sync + 'static) {
         self.obs_sink.set_observation_cb(Box::new(callback));
     }
 
-    pub fn on_state(&self, callback: impl Fn(HashMap<String, f64>) + Send + Sync + 'static) {
-        *self.state_cb.lock() = Some(Box::new(callback));
+    pub fn on_state(&self, callback: impl Fn(&HashMap<String, f64>) + Send + Sync + 'static) {
+        *self.state.cb.lock() = Some(Box::new(callback));
     }
 
     pub fn on_video_frame(
@@ -340,8 +322,8 @@ impl Portal {
         track_name: &str,
         callback: impl Fn(&str, &VideoFrameData) + Send + Sync + 'static,
     ) {
-        match self.video_cbs.get(track_name) {
-            Some(cb_slot) => *cb_slot.lock() = Some(Box::new(callback)),
+        match self.video_tracks.get(track_name) {
+            Some(slots) => *slots.cb.lock() = Some(Box::new(callback)),
             None => log::warn!(
                 "on_video_frame: track '{track_name}' is not registered — callback ignored"
             ),
@@ -442,13 +424,10 @@ struct EventContext {
     config: PortalConfig,
     sync_buffer: Option<Arc<Mutex<SyncBuffer>>>,
     obs_sink: Arc<ObservationSink>,
-    action_cb: Arc<Mutex<Option<DataCb>>>,
-    state_cb: Arc<Mutex<Option<DataCb>>>,
-    video_cbs: HashMap<String, Arc<Mutex<Option<VideoCb>>>>,
+    action: Arc<DataSlots>,
+    state: Arc<DataSlots>,
+    video_tracks: HashMap<String, Arc<VideoTrackSlots>>,
     video_receivers: Arc<Mutex<HashMap<String, VideoReceiver>>>,
-    action_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
-    state_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
-    video_latest: HashMap<String, Arc<Mutex<Option<VideoFrameData>>>>,
     metrics: Arc<MetricsRegistry>,
     rtt: Arc<RttService>,
 }
@@ -467,16 +446,11 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                         ctx.config.session
                     );
                     if let Some(sync_buffer) = &ctx.sync_buffer {
-                        let raw_cb = ctx
-                            .video_cbs
+                        let slots = ctx
+                            .video_tracks
                             .get(track_name.as_str())
                             .cloned()
-                            .unwrap_or_else(|| Arc::new(Mutex::new(None)));
-                        let latest = ctx
-                            .video_latest
-                            .get(track_name.as_str())
-                            .cloned()
-                            .unwrap_or_else(|| Arc::new(Mutex::new(None)));
+                            .unwrap_or_else(|| Arc::new(VideoTrackSlots::new()));
                         let track_metrics = ctx
                             .metrics
                             .track(track_name.as_str())
@@ -487,8 +461,7 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                             track_name.to_string(),
                             stream,
                             sync_buffer.clone(),
-                            raw_cb,
-                            latest,
+                            slots,
                             ctx.obs_sink.clone(),
                             track_metrics,
                         );
@@ -497,25 +470,21 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                 }
             }
         }
-        RoomEvent::DataReceived { payload, topic, .. } => {
-            if let Some(topic) = &topic {
-                let output = handle_data_received(
-                    &payload,
-                    topic,
-                    ctx.config.role,
-                    &ctx.config.action_fields,
-                    &ctx.config.state_fields,
-                    &ctx.action_cb,
-                    &ctx.state_cb,
-                    &ctx.action_latest,
-                    &ctx.state_latest,
-                    ctx.sync_buffer.as_ref(),
-                    &ctx.metrics,
-                    &ctx.rtt,
-                );
-                if !output.is_empty() {
-                    ctx.obs_sink.dispatch(output);
-                }
+        RoomEvent::DataReceived { payload, topic: Some(topic), .. } => {
+            let output = handle_data_received(
+                &payload,
+                &topic,
+                ctx.config.role,
+                &ctx.config.action_fields,
+                &ctx.config.state_fields,
+                &ctx.action,
+                &ctx.state,
+                ctx.sync_buffer.as_ref(),
+                &ctx.metrics,
+                &ctx.rtt,
+            );
+            if !output.is_empty() {
+                ctx.obs_sink.dispatch(output);
             }
         }
         RoomEvent::Reconnected => {

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use livekit::prelude::*;
@@ -26,19 +26,17 @@ type DropCb = Box<dyn Fn(Vec<HashMap<String, f64>>) + Send + Sync>;
 pub(crate) struct ObservationSink {
     observation_cb: Mutex<Option<ObservationCb>>,
     drop_cb: Mutex<Option<DropCb>>,
-    buffer: Mutex<VecDeque<Observation>>,
-    buffer_size: usize,
-    metrics: Arc<MetricsRegistry>,
+    // Latest-wins slot. Consumers peek via `get()` (clone). Consumers that
+    // want history register `on_observation` and buffer on their own side.
+    latest: Mutex<Option<Observation>>,
 }
 
 impl ObservationSink {
-    pub(crate) fn new(buffer_size: usize, metrics: Arc<MetricsRegistry>) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             observation_cb: Mutex::new(None),
             drop_cb: Mutex::new(None),
-            buffer: Mutex::new(VecDeque::new()),
-            buffer_size,
-            metrics,
+            latest: Mutex::new(None),
         }
     }
 
@@ -46,7 +44,6 @@ impl ObservationSink {
         let SyncOutput { observations, drops } = output;
 
         if !observations.is_empty() {
-            // Fire callback by reference — no clone, even with a registered consumer.
             {
                 let cb_slot = self.observation_cb.lock();
                 if let Some(cb) = cb_slot.as_ref() {
@@ -55,24 +52,12 @@ impl ObservationSink {
                     }
                 }
             }
-            if self.buffer_size > 0 {
-                let mut evicted = 0u64;
-                {
-                    let mut buf = self.buffer.lock();
-                    for obs in observations {
-                        buf.push_back(obs);
-                        while buf.len() > self.buffer_size {
-                            buf.pop_front();
-                            evicted += 1;
-                        }
-                    }
-                }
-                if evicted > 0 {
-                    self.metrics.record_observation_evicted(evicted);
-                    log::warn!(
-                        "observation buffer overflow: evicted {evicted} observation(s) — consumer is lagging"
-                    );
-                }
+            // Writer always wins — overwrite is the expected behavior in
+            // latest-wins mode. Consumers that care about every observation
+            // use the callback.
+            let mut slot = self.latest.lock();
+            for obs in observations {
+                *slot = Some(obs);
             }
         }
 
@@ -83,16 +68,12 @@ impl ObservationSink {
         }
     }
 
-    pub(crate) fn take(&self) -> Vec<Observation> {
-        self.buffer.lock().drain(..).collect()
+    pub(crate) fn get(&self) -> Option<Observation> {
+        self.latest.lock().clone()
     }
 
     pub(crate) fn clear(&self) {
-        self.buffer.lock().clear();
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.buffer.lock().len()
+        *self.latest.lock() = None;
     }
 
     pub(crate) fn set_observation_cb(&self, cb: ObservationCb) {
@@ -130,11 +111,17 @@ pub struct Portal {
     sync_buffer: Mutex<Option<Arc<Mutex<SyncBuffer>>>>,
     obs_sink: Arc<ObservationSink>,
 
-    // Data callbacks.
+    // Data callbacks (push API).
     action_cb: Arc<Mutex<Option<DataCb>>>,
     state_cb: Arc<Mutex<Option<DataCb>>>,
     // Fixed at construction (keyed by declared video_tracks) — no lock on the map itself.
     video_cbs: HashMap<String, Arc<Mutex<Option<VideoCb>>>>,
+
+    // Latest-wins slots (pull API). Parallel to the callback slots — updated
+    // on every receive regardless of whether a callback is registered.
+    action_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
+    state_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
+    video_latest: HashMap<String, Arc<Mutex<Option<VideoFrameData>>>>,
 
     metrics: Arc<MetricsRegistry>,
 }
@@ -146,12 +133,14 @@ impl Portal {
             .iter()
             .map(|name| (name.clone(), Arc::new(Mutex::new(None))))
             .collect();
+        let video_latest: HashMap<_, _> = config
+            .video_tracks
+            .iter()
+            .map(|name| (name.clone(), Arc::new(Mutex::new(None))))
+            .collect();
 
         let metrics = Arc::new(MetricsRegistry::new(&config.video_tracks));
-        let obs_sink = Arc::new(ObservationSink::new(
-            config.sync_config.observation_buffer_size as usize,
-            metrics.clone(),
-        ));
+        let obs_sink = Arc::new(ObservationSink::new());
 
         Self {
             config,
@@ -165,6 +154,9 @@ impl Portal {
             action_cb: Arc::new(Mutex::new(None)),
             state_cb: Arc::new(Mutex::new(None)),
             video_cbs,
+            action_latest: Arc::new(Mutex::new(None)),
+            state_latest: Arc::new(Mutex::new(None)),
+            video_latest,
             metrics,
         }
     }
@@ -190,7 +182,7 @@ impl Portal {
 
         let rtt = Arc::new(RttService::spawn(
             room.local_participant(),
-            self.config.ping_interval_ms,
+            self.config.ping_ms,
             self.metrics.clone(),
         ));
 
@@ -206,6 +198,9 @@ impl Portal {
             state_cb: self.state_cb.clone(),
             video_cbs: self.video_cbs.clone(),
             video_receivers: self.video_receivers.clone(),
+            action_latest: self.action_latest.clone(),
+            state_latest: self.state_latest.clone(),
+            video_latest: self.video_latest.clone(),
             metrics: self.metrics.clone(),
             rtt: rtt.clone(),
         };
@@ -293,15 +288,40 @@ impl Portal {
             sb.lock().clear();
         }
         self.obs_sink.clear();
+        *self.action_latest.lock() = None;
+        *self.state_latest.lock() = None;
+        for slot in self.video_latest.values() {
+            *slot.lock() = None;
+        }
 
         Ok(())
     }
 
-    pub fn take_observations(&self) -> Vec<Observation> {
-        self.obs_sink.take()
+    // --- Pull API (latest-wins, peek semantics) ---
+
+    /// Clone of the latest observation, or `None` if none received yet.
+    /// Consumers wanting a history of observations should register
+    /// `on_observation` and buffer on their own side.
+    pub fn get_observation(&self) -> Option<Observation> {
+        self.obs_sink.get()
     }
 
-    // --- Callback registration ---
+    /// Clone of the latest action received (Robot side), or `None`.
+    pub fn get_action(&self) -> Option<HashMap<String, f64>> {
+        self.action_latest.lock().clone()
+    }
+
+    /// Clone of the latest state received (Operator side), or `None`.
+    pub fn get_state(&self) -> Option<HashMap<String, f64>> {
+        self.state_latest.lock().clone()
+    }
+
+    /// Clone of the latest frame received for `track_name`, or `None`.
+    pub fn get_video_frame(&self, track_name: &str) -> Option<VideoFrameData> {
+        self.video_latest.get(track_name).and_then(|s| s.lock().clone())
+    }
+
+    // --- Callback registration (push API) ---
 
     pub fn on_action(&self, callback: impl Fn(HashMap<String, f64>) + Send + Sync + 'static) {
         *self.action_cb.lock() = Some(Box::new(callback));
@@ -315,16 +335,16 @@ impl Portal {
         *self.state_cb.lock() = Some(Box::new(callback));
     }
 
-    pub fn on_video(
+    pub fn on_video_frame(
         &self,
         track_name: &str,
         callback: impl Fn(&str, &VideoFrameData) + Send + Sync + 'static,
     ) {
         match self.video_cbs.get(track_name) {
             Some(cb_slot) => *cb_slot.lock() = Some(Box::new(callback)),
-            None => {
-                log::warn!("on_video: track '{track_name}' is not registered — callback ignored")
-            }
+            None => log::warn!(
+                "on_video_frame: track '{track_name}' is not registered — callback ignored"
+            ),
         }
     }
 
@@ -375,7 +395,7 @@ impl Portal {
         let sync_buffer = Arc::new(Mutex::new(SyncBuffer::new(
             &self.config.video_tracks,
             self.config.state_fields.clone(),
-            self.config.sync_config,
+            self.config.sync_config(),
             self.metrics.clone(),
         )));
         *self.sync_buffer.lock() = Some(sync_buffer);
@@ -408,8 +428,7 @@ impl Portal {
             }
             None => (HashMap::new(), 0),
         };
-        let observation_fill = self.obs_sink.len();
-        self.metrics.snapshot(video_fill, state_fill, observation_fill)
+        self.metrics.snapshot(video_fill, state_fill)
     }
 
     pub fn reset_metrics(&self) {
@@ -427,6 +446,9 @@ struct EventContext {
     state_cb: Arc<Mutex<Option<DataCb>>>,
     video_cbs: HashMap<String, Arc<Mutex<Option<VideoCb>>>>,
     video_receivers: Arc<Mutex<HashMap<String, VideoReceiver>>>,
+    action_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
+    state_latest: Arc<Mutex<Option<HashMap<String, f64>>>>,
+    video_latest: HashMap<String, Arc<Mutex<Option<VideoFrameData>>>>,
     metrics: Arc<MetricsRegistry>,
     rtt: Arc<RttService>,
 }
@@ -450,6 +472,11 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                             .get(track_name.as_str())
                             .cloned()
                             .unwrap_or_else(|| Arc::new(Mutex::new(None)));
+                        let latest = ctx
+                            .video_latest
+                            .get(track_name.as_str())
+                            .cloned()
+                            .unwrap_or_else(|| Arc::new(Mutex::new(None)));
                         let track_metrics = ctx
                             .metrics
                             .track(track_name.as_str())
@@ -461,6 +488,7 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                             stream,
                             sync_buffer.clone(),
                             raw_cb,
+                            latest,
                             ctx.obs_sink.clone(),
                             track_metrics,
                         );
@@ -479,6 +507,8 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                     &ctx.config.state_fields,
                     &ctx.action_cb,
                     &ctx.state_cb,
+                    &ctx.action_latest,
+                    &ctx.state_latest,
                     ctx.sync_buffer.as_ref(),
                     &ctx.metrics,
                     &ctx.rtt,

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -166,6 +166,10 @@ impl SyncBuffer {
             }
 
             let state_ts = self.state_buffer[0].0;
+            // Next state in the buffer (if any) — used for fair-share: if a
+            // candidate frame is closer to the next state than to the head
+            // state, we skip it so the later state can claim it.
+            let next_state_ts = self.state_buffer.get(1).map(|(ts, _)| *ts);
 
             for slot in &mut self.matched_scratch {
                 *slot = None;
@@ -212,10 +216,20 @@ impl SyncBuffer {
                 {
                     if let Some(f) = frame_buf.get(candidate) {
                         let d = state_ts.abs_diff(f.timestamp_us);
-                        if d < range && d < best_delta {
-                            best_delta = d;
-                            best_idx = Some(candidate);
+                        if d >= range || d >= best_delta {
+                            continue;
                         }
+                        // Fair-share: if a later buffered state has a strictly
+                        // closer claim, leave the frame for it. Prevents a
+                        // greedy head-state from stealing its neighbor's frame
+                        // when tolerance > 1 tick.
+                        if let Some(nts) = next_state_ts {
+                            if nts.abs_diff(f.timestamp_us) < d {
+                                continue;
+                            }
+                        }
+                        best_delta = d;
+                        best_idx = Some(candidate);
                     }
                 }
 
@@ -690,6 +704,87 @@ mod tests {
         let out = buf.push_state(300, vec![3.0]);
         assert_eq!(out.drops.len(), 1);
         assert_eq!(out.drops[0]["j1"], 1.0);
+    }
+
+    /// With a widened range (>1 tick), a state whose exact frame was lost
+    /// falls back to an adjacent frame if no later state has a closer claim.
+    #[test]
+    fn wide_range_matches_neighbor_when_native_lost() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        // 30fps ticks = 33_333us; tolerance 1.5 → range = 50_000us.
+        let config = SyncConfig {
+            video_buffer_size: 5,
+            state_buffer_size: 5,
+            search_range_us: 50_000,
+        };
+        let mut buf = mk(&tracks, fields, config);
+
+        // Frame at tick 0 stands in for "T−1"; frame at T was lost; only
+        // frame@0 is available for state@33_333.
+        let _ = push_f(&mut buf, "cam1", 0);
+        let out = buf.push_state(33_333, vec![1.0]);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam1"].timestamp_us, 0);
+    }
+
+    /// Fair-share: if an earlier state and a later state are both in the
+    /// buffer and a single frame sits closer to the later state, the earlier
+    /// state must NOT steal it. It may drop, but the later state gets to use
+    /// its own frame.
+    #[test]
+    fn fair_share_prevents_stealing() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let config = SyncConfig {
+            video_buffer_size: 5,
+            state_buffer_size: 5,
+            search_range_us: 50_000, // tolerance 1.5 at 30fps
+        };
+        let mut buf = mk(&tracks, fields, config);
+
+        // Both states buffered before any frames arrive.
+        assert!(buf.push_state(0, vec![1.0]).is_empty());
+        assert!(buf.push_state(33_333, vec![2.0]).is_empty());
+
+        // frame@33_333 is closer to state@33_333 than to state@0;
+        // fair-share must keep state@0 from grabbing it.
+        let out = push_f(&mut buf, "cam1", 33_333);
+        assert!(
+            out.observations.is_empty(),
+            "state@0 must not steal frame@33_333 from state@33_333"
+        );
+
+        // Push a later frame past state@0's horizon to force the drop;
+        // state@33_333 then matches its own frame.
+        let out = push_f(&mut buf, "cam1", 100_000);
+        assert_eq!(out.drops.len(), 1, "state@0 drops once its horizon is crossed");
+        assert_eq!(out.drops[0]["j1"], 1.0);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].state["j1"], 2.0);
+        assert_eq!(out.observations[0].frames["cam1"].timestamp_us, 33_333);
+    }
+
+    /// Tight range (<1 tick) preserves the legacy drop-on-loss behavior:
+    /// a state can't reach an adjacent frame, so it drops as soon as a
+    /// later frame crosses the horizon.
+    #[test]
+    fn tight_range_still_drops_on_loss() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        // tolerance 0.5 at 30fps → range = 16_666us, adjacent frames unreachable.
+        let config = SyncConfig {
+            video_buffer_size: 5,
+            state_buffer_size: 5,
+            search_range_us: 16_666,
+        };
+        let mut buf = mk(&tracks, fields, config);
+
+        let _ = push_f(&mut buf, "cam1", 0);
+        assert!(buf.push_state(33_333, vec![1.0]).is_empty()); // blocks: no match in range
+        let out = push_f(&mut buf, "cam1", 100_000); // crosses horizon, fires drop
+        assert!(out.observations.is_empty());
+        assert_eq!(out.drops.len(), 1, "tight range must drop when native frame is missing");
     }
 
     /// Sanity: inputs that stress the binary/cursor path with many empty and

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -521,7 +521,6 @@ mod tests {
             video_buffer_size: 1,
             state_buffer_size: 10,
             search_range_us: 30_000,
-            observation_buffer_size: 10,
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -642,7 +641,6 @@ mod tests {
             video_buffer_size: 10,
             state_buffer_size: 10,
             search_range_us: 500,
-            observation_buffer_size: 10,
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -667,7 +665,6 @@ mod tests {
             video_buffer_size: 10,
             state_buffer_size: 10,
             search_range_us: 500,
-            observation_buffer_size: 10,
         };
         let mut buf = mk(&tracks, fields, config);
 

--- a/livekit-portal/src/types.rs
+++ b/livekit-portal/src/types.rs
@@ -24,22 +24,20 @@ pub struct VideoFrameData {
     pub timestamp_us: u64,
 }
 
-/// Sync configuration with sensible defaults for 60fps robotics.
+/// Internal sync configuration, derived from `PortalConfig` knobs.
 #[derive(Debug, Clone, Copy)]
 pub struct SyncConfig {
     pub video_buffer_size: u32,
     pub state_buffer_size: u32,
     pub search_range_us: u64,
-    pub observation_buffer_size: u32,
 }
 
 impl Default for SyncConfig {
     fn default() -> Self {
         Self {
-            video_buffer_size: 5,       // ~83ms at 60fps
-            state_buffer_size: 5,       // ~83ms at 60fps
-            search_range_us: 10_000,    // 10ms — half a frame interval at 60fps
-            observation_buffer_size: 3, // ~50ms of consumer headroom
+            video_buffer_size: 5,    // ~83ms at 60fps
+            state_buffer_size: 5,    // ~83ms at 60fps
+            search_range_us: 10_000, // 10ms — half a frame interval at 60fps
         }
     }
 }

--- a/livekit-portal/src/video.rs
+++ b/livekit-portal/src/video.rs
@@ -89,11 +89,13 @@ pub(crate) struct VideoReceiver {
 }
 
 impl VideoReceiver {
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         name: String,
         stream: NativeVideoStream,
         sync_buffer: Arc<Mutex<SyncBuffer>>,
         raw_callback: Arc<Mutex<Option<VideoCb>>>,
+        latest: Arc<Mutex<Option<VideoFrameData>>>,
         obs_sink: Arc<ObservationSink>,
         metrics: Arc<TrackMetrics>,
     ) -> Self {
@@ -115,6 +117,8 @@ impl VideoReceiver {
                 if let Some(cb) = raw_callback.lock().as_ref() {
                     cb(&name, &frame_arc);
                 }
+                // VideoFrameData clone is cheap — pixel buffer is Arc<[u8]>.
+                *latest.lock() = Some((*frame_arc).clone());
                 let output = sync_buffer.lock().push_frame(&name, frame_arc);
                 if !output.is_empty() {
                     obs_sink.dispatch(output);

--- a/livekit-portal/src/video.rs
+++ b/livekit-portal/src/video.rs
@@ -82,20 +82,35 @@ impl VideoPublisher {
 
 // --- Receiver ---
 
-type VideoCb = Box<dyn Fn(&str, &VideoFrameData) + Send + Sync>;
+pub(crate) type VideoCb = Box<dyn Fn(&str, &VideoFrameData) + Send + Sync>;
+
+/// Push callback + latest-wins slot for a single video track, paired so the
+/// receiver task and `get_video_frame` share one allocation.
+pub(crate) struct VideoTrackSlots {
+    pub cb: Mutex<Option<VideoCb>>,
+    pub latest: Mutex<Option<VideoFrameData>>,
+}
+
+impl VideoTrackSlots {
+    pub fn new() -> Self {
+        Self { cb: Mutex::new(None), latest: Mutex::new(None) }
+    }
+
+    pub fn clear(&self) {
+        *self.latest.lock() = None;
+    }
+}
 
 pub(crate) struct VideoReceiver {
     task_handle: JoinHandle<()>,
 }
 
 impl VideoReceiver {
-    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         name: String,
         stream: NativeVideoStream,
         sync_buffer: Arc<Mutex<SyncBuffer>>,
-        raw_callback: Arc<Mutex<Option<VideoCb>>>,
-        latest: Arc<Mutex<Option<VideoFrameData>>>,
+        slots: Arc<VideoTrackSlots>,
         obs_sink: Arc<ObservationSink>,
         metrics: Arc<TrackMetrics>,
     ) -> Self {
@@ -114,11 +129,11 @@ impl VideoReceiver {
 
                 metrics.record_received(timestamp_us, now_us());
 
-                if let Some(cb) = raw_callback.lock().as_ref() {
+                if let Some(cb) = slots.cb.lock().as_ref() {
                     cb(&name, &frame_arc);
                 }
                 // VideoFrameData clone is cheap — pixel buffer is Arc<[u8]>.
-                *latest.lock() = Some((*frame_arc).clone());
+                *slots.latest.lock() = Some((*frame_arc).clone());
                 let output = sync_buffer.lock().push_frame(&name, frame_arc);
                 if !output.is_empty() {
                     obs_sink.dispatch(output);

--- a/spec.md
+++ b/spec.md
@@ -100,34 +100,42 @@ inference_portal.send_action({"joint1": 0.0, "joint2": 0.0, "joint3": 0.0})  # o
 
 ### Receiving
 
-State and action format: `Dict[str, float]`
+State and action format: `Dict[str, float]`. Both a push API (callbacks, fire on every receive) and a pull API (latest-wins peek) are provided. Use the callback if you want every sample (with your own history buffer). Use the pull API if you only care about the most recent value per inference tick.
 
 ```python
+# --- Push API (callbacks) ---
 # On robot side
 inference_portal.on_action(callback)
 
 # On operator side
-inference_portal.on_observation(callback)  # synced bundle of all video frames + state, called when a complete sync is formed
-inference_portal.on_state(callback)        # called when a new state is received (unsynced)
-inference_portal.on_video("camera1", callback)  # called when a new frame is received (unsynced)
+inference_portal.on_observation(callback)      # synced bundle, fires when a complete sync is formed
+inference_portal.on_state(callback)            # fires on every state received (unsynced)
+inference_portal.on_video_frame("camera1", callback)  # fires on every frame received (unsynced)
+inference_portal.on_drop(callback)             # fires on sync-fail and state-buffer overflow
+
+# --- Pull API (latest-wins) ---
+action = inference_portal.get_action()         # robot: Option[Dict[str, float]]
+obs    = inference_portal.get_observation()    # operator: Option[Observation]
+state  = inference_portal.get_state()          # operator: Option[Dict[str, float]]
+frame  = inference_portal.get_video_frame("camera1")  # operator: Option[VideoFrameData]
 ```
 
 An observation is a complete synced bundle: one state matched with one frame from every registered video track. There are no partial observations. If any registered video track is missing a matching frame within the sync window, the observation is not formed and the state is dropped.
 
+The pull API is peek-style: `get_*()` always returns the most recent value (or `None` if nothing has arrived yet), and repeated calls return the same value until a new one arrives. The library does not buffer history for the pull API — if you need every sample, register the callback and buffer on your side.
+
 ### Tuning
 
-All tuning is set on the config object before connecting.
+All tuning is set on the config object before connecting. Portal is built around unified sampling: the robot captures state + frames at the same tick rate, so a single `fps` knob derives the sync search window, and a single `slack` knob sizes all internal buffers.
 
 ```python
-config.set_video_buffer(30)       # (unit: samples) how many frames to buffer per video track for sync
-config.set_state_buffer(30)       # (unit: samples) how many states to buffer for sync
-config.set_search_range(30)       # (unit: ms) match if |timestamp_state - timestamp_frame| < range, pick minimum delta
-config.set_observation_buffer(10) # how many synced observations to buffer
+config.set_fps(30)               # unified capture rate; derives search_range = 1/(2·fps)
+config.set_slack(5)              # ticks of pipeline headroom (video + state sync buffers)
 
-config.set_state_reliable(True)   # default: True. reliable = lossless ordered delivery, unreliable = lowest latency
-config.set_action_reliable(True)  # default: True. use False for high-frequency inference where latest value matters most
+config.set_state_reliable(True)  # default: True. reliable = lossless ordered delivery, unreliable = lowest latency
+config.set_action_reliable(True) # default: True. use False for high-frequency inference where latest value matters most
 
-config.set_ping_interval_ms(1000) # default: 1000. set 0 to disable RTT pinging on this side
+config.set_ping_ms(1000)         # default: 1000. set 0 to disable RTT pinging on this side
 ```
 
 ### Metrics
@@ -158,16 +166,14 @@ metrics.transport
 metrics.buffers                   # fill gauges + overflow counters
   video_fill                      # gauge, per video track
   state_fill                      # gauge
-  observation_fill                # gauge
   evictions                       # per video track, cumulative (overflow)
-  observations_evicted            # cumulative: consumer lagged on pull side
 
 metrics.rtt
   rtt_us_last / rtt_us_mean / rtt_us_p95
   pings_sent / pongs_received
 ```
 
-RTT is measured on a reserved `portal_rtt` data topic. Each side sends an unreliable ping at `ping_interval_ms`; the other side echoes it as a pong carrying the original timestamp. The pinging side computes RTT = `now − ping_ts` when the pong arrives. Unreliable delivery is deliberate: reliable retransmits would inflate the measurement. Echo is always active, so one side can disable pinging and still let the other measure.
+RTT is measured on a reserved `portal_rtt` data topic. Each side sends an unreliable ping at `ping_ms`; the other side echoes it as a pong carrying the original timestamp. The pinging side computes RTT = `now − ping_ts` when the pong arrives. Unreliable delivery is deliberate: reliable retransmits would inflate the measurement. Echo is always active, so one side can disable pinging and still let the other measure.
 
 Jitter is the RFC 3550 EWMA on inter-arrival deltas: `J += (|D| − J) / 16`, where `D = (recv_i − recv_{i-1}) − (send_i − send_{i-1})`. Drift-robust (only looks at deltas) and unitless of absolute clock offset.
 

--- a/spec.md
+++ b/spec.md
@@ -129,14 +129,17 @@ The pull API is peek-style: `get_*()` always returns the most recent value (or `
 All tuning is set on the config object before connecting. Portal is built around unified sampling: the robot captures state + frames at the same tick rate, so a single `fps` knob derives the sync search window, and a single `slack` knob sizes all internal buffers.
 
 ```python
-config.set_fps(30)               # unified capture rate; derives search_range = 1/(2·fps)
+config.set_fps(30)               # unified capture rate (video rate if asymmetric); tolerance*fps = search window
 config.set_slack(5)              # ticks of pipeline headroom (video + state sync buffers)
+config.set_tolerance(1.5)        # ticks of match window. 0.5 = tight (drop on loss); 1.5 = ±1 neighbor fallback
 
 config.set_state_reliable(True)  # default: True. reliable = lossless ordered delivery, unreliable = lowest latency
 config.set_action_reliable(True) # default: True. use False for high-frequency inference where latest value matters most
 
 config.set_ping_ms(1000)         # default: 1000. set 0 to disable RTT pinging on this side
 ```
+
+**Tolerance tradeoff**: at `tolerance=0.5`, a state only matches a frame within half a tick — a single lost frame drops the observation (precision over recovery). At the default `tolerance=1.5`, a state can fall back to the adjacent frame (T±1) if its own was lost, preserving the observation at the cost of ±1 tick of misalignment. A fair-share check prevents an earlier state from stealing a frame that a later state in the buffer has a closer claim to. Values `>2.0` allow T±2 fallback (rarely worth it). Pick **tight (≤1.0)** for real-time control where misalignment is unsafe; pick **widened (≥1.5)** for data collection or lossy links where dropping is worse than slight misalignment.
 
 ### Metrics
 

--- a/spec.md
+++ b/spec.md
@@ -77,8 +77,8 @@ inference_portal.add_action("joint1", "joint2", "joint3")
 
 Edge cases:
 
-- If operator adds a non-existent state or video (or doesn't add an existing one), nothing happens. They'll just not receive data for that particular state or video. Internally there is a buffer for state — if a new incomplete entry is added, it will carry forward the last known value.
-- If robot adds a non-existent action, they will just not receive anything. The non-existent action will be 0.
+- If a side declares a field or video track that the peer never publishes, the consumer simply never receives it — no error. Extra fields on the peer side are ignored.
+- When a caller sends a partial state/action dict (only some of the declared fields), missing fields **carry forward** their last sent value on the publisher side. Fields never sent start at `0.0`. This keeps the observation coherent when a sensor reports only a subset per tick.
 - Portal is built to be as stateless as possible, so disconnect and reconnect can be gracefully handled.
 
 ### Sending


### PR DESCRIPTION
## Summary

This PR ships **v0.1** of the `livekit-portal` crate: everything needed for a VLA-style robotics loop on LiveKit with observable sync health.

The work landed in two waves. The first four commits (`8b615f7`, `7731cf0`, `fa7007f`, `c98ef37`) were pushed directly to `main` earlier in the session. The five commits in this PR (`485a099` → `af9401b`) complete v0.1 and should be reviewed as one unit.

### What v0.1 contains (complete picture)

**Observability** — already on `main`
- `Portal::metrics()` snapshot API with four sections: sync (observations emitted, states dropped, match-delta p50/p95, last blocker track), transport (per-stream counters, RFC 3550 inter-arrival jitter), buffers (fill gauges + eviction counters), RTT.
- Ping-pong RTT on a reserved `portal_rtt` data topic. Unreliable so retransmits don't inflate measurement. Both sides ping at `ping_ms` cadence (configurable, 0 disables), peer echoes verbatim.
- `warn` logs on silent overflow paths (video buffer, state buffer, observation slot) — one log per call, not per item.

**Drop correctness** — already on `main`
- `push_state` now surfaces overflow-evicted states via `output.drops` so `on_drop` fires on both sync failure and buffer overflow (matching the spec).
- `VideoReceiver` panics with a clear message if a frame arrives without `PacketTrailerFeatures.user_timestamp` — any peer not using this crate is explicitly incompatible rather than silently corrupting sync and jitter state.
- `DataPublisher::send` only bumps the send counter when the channel accepts the packet.

**API reshape (this PR)** — `485a099`
- Config collapses from seven knobs to three load-bearing + reliability: `set_fps(30)`, `set_slack(5)`, `set_ping_ms(1000)`. All internal buffers derive from `slack`; search window derives from `fps`.
- Pull API added on every receive channel, peek semantics: `get_observation`, `get_action`, `get_state`, `get_video_frame`. Returns `Option<T>` — always the latest, consumer paces themselves.
- `on_video` renamed to `on_video_frame` for consistency with `send_video_frame`.
- Observation FIFO buffer collapsed to a single latest-wins slot. Consumers needing history register `on_observation` and buffer on their own side.

**Cleanup** — `dd09935`
- Dead code removal (unused `SyncConfig::observation_buffer_size`, `TrackMetrics::name`).
- `DataSlots` and `VideoTrackSlots` bundle the push callback + pull latest per stream/track — halves the Arc plumbing through `EventContext`.
- `DataCb` now takes `&HashMap` instead of owned. Saves one HashMap clone per state/action received on the hot path.

**Carry-forward** — `6b43564`
- `DataPublisher` holds a per-field snapshot of last sent values. Partial `send_map` dicts inherit missing fields from the previous send instead of silently zeroing — matches spec intent and keeps a single-sensor update from clobbering unrelated joints.
- Dead `DataPublisher::send` method and `WrongValueCount` error variant removed.

**Tunable sync window** — `aa7c401`
- New `set_tolerance(ticks)` knob. `search_range = tolerance / fps`.
- `0.5` = tight (drop on any frame loss, real-time control).
- `1.5` (default) = widened; a state falls back to the T±1 neighbor if its native frame was lost. Preserves observations at the cost of ±1-tick misalignment — right default for data collection and lossy links.
- Fair-share check in `try_sync` prevents an earlier buffered state from stealing a frame closer to a later state.

**Docs** — `af9401b`
- README tuning guide with a tolerance-picker table by use case (real-time → 0.5, data collection → 1.5, etc.) and a worked example for asymmetric rates (video 60fps, state 10Hz → `slack=8`).

### Architecture notes

- **Unified sampling is an assumption, not enforced.** `fps` tunes the sync window; the user is responsible for capturing state + frames at the same tick. Reality: LeRobot-style loops already do this.
- **Video transport is unreliable**, so a match window is load-bearing. Exact-ts reunion (what an ideal unified-sampling algo would use) would drop an observation for every lost frame. The widened window + fair-share recovers that gracefully.
- **Asymmetric rates work** (video > state) — intervening frames are drained on match. `slack` must cover the video-to-state rate ratio.

### Known limitations (shipped, not fixed)

- `get_video_frame` returns per-track latest with no cross-track alignment. For aligned frames use `get_observation`.
- Reserved data topics `portal_rtt`, `portal_state`, `portal_action` — user apps must not reuse them.
- Role is a convention, not enforced via LiveKit identity. Two robots with the same role can technically join if tokens allow.

### Test plan
- [x] `cargo test` — 32 tests pass, including 3 new tests for widened range / fair-share / tight-range-drops.
- [x] `cargo clippy --lib` clean.
- [ ] End-to-end with a real LiveKit room + LeRobot-style loop (requires FFI bindings — out of scope for v0.1 core crate).
- [ ] Field telemetry on `metrics.sync.states_dropped` to validate the tight-vs-widened tolerance default once bindings exist.