### PR TITLE
README: landing page with features, quick links, and a two-file lerobot before/after

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <!--END_DESCRIPTION-->
 
 <p align="center">
-  <a href="#your-code-does-not-change">Show me</a> ·
+  <a href="#at-a-glance">Show me</a> ·
   <a href="#install">Install</a> ·
   <a href="#examples">Examples</a> ·
   <a href="docs/quickstart.md">Quickstart</a> ·
@@ -40,70 +40,86 @@
 
 ---
 
-## Your code does not change
+## At a glance
 
-A classical lerobot loop runs on the same machine as the robot:
+A complete remote-robot session in two files. The robot host publishes
+frames and state, executes actions, and exposes a `home` RPC. The control
+host receives synced observations, runs a policy, and calls `home` before
+the control loop starts.
 
-```python
-# all on one machine, robot plugged in
-from lerobot.robots.myrobot import MyRobot
-
-robot = MyRobot(config=...)
-robot.connect()
-
-obs = robot.get_observation()
-action = model.select_action(obs)
-robot.send_action(action)
-```
-
-With Portal, the same loop splits into two small files. One lives next to the
-robot. The other lives wherever your policy or teleop runs.
-
-**`robot_host.py`** runs on the machine the robot is plugged into.
+**`robot.py`** runs on the machine the robot is plugged into.
 
 ```python
-from lerobot.robots.myrobot import MyRobot
-from lerobot_teleoperator_livekit import (
-    LiveKitTeleoperator, LiveKitTeleoperatorConfig,
-)
+import asyncio, time
+from livekit.portal import Portal, PortalConfig, Role
 
-robot = MyRobot(config=...)
-robot.connect()
+async def main():
+    cfg = PortalConfig("session-1", Role.ROBOT)
+    cfg.add_video("front")                       # add more tracks for multi-camera
+    cfg.add_state(["j1", "j2", "j3"])
+    cfg.add_action(["j1", "j2", "j3"])
+    cfg.set_fps(30)
 
-teleop = LiveKitTeleoperator(
-    LiveKitTeleoperatorConfig(url=..., token=..., session="session-1", fps=30),
-    robot=robot,
-)
-teleop.connect()
+    portal = Portal(cfg)
 
-while running:
-    teleop.send_feedback(robot.get_observation())     # upstream to operator
-    if action := teleop.get_action():                 # action from operator
-        robot.send_action(action)
+    # One-shot commands. Either side can register. Either side can invoke.
+    def on_home(_):
+        robot.home()
+        return "ok"
+    portal.register_rpc_method("home", on_home)
+
+    # Actions arrive here as the operator produces them.
+    portal.on_action(lambda a: robot.send_action(a.values))
+
+    await portal.connect(url, token)
+
+    while running:
+        obs = robot.get_observation()
+        ts = int(time.time() * 1_000_000)
+        portal.send_video_frame("front", obs.image, 640, 480, timestamp_us=ts)
+        portal.send_state(obs.state, timestamp_us=ts)
+        await asyncio.sleep(1 / 30)
+
+asyncio.run(main())
 ```
 
-**`control_host.py`** runs wherever you drive the robot from.
+**`operator.py`** runs wherever your policy or teleop UI lives.
 
 ```python
-from lerobot_robot_livekit import LiveKitRobot, LiveKitRobotConfig
+import asyncio
+from livekit.portal import Portal, PortalConfig, Role
 
-robot = LiveKitRobot(LiveKitRobotConfig(
-    url=..., token=..., session="session-1", fps=30,
-    camera_names=("cam1",),
-))
-robot.connect()
+async def main():
+    cfg = PortalConfig("session-1", Role.OPERATOR)
+    cfg.add_video("front")
+    cfg.add_state(["j1", "j2", "j3"])
+    cfg.add_action(["j1", "j2", "j3"])
+    cfg.set_fps(30)
 
-obs = robot.get_observation()
-action = model.select_action(obs)
-robot.send_action(action)
+    portal = Portal(cfg)
+
+    # Cameras, state, and a sender timestamp arrive fused as one tuple.
+    def on_observation(obs):
+        # obs.frames["front"], obs.state, obs.timestamp_us
+        portal.send_action(policy(obs))
+
+    portal.on_observation(on_observation)
+    await portal.connect(url, token)
+
+    await portal.perform_rpc("home")             # imperative commands, not a loop
+    print(portal.metrics())                      # RTT, sync delta, jitter, drops
+
+    while running:
+        await asyncio.sleep(1)
+
+asyncio.run(main())
 ```
 
-The last three lines of `control_host.py` are the same three lines as the
-classical loop. The robot just lives on another machine now.
-
-The example above uses the lerobot plugin because it makes the diff a single
-import. Portal itself is a standalone library. The plugin is a thin wrap on
-top. See the [30-second sketch](#30-second-sketch) for the raw Portal API.
+That is the whole surface at work in one page. Synced observations, an
+action callback, an RPC for one-shots, and a live metrics snapshot. The
+code above is a sketch, not a runnable file. The real one is in
+[`examples/python/basic/`](examples/python/basic) with token minting
+already wired up.
 
 ## The idea
 
@@ -159,56 +175,13 @@ driven by a remote **SO-101 leader**. Camera and joint state render in
 [rerun](https://rerun.io). Full calibration and wiring walkthrough in its
 [README](examples/python/so101/README.md).
 
-## 30-second sketch
+## Using with lerobot
 
-The raw Portal API, no plugin. This is what the lerobot wrappers use
-internally.
-
-Robot side. Publishes frames and state. Receives actions.
-
-```python
-from livekit.portal import Portal, PortalConfig, Role
-
-cfg = PortalConfig("session-1", Role.ROBOT)
-cfg.add_video("cam1")
-cfg.add_state(["j1", "j2", "j3"])
-cfg.add_action(["j1", "j2", "j3"])
-
-portal = Portal(cfg)
-portal.on_action(lambda a: robot.send_action(a.values))
-await portal.connect(url, token)
-
-while running:
-    obs = robot.get_observation()
-    portal.send_video_frame("cam1", obs.image, width, height)
-    portal.send_state(obs.state)
-    await asyncio.sleep(1 / 30)
-```
-
-Control side. Receives synced observations. Publishes actions.
-
-```python
-from livekit.portal import Portal, PortalConfig, Role
-
-cfg = PortalConfig("session-1", Role.OPERATOR)
-cfg.add_video("cam1")
-cfg.add_state(["j1", "j2", "j3"])
-cfg.add_action(["j1", "j2", "j3"])
-
-portal = Portal(cfg)
-
-def on_observation(obs):
-    # obs.frames:       dict[str, np.ndarray]
-    # obs.state:        dict[str, float]
-    # obs.timestamp_us: int
-    portal.send_action(policy(obs))     # or teleop.get_action()
-
-portal.on_observation(on_observation)
-await portal.connect(url, token)
-```
-
-Full runnable version, including token minting, in the
-[Quickstart](docs/quickstart.md).
+If your stack is already on [lerobot](https://github.com/huggingface/lerobot),
+two optional plugin packages wrap the Portal code above. You pass in your
+existing `Robot` or `Teleoperator` and the remote arm shows up as a local
+lerobot device to any workflow (teleop, dataset recording, policy eval). See
+[lerobot integration](docs/lerobot.md) for the full reference.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 
 ## Features
 
+<p align="center">
+  <img src=".github/assets/portal-demo.gif" alt="Portal demo: synced camera and joint state between a remote robot and a local operator" width="720">
+</p>
+
 **Remote robot, same code.** Your robot loop keeps its shape. Portal moves the hardware to another machine. Your policy or teleop code still sees a local-looking `Robot` object.
 
 **Synced observations out of the box.** Cameras and joint state arrive fused into `Observation(frames, state, timestamp_us)`. That is the shape robotics policies already consume. No matching logic on your side.

--- a/README.md
+++ b/README.md
@@ -178,17 +178,37 @@ code above is a sketch. For a runnable version with token minting already
 wired up, see [`examples/python/basic/`](examples/python/basic) or the
 step-by-step [Quickstart doc](docs/quickstart.md).
 
-## The idea
+## Behind the project
 
-Think of your robot as a device that normally plugs into one computer.
-Portal lets it plug into a different one over the network. Your teleop
-interface, your training loop, or your policy server can run anywhere and
-still see the robot as if it were local.
+Robotics policies want one bundled `Observation` per tick: cameras, joint
+state, and a timestamp arriving together. LiveKit's transport primitives do
+not deliver data that way. Video tracks and data streams each have their
+own pacing, codec path, and retransmission. On the receiver they surface
+as independent event streams arriving out of phase.
 
-You use Portal by wrapping whatever code already drives your robot. On the
-robot host, you publish frames and state through a `Portal` object. On the
-control host, you receive them as a bundled `Observation` and publish actions
-back. No framework is assumed.
+Portal closes that gap. Every outgoing frame and state packet carries the
+sender's monotonic clock (packet-trailer metadata for video, a `u64`
+prefix for data). On the control side, a per-session `SyncBuffer` matches
+them by sender timestamp:
+
+```text
+for each head state S:
+    for each registered video track k:
+        F = nearest pending frame in track k to S
+        if |S - F| < search_range:                   track k matches
+        elif track k's newest frame is past S + R:   drop the state
+        else:                                        wait for a newer frame
+
+if every track matched:
+    emit Observation { frames, state, timestamp_us: S }
+```
+
+The real implementation is amortized `O(N + M)` through two-pointer
+cursors and blocker-gated short-circuiting, with `O(1)` unmatchability
+detection. Full walkthrough in
+[docs/synchronization.md](docs/synchronization.md). The
+[Concepts](docs/concepts.md) page covers roles and the observation model.
+[Tuning](docs/tuning.md) covers `fps`, `slack`, and `tolerance`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -9,41 +9,44 @@
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
 
 <!--BEGIN_DESCRIPTION-->
-Teleoperate a robot, or run a policy against it, from anywhere on the internet. Portal carries cameras, joint state, and actions over LiveKit and delivers synchronized `(frames, state, timestamp)` observations on the control side — the shape robotics policies already expect. Drop-in for [LeRobot](https://github.com/huggingface/lerobot); a direct API covers other stacks.
+Teleoperate a robot, or run a policy against it, from anywhere on the internet. Portal is a Rust/Python library that carries cameras, joint state, and actions between a robot host and a control host over LiveKit, and delivers them on the control side as synchronized `(frames, state, timestamp)` observations. Works with any robotics stack; an optional [LeRobot](https://github.com/huggingface/lerobot) plugin adds a one-line wrap for lerobot users.
 <!--END_DESCRIPTION-->
 
 ## The idea
 
 Think of your robot as a device that normally plugs into one computer. Portal
-lets it "plug into" a different one over the network — so your teleop
+lets it "plug into" a different one over the network, so your teleop
 interface, your training loop, or your policy server can run anywhere and
 still see the robot as if it were local. The physical robot stays in the
 loop; Portal only adds the network tier.
 
-Two plugins make this drop-in for
-[lerobot](https://github.com/huggingface/lerobot): wrap your existing `Robot`
-on the robot-side machine and your `Teleoperator` (or policy output) on the
-control-side machine, and the remote arm shows up as a local lerobot device
-to any workflow — teleoperation, dataset recording, policy eval. If you're
-not on lerobot, a direct `Portal` API covers the same ground.
+You use Portal by wrapping whatever code already drives your robot. On the
+robot host you publish frames and state through a `Portal` object; on the
+control host you receive them as a bundled `Observation(frames, state,
+timestamp_us)` and publish actions back. No framework is assumed.
+
+If you happen to be on [lerobot](https://github.com/huggingface/lerobot),
+two optional plugin packages collapse that to a one-line wrap around your
+existing `Robot` or `Teleoperator` (see [lerobot integration](docs/lerobot.md)).
 
 ## I want to…
 
 | Goal | Start here |
 |---|---|
-| **Teleoperate a lerobot-compatible robot over the network** | [Quickstart](docs/quickstart.md) |
-| **Run a policy against a remote robot** | [Quickstart](docs/quickstart.md) (same setup — the policy replaces the leader on the control side) |
-| **Use Portal directly from a non-lerobot stack** | [Portal API](docs/portal-api.md) |
-| **See a working end-to-end example** | [Examples](#examples) below |
+| **Wire Portal into my own robotics stack** | [Quickstart](docs/quickstart.md) and [Portal API](docs/portal-api.md) |
+| **Run a policy against a remote robot** | [Quickstart](docs/quickstart.md) (the policy sits on the control side and consumes `Observation`s) |
+| **See a working end-to-end example with no hardware** | [`examples/python/basic/`](examples/python/basic) |
+| **Shortcut for lerobot users** | [lerobot integration](docs/lerobot.md) |
 
 ## Examples
 
 Running examples is the fastest way to a known-good setup. Both live under
 [`examples/python/`](examples/python):
 
-- **[`examples/python/basic/`](examples/python/basic)** — no hardware
-  required. Synthetic video + state on one terminal, subscriber on another.
-  Proves your LiveKit credentials and native build are healthy.
+- **[`examples/python/basic/`](examples/python/basic)**: no hardware
+  required, uses the Portal API directly. Synthetic video + state on one
+  terminal, subscriber on another. Proves your LiveKit credentials and
+  native build are healthy.
   ```bash
   cd examples/python/basic
   cp .env.example .env            # fill in LIVEKIT_URL / API_KEY / API_SECRET
@@ -51,47 +54,61 @@ Running examples is the fastest way to a known-good setup. Both live under
   uv run robot.py                 # terminal 1
   uv run teleoperator.py          # terminal 2
   ```
-- **[`examples/python/so101/`](examples/python/so101)** — real hardware.
-  Physical **SO-101 follower** driven by a remote **SO-101 leader**, with the
-  camera and joint state rendered in [rerun](https://rerun.io). Full
-  calibration + wiring walkthrough in its
+- **[`examples/python/so101/`](examples/python/so101)**: real hardware, uses
+  the lerobot plugin. Physical **SO-101 follower** driven by a remote
+  **SO-101 leader**, with the camera and joint state rendered in
+  [rerun](https://rerun.io). Full calibration + wiring walkthrough in its
   [README](examples/python/so101/README.md).
 
-Adapt either of them to bring up your own setup.
+Adapt either to bring up your own setup.
 
 ## 30-second sketch
 
-Robot side (wraps your existing lerobot `Robot`):
+Robot side (publishes frames and state, receives actions):
 
 ```python
-teleop = LiveKitTeleoperator(
-    LiveKitTeleoperatorConfig(url=..., token=..., session="session-1", fps=30),
-    robot=robot,
-)
-teleop.connect()
+from livekit.portal import Portal, PortalConfig, Role
+
+cfg = PortalConfig("session-1", Role.ROBOT)
+cfg.add_video("cam1")
+cfg.add_state(["j1", "j2", "j3"])
+cfg.add_action(["j1", "j2", "j3"])
+
+portal = Portal(cfg)
+portal.on_action(lambda a: robot.send_action(a.values))
+await portal.connect(url, token)
+
 while running:
-    teleop.send_feedback(robot.get_observation())
-    action = teleop.get_action()
-    if action:
-        robot.send_action(action)
+    obs = robot.get_observation()
+    portal.send_video_frame("cam1", obs.image, width, height)
+    portal.send_state(obs.state)
+    await asyncio.sleep(1 / 30)
 ```
 
-Operator side (wraps your local leader / gamepad / policy):
+Control side (receives synced observations, publishes actions):
 
 ```python
-robot = LiveKitRobot(
-    LiveKitRobotConfig(url=..., token=..., session="session-1", fps=30,
-                       camera_names=("cam1",), camera_height=480, camera_width=640),
-    teleop=leader,
-)
-robot.connect()
-while running:
-    obs = robot.get_observation()          # synced frames + state
-    robot.send_action(leader.get_action()) # or policy(obs)
+from livekit.portal import Portal, PortalConfig, Role
+
+cfg = PortalConfig("session-1", Role.OPERATOR)
+cfg.add_video("cam1")
+cfg.add_state(["j1", "j2", "j3"])
+cfg.add_action(["j1", "j2", "j3"])
+
+portal = Portal(cfg)
+
+def on_observation(obs):
+    # obs.frames: dict[str, np.ndarray]
+    # obs.state:  dict[str, float]
+    # obs.timestamp_us: int
+    portal.send_action(policy(obs))          # or teleop.get_action()
+
+portal.on_observation(on_observation)
+await portal.connect(url, token)
 ```
 
-Full runnable version — including token minting and the non-lerobot variant —
-in the [Quickstart](docs/quickstart.md).
+Full runnable version, including token minting, in the
+[Quickstart](docs/quickstart.md).
 
 ## Install
 
@@ -111,17 +128,18 @@ bash scripts/build_native.sh release
 
 ## Documentation
 
-- [Quickstart](docs/quickstart.md) — install, tokens, first run.
-- [Concepts](docs/concepts.md) — roles, observation model, frame format.
-- [lerobot integration](docs/lerobot.md) — plugin config, CLI mode,
-  troubleshooting.
-- [Portal API](docs/portal-api.md) — raw API for non-lerobot stacks.
-- [Tuning](docs/tuning.md) — `fps` / `slack` / `tolerance`, asymmetric rates,
+- [Quickstart](docs/quickstart.md): install, tokens, first run with the
+  Portal API.
+- [Portal API](docs/portal-api.md): the primary surface. `PortalConfig`,
+  callbacks, send methods, role semantics.
+- [Concepts](docs/concepts.md): roles, observation model, frame format.
+- [Tuning](docs/tuning.md): `fps` / `slack` / `tolerance`, asymmetric rates,
   reliability.
-- [RPC](docs/rpc.md) — imperative commands (`home`, `calibrate`, etc.) on top
+- [RPC](docs/rpc.md): imperative commands (`home`, `calibrate`, etc.) on top
   of LiveKit RPC.
-- [Synchronization deep dive](docs/synchronization.md) — the full match
+- [Synchronization deep dive](docs/synchronization.md): the full match
   algorithm, cursor bookkeeping, complexity analysis.
+- [lerobot integration](docs/lerobot.md): the optional convenience plugins.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,62 +9,107 @@
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
 
 <!--BEGIN_DESCRIPTION-->
-Teleoperate a robot, or run a policy against it, from anywhere on the internet. Portal is a Rust/Python library that carries cameras, joint state, and actions between a robot host and a control host over LiveKit, and delivers them on the control side as synchronized `(frames, state, timestamp)` observations. Works with any robotics stack; an optional [LeRobot](https://github.com/huggingface/lerobot) plugin adds a one-line wrap for lerobot users.
+Teleoperate a robot, or run a policy against it, from anywhere on the internet. Portal carries cameras, joint state, and actions between a robot host and a control host over LiveKit. On the control side, everything arrives as synchronized `(frames, state, timestamp)` observations. Works with any robotics stack. An optional [LeRobot](https://github.com/huggingface/lerobot) plugin adds a one-line wrap for lerobot users.
 <!--END_DESCRIPTION-->
+
+## Your code does not change
+
+A local lerobot loop looks like this:
+
+```python
+from lerobot.robots.myrobot import MyRobot
+
+robot = MyRobot(config=...)
+robot.connect()
+
+obs = robot.get_observation()
+action = model.select_action(obs)
+robot.send_action(action)
+```
+
+Swap one import and you get the same loop driving a robot on another
+machine, over the internet:
+
+```python
+from lerobot_robot_livekit import LiveKitRobot, LiveKitRobotConfig
+
+robot = LiveKitRobot(LiveKitRobotConfig(url=..., token=..., fps=30,
+                                        camera_names=("cam1",)))
+robot.connect()
+
+obs = robot.get_observation()
+action = model.select_action(obs)
+robot.send_action(action)
+```
+
+Same three lines at the bottom. The robot can be in another room or
+another country. `obs` still arrives as a bundled, timestamp-synced
+observation.
+
+The example above uses the lerobot plugin, because it gives the cleanest
+apples-to-apples comparison. Portal itself is a standalone library. The
+plugin is a thin, optional wrap on top of it. See the
+[30-second sketch](#30-second-sketch) for the same idea in the raw Portal
+API.
 
 ## The idea
 
-Think of your robot as a device that normally plugs into one computer. Portal
-lets it "plug into" a different one over the network, so your teleop
+Think of your robot as a device that normally plugs into one computer.
+Portal lets it plug into a different one over the network. Your teleop
 interface, your training loop, or your policy server can run anywhere and
 still see the robot as if it were local. The physical robot stays in the
-loop; Portal only adds the network tier.
+loop. Portal only adds the network tier.
 
 You use Portal by wrapping whatever code already drives your robot. On the
-robot host you publish frames and state through a `Portal` object; on the
-control host you receive them as a bundled `Observation(frames, state,
+robot host, you publish frames and state through a `Portal` object. On the
+control host, you receive them as a bundled `Observation(frames, state,
 timestamp_us)` and publish actions back. No framework is assumed.
 
 If you happen to be on [lerobot](https://github.com/huggingface/lerobot),
 two optional plugin packages collapse that to a one-line wrap around your
-existing `Robot` or `Teleoperator` (see [lerobot integration](docs/lerobot.md)).
+existing `Robot` or `Teleoperator`. See
+[lerobot integration](docs/lerobot.md).
 
 ## I want to…
 
 | Goal | Start here |
 |---|---|
 | **Wire Portal into my own robotics stack** | [Quickstart](docs/quickstart.md) and [Portal API](docs/portal-api.md) |
-| **Run a policy against a remote robot** | [Quickstart](docs/quickstart.md) (the policy sits on the control side and consumes `Observation`s) |
+| **Run a policy against a remote robot** | [Quickstart](docs/quickstart.md). The policy sits on the control side and consumes `Observation`s. |
 | **See a working end-to-end example with no hardware** | [`examples/python/basic/`](examples/python/basic) |
 | **Shortcut for lerobot users** | [lerobot integration](docs/lerobot.md) |
 
 ## Examples
 
 Running examples is the fastest way to a known-good setup. Both live under
-[`examples/python/`](examples/python):
+[`examples/python/`](examples/python).
 
-- **[`examples/python/basic/`](examples/python/basic)**: no hardware
-  required, uses the Portal API directly. Synthetic video + state on one
-  terminal, subscriber on another. Proves your LiveKit credentials and
-  native build are healthy.
-  ```bash
-  cd examples/python/basic
-  cp .env.example .env            # fill in LIVEKIT_URL / API_KEY / API_SECRET
-  uv sync
-  uv run robot.py                 # terminal 1
-  uv run teleoperator.py          # terminal 2
-  ```
-- **[`examples/python/so101/`](examples/python/so101)**: real hardware, uses
-  the lerobot plugin. Physical **SO-101 follower** driven by a remote
-  **SO-101 leader**, with the camera and joint state rendered in
-  [rerun](https://rerun.io). Full calibration + wiring walkthrough in its
-  [README](examples/python/so101/README.md).
+**[`examples/python/basic/`](examples/python/basic)**
+
+No hardware required. Uses the Portal API directly. Synthetic video and
+state on one terminal, subscriber on another. Proves your LiveKit
+credentials and native build are healthy.
+
+```bash
+cd examples/python/basic
+cp .env.example .env            # fill in LIVEKIT_URL / API_KEY / API_SECRET
+uv sync
+uv run robot.py                 # terminal 1
+uv run teleoperator.py          # terminal 2
+```
+
+**[`examples/python/so101/`](examples/python/so101)**
+
+Real hardware. Uses the lerobot plugin. A physical **SO-101 follower** is
+driven by a remote **SO-101 leader**. Camera and joint state render in
+[rerun](https://rerun.io). Full calibration and wiring walkthrough in its
+[README](examples/python/so101/README.md).
 
 Adapt either to bring up your own setup.
 
 ## 30-second sketch
 
-Robot side (publishes frames and state, receives actions):
+Robot side. Publishes frames and state. Receives actions.
 
 ```python
 from livekit.portal import Portal, PortalConfig, Role
@@ -85,7 +130,7 @@ while running:
     await asyncio.sleep(1 / 30)
 ```
 
-Control side (receives synced observations, publishes actions):
+Control side. Receives synced observations. Publishes actions.
 
 ```python
 from livekit.portal import Portal, PortalConfig, Role
@@ -128,18 +173,18 @@ bash scripts/build_native.sh release
 
 ## Documentation
 
-- [Quickstart](docs/quickstart.md): install, tokens, first run with the
+- [Quickstart](docs/quickstart.md). Install, tokens, first run with the
   Portal API.
-- [Portal API](docs/portal-api.md): the primary surface. `PortalConfig`,
+- [Portal API](docs/portal-api.md). The primary surface. `PortalConfig`,
   callbacks, send methods, role semantics.
-- [Concepts](docs/concepts.md): roles, observation model, frame format.
-- [Tuning](docs/tuning.md): `fps` / `slack` / `tolerance`, asymmetric rates,
+- [Concepts](docs/concepts.md). Roles, observation model, frame format.
+- [Tuning](docs/tuning.md). `fps`, `slack`, `tolerance`, asymmetric rates,
   reliability.
-- [RPC](docs/rpc.md): imperative commands (`home`, `calibrate`, etc.) on top
-  of LiveKit RPC.
-- [Synchronization deep dive](docs/synchronization.md): the full match
+- [RPC](docs/rpc.md). Imperative commands (`home`, `calibrate`, etc.) on
+  top of LiveKit RPC.
+- [Synchronization deep dive](docs/synchronization.md). The full match
   algorithm, cursor bookkeeping, complexity analysis.
-- [lerobot integration](docs/lerobot.md): the optional convenience plugins.
+- [lerobot integration](docs/lerobot.md). The optional convenience plugins.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,51 @@
-<a href="https://livekit.io/">
-  <img src=".github/assets/livekit-mark.png" alt="LiveKit logo" width="100" height="100">
-</a>
+<p align="center">
+  <a href="https://livekit.io/">
+    <img src=".github/assets/livekit-mark.png" alt="LiveKit logo" width="100" height="100">
+  </a>
+</p>
 
-# livekit-portal
+<h1 align="center">livekit-portal</h1>
 
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
-[![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+"></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-stable-orange" alt="Rust"></a>
+</p>
 
 <!--BEGIN_DESCRIPTION-->
-Teleoperate a robot, or run a policy against it, from anywhere on the internet. Portal carries cameras, joint state, and actions between a robot host and a control host over LiveKit. On the control side, everything arrives as synchronized `(frames, state, timestamp)` observations. Works with any robotics stack. An optional [LeRobot](https://github.com/huggingface/lerobot) plugin adds a one-line wrap for lerobot users.
+<p align="center"><b>Teleoperate a robot, or run a policy against it, from anywhere on the internet.</b> Portal carries cameras, joint state, and actions between a robot host and a control host over LiveKit. On the control side, everything arrives as synchronized <code>(frames, state, timestamp)</code> observations. Works with any robotics stack. An optional <a href="https://github.com/huggingface/lerobot">LeRobot</a> plugin adds a one-line drop-in for lerobot users.</p>
 <!--END_DESCRIPTION-->
+
+<p align="center">
+  <a href="#your-code-does-not-change">Show me</a> ·
+  <a href="#install">Install</a> ·
+  <a href="#examples">Examples</a> ·
+  <a href="docs/quickstart.md">Quickstart</a> ·
+  <a href="docs/portal-api.md">Portal API</a> ·
+  <a href="docs/concepts.md">Concepts</a> ·
+  <a href="docs/synchronization.md">Deep dive</a>
+</p>
+
+---
+
+## Features
+
+**Remote robot, same code.** Your robot loop keeps its shape. Portal moves the hardware to another machine. Your policy or teleop code still sees a local-looking `Robot` object.
+
+**Synced observations out of the box.** Cameras and joint state arrive fused into `Observation(frames, state, timestamp_us)`. That is the shape robotics policies already consume. No matching logic on your side.
+
+**Works with any stack.** A direct `Portal` API in Python and Rust. An optional [lerobot](https://github.com/huggingface/lerobot) plugin for a one-line wrap around your existing `Robot` or `Teleoperator`.
+
+**Low-latency transport.** WebRTC video (SIMD RGB→I420). SCTP data channels with reliable or unreliable delivery per stream. RPC for one-shots like `home` or `calibrate`. Rust core, Python bindings via UniFFI.
+
+---
 
 ## Your code does not change
 
-A local lerobot loop looks like this:
+A classical lerobot loop runs on the same machine as the robot:
 
 ```python
+# all on one machine, robot plugged in
 from lerobot.robots.myrobot import MyRobot
 
 robot = MyRobot(config=...)
@@ -27,14 +56,41 @@ action = model.select_action(obs)
 robot.send_action(action)
 ```
 
-Swap one import and you get the same loop driving a robot on another
-machine, over the internet:
+With Portal, the same loop splits into two small files. One lives next to the
+robot. The other lives wherever your policy or teleop runs.
+
+**`robot_host.py`** runs on the machine the robot is plugged into.
+
+```python
+from lerobot.robots.myrobot import MyRobot
+from lerobot_teleoperator_livekit import (
+    LiveKitTeleoperator, LiveKitTeleoperatorConfig,
+)
+
+robot = MyRobot(config=...)
+robot.connect()
+
+teleop = LiveKitTeleoperator(
+    LiveKitTeleoperatorConfig(url=..., token=..., session="session-1", fps=30),
+    robot=robot,
+)
+teleop.connect()
+
+while running:
+    teleop.send_feedback(robot.get_observation())     # upstream to operator
+    if action := teleop.get_action():                 # action from operator
+        robot.send_action(action)
+```
+
+**`control_host.py`** runs wherever you drive the robot from.
 
 ```python
 from lerobot_robot_livekit import LiveKitRobot, LiveKitRobotConfig
 
-robot = LiveKitRobot(LiveKitRobotConfig(url=..., token=..., fps=30,
-                                        camera_names=("cam1",)))
+robot = LiveKitRobot(LiveKitRobotConfig(
+    url=..., token=..., session="session-1", fps=30,
+    camera_names=("cam1",),
+))
 robot.connect()
 
 obs = robot.get_observation()
@@ -42,42 +98,40 @@ action = model.select_action(obs)
 robot.send_action(action)
 ```
 
-Same three lines at the bottom. The robot can be in another room or
-another country. `obs` still arrives as a bundled, timestamp-synced
-observation.
+The last three lines of `control_host.py` are the same three lines as the
+classical loop. The robot just lives on another machine now.
 
-The example above uses the lerobot plugin, because it gives the cleanest
-apples-to-apples comparison. Portal itself is a standalone library. The
-plugin is a thin, optional wrap on top of it. See the
-[30-second sketch](#30-second-sketch) for the same idea in the raw Portal
-API.
+The example above uses the lerobot plugin because it makes the diff a single
+import. Portal itself is a standalone library. The plugin is a thin wrap on
+top. See the [30-second sketch](#30-second-sketch) for the raw Portal API.
 
 ## The idea
 
 Think of your robot as a device that normally plugs into one computer.
 Portal lets it plug into a different one over the network. Your teleop
 interface, your training loop, or your policy server can run anywhere and
-still see the robot as if it were local. The physical robot stays in the
-loop. Portal only adds the network tier.
+still see the robot as if it were local.
 
 You use Portal by wrapping whatever code already drives your robot. On the
 robot host, you publish frames and state through a `Portal` object. On the
-control host, you receive them as a bundled `Observation(frames, state,
-timestamp_us)` and publish actions back. No framework is assumed.
+control host, you receive them as a bundled `Observation` and publish actions
+back. No framework is assumed.
 
-If you happen to be on [lerobot](https://github.com/huggingface/lerobot),
-two optional plugin packages collapse that to a one-line wrap around your
-existing `Robot` or `Teleoperator`. See
-[lerobot integration](docs/lerobot.md).
+## Install
 
-## I want to…
+```bash
+uv pip install livekit-portal
+# or
+pip install livekit-portal
+```
 
-| Goal | Start here |
-|---|---|
-| **Wire Portal into my own robotics stack** | [Quickstart](docs/quickstart.md) and [Portal API](docs/portal-api.md) |
-| **Run a policy against a remote robot** | [Quickstart](docs/quickstart.md). The policy sits on the control side and consumes `Observation`s. |
-| **See a working end-to-end example with no hardware** | [`examples/python/basic/`](examples/python/basic) |
-| **Shortcut for lerobot users** | [lerobot integration](docs/lerobot.md) |
+For local development, build the native library once:
+
+```bash
+cd python/packages/livekit-portal
+uv sync
+bash scripts/build_native.sh release
+```
 
 ## Examples
 
@@ -105,9 +159,10 @@ driven by a remote **SO-101 leader**. Camera and joint state render in
 [rerun](https://rerun.io). Full calibration and wiring walkthrough in its
 [README](examples/python/so101/README.md).
 
-Adapt either to bring up your own setup.
-
 ## 30-second sketch
+
+The raw Portal API, no plugin. This is what the lerobot wrappers use
+internally.
 
 Robot side. Publishes frames and state. Receives actions.
 
@@ -143,10 +198,10 @@ cfg.add_action(["j1", "j2", "j3"])
 portal = Portal(cfg)
 
 def on_observation(obs):
-    # obs.frames: dict[str, np.ndarray]
-    # obs.state:  dict[str, float]
+    # obs.frames:       dict[str, np.ndarray]
+    # obs.state:        dict[str, float]
     # obs.timestamp_us: int
-    portal.send_action(policy(obs))          # or teleop.get_action()
+    portal.send_action(policy(obs))     # or teleop.get_action()
 
 portal.on_observation(on_observation)
 await portal.connect(url, token)
@@ -155,36 +210,17 @@ await portal.connect(url, token)
 Full runnable version, including token minting, in the
 [Quickstart](docs/quickstart.md).
 
-## Install
-
-```bash
-uv pip install livekit-portal
-# or
-pip install livekit-portal
-```
-
-For local development, build the native library once:
-
-```bash
-cd python/packages/livekit-portal
-uv sync
-bash scripts/build_native.sh release
-```
-
 ## Documentation
 
-- [Quickstart](docs/quickstart.md). Install, tokens, first run with the
-  Portal API.
-- [Portal API](docs/portal-api.md). The primary surface. `PortalConfig`,
-  callbacks, send methods, role semantics.
-- [Concepts](docs/concepts.md). Roles, observation model, frame format.
-- [Tuning](docs/tuning.md). `fps`, `slack`, `tolerance`, asymmetric rates,
-  reliability.
-- [RPC](docs/rpc.md). Imperative commands (`home`, `calibrate`, etc.) on
-  top of LiveKit RPC.
-- [Synchronization deep dive](docs/synchronization.md). The full match
-  algorithm, cursor bookkeeping, complexity analysis.
-- [lerobot integration](docs/lerobot.md). The optional convenience plugins.
+| Page | What's in it |
+|---|---|
+| [Quickstart](docs/quickstart.md) | Install, tokens, first run with the Portal API |
+| [Portal API](docs/portal-api.md) | The primary surface. `PortalConfig`, callbacks, send methods, role semantics |
+| [Concepts](docs/concepts.md) | Roles, the observation model, frame format |
+| [Tuning](docs/tuning.md) | `fps`, `slack`, `tolerance`, asymmetric rates, reliability |
+| [RPC](docs/rpc.md) | Imperative commands (`home`, `calibrate`, ...) on top of LiveKit RPC |
+| [Synchronization deep dive](docs/synchronization.md) | The full match algorithm, cursor bookkeeping, complexity |
+| [lerobot integration](docs/lerobot.md) | The optional convenience plugins |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,33 +9,30 @@
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
 
 <!--BEGIN_DESCRIPTION-->
-A drop-in link between robots and their teleoperators or agents. Portal handles video streams, data streams, and **timestamp-synced observations** over LiveKit, so a VLA model on the operator side sees the same bundled `(frames, state, t)` tuple it would see from a local robot. Works with [LeRobot](https://github.com/huggingface/lerobot) out of the box.
+Teleoperate a robot, or run a policy against it, from anywhere on the internet. Portal carries cameras, joint state, and actions over LiveKit and delivers synchronized `(frames, state, timestamp)` observations on the control side — the shape robotics policies already expect. Drop-in for [LeRobot](https://github.com/huggingface/lerobot); a direct API covers other stacks.
 <!--END_DESCRIPTION-->
 
-## What it is
+## The idea
 
-If you have a robot *here* and you want to **teleoperate it** or **run a
-policy against it** from *somewhere else*, Portal is the network tier. The
-physical robot stays in the loop; Portal bundles synchronized
-`(frames, state, timestamp)` observations and routes actions back — over
-LiveKit, so it works across WAN.
+Think of your robot as a device that normally plugs into one computer. Portal
+lets it "plug into" a different one over the network — so your teleop
+interface, your training loop, or your policy server can run anywhere and
+still see the robot as if it were local. The physical robot stays in the
+loop; Portal only adds the network tier.
 
-Three concrete things you get:
-
-- **Synchronized observations** — video frames and state arrive bundled by
-  sender timestamp, in the shape VLA policies expect.
-- **Drop-in for lerobot** — two plugins wrap your existing `Robot` or
-  `Teleoperator`; the remote arm appears as a local device to any lerobot
-  workflow (teleop, dataset recording, policy eval).
-- **Works with or without it** — Rust core, Python via UniFFI. If you're not
-  on lerobot, there's a direct `Portal` API.
+Two plugins make this drop-in for
+[lerobot](https://github.com/huggingface/lerobot): wrap your existing `Robot`
+on the robot-side machine and your `Teleoperator` (or policy output) on the
+control-side machine, and the remote arm shows up as a local lerobot device
+to any workflow — teleoperation, dataset recording, policy eval. If you're
+not on lerobot, a direct `Portal` API covers the same ground.
 
 ## I want to…
 
 | Goal | Start here |
 |---|---|
 | **Teleoperate a lerobot-compatible robot over the network** | [Quickstart](docs/quickstart.md) |
-| **Run a VLA policy against a remote robot** | [Quickstart](docs/quickstart.md) (same setup, policy replaces the leader on the operator side) |
+| **Run a policy against a remote robot** | [Quickstart](docs/quickstart.md) (same setup — the policy replaces the leader on the control side) |
 | **Use Portal directly from a non-lerobot stack** | [Portal API](docs/portal-api.md) |
 | **See a working end-to-end example** | [Examples](#examples) below |
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@
 <!--END_DESCRIPTION-->
 
 <p align="center">
-  <a href="#at-a-glance">Show me</a> ·
-  <a href="#install">Install</a> ·
+  <a href="#quickstart">Quickstart</a> ·
   <a href="#examples">Examples</a> ·
-  <a href="docs/quickstart.md">Quickstart</a> ·
   <a href="docs/portal-api.md">Portal API</a> ·
   <a href="docs/concepts.md">Concepts</a> ·
   <a href="docs/synchronization.md">Deep dive</a>
@@ -40,7 +38,38 @@
 
 ---
 
-## At a glance
+## Quickstart
+
+### Install
+
+Portal is not on PyPI yet, and there are no prebuilt native binaries.
+Today you build from source. The flow is one clone, one build, one sync.
+
+**Prerequisites:**
+
+- A [Rust toolchain](https://rustup.rs/) (stable `cargo`)
+- Python 3.10+
+- [`uv`](https://docs.astral.sh/uv/)
+
+```bash
+git clone https://github.com/livekit/livekit-portal.git
+cd livekit-portal/python/packages/livekit-portal
+
+uv sync                                    # install Python deps into .venv
+bash scripts/build_native.sh release       # compile cdylib + generate UniFFI bindings
+```
+
+`build_native.sh` calls `cargo build -p livekit-portal-ffi`, drops the
+resulting `liblivekit_portal_ffi.{dylib,so,dll}` next to the Python
+sources, and runs `uniffi-bindgen` to emit the matching Python module. On
+a cold machine this takes a couple of minutes.
+
+Now `from livekit.portal import Portal` works inside
+`python/packages/livekit-portal/.venv/`. To depend on the package from
+another project, `pip install .` (or `pip install -e .`) from the same
+directory after the native build. Prebuilt wheels are on the roadmap.
+
+### Code
 
 A complete remote-robot session in two files. The robot host publishes
 frames and state, executes actions, and exposes a `home` RPC. The control
@@ -117,9 +146,9 @@ asyncio.run(main())
 
 That is the whole surface at work in one page. Synced observations, an
 action callback, an RPC for one-shots, and a live metrics snapshot. The
-code above is a sketch, not a runnable file. The real one is in
-[`examples/python/basic/`](examples/python/basic) with token minting
-already wired up.
+code above is a sketch. For a runnable version with token minting already
+wired up, see [`examples/python/basic/`](examples/python/basic) or the
+step-by-step [Quickstart doc](docs/quickstart.md).
 
 ## The idea
 
@@ -132,22 +161,6 @@ You use Portal by wrapping whatever code already drives your robot. On the
 robot host, you publish frames and state through a `Portal` object. On the
 control host, you receive them as a bundled `Observation` and publish actions
 back. No framework is assumed.
-
-## Install
-
-```bash
-uv pip install livekit-portal
-# or
-pip install livekit-portal
-```
-
-For local development, build the native library once:
-
-```bash
-cd python/packages/livekit-portal
-uv sync
-bash scripts/build_native.sh release
-```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -180,11 +180,19 @@ step-by-step [Quickstart doc](docs/quickstart.md).
 
 ## Behind the project
 
-Robotics policies want one bundled `Observation` per tick: cameras, joint
-state, and a timestamp arriving together. LiveKit's transport primitives do
-not deliver data that way. Video tracks and data streams each have their
-own pacing, codec path, and retransmission. On the receiver they surface
-as independent event streams arriving out of phase.
+Teleoperation over WAN is a networking problem before it is a robotics
+problem. Low-latency video and control data have to traverse NAT,
+asymmetric bandwidth, jitter, and packet loss. WebRTC was built for
+exactly this, and [LiveKit](https://livekit.io/) wraps it in a
+production-grade SFU with a clean SDK. Portal builds the robotics layer
+on top.
+
+That layer exists because robotics policies want one bundled
+`Observation` per tick: cameras, joint state, and a timestamp arriving
+together. LiveKit's transport primitives do not deliver data that way.
+Video tracks and data streams each have their own pacing, codec path,
+and retransmission. On the receiver they surface as independent event
+streams arriving out of phase.
 
 Portal closes that gap. Every outgoing frame and state packet carries the
 sender's monotonic clock (packet-trailer metadata for video, a `u64`

--- a/README.md
+++ b/README.md
@@ -64,10 +64,34 @@ resulting `liblivekit_portal_ffi.{dylib,so,dll}` next to the Python
 sources, and runs `uniffi-bindgen` to emit the matching Python module. On
 a cold machine this takes a couple of minutes.
 
-Now `from livekit.portal import Portal` works inside
-`python/packages/livekit-portal/.venv/`. To depend on the package from
-another project, `pip install .` (or `pip install -e .`) from the same
-directory after the native build. Prebuilt wheels are on the roadmap.
+`from livekit.portal import Portal` now works inside that `.venv`.
+
+**Use from another project.** After the native build, depend on the
+package by path. The [shipped examples](examples/python/basic/pyproject.toml)
+do this with relative paths because they sit inside the repo. From any
+other project, use an absolute path:
+
+```bash
+# uv
+uv add --editable /absolute/path/to/livekit-portal/python/packages/livekit-portal
+
+# pip
+pip install -e /absolute/path/to/livekit-portal/python/packages/livekit-portal
+```
+
+Or wire it directly into your `pyproject.toml`:
+
+```toml
+[project]
+dependencies = ["livekit-portal"]
+
+[tool.uv.sources]
+livekit-portal = { path = "/absolute/path/to/livekit-portal/python/packages/livekit-portal", editable = true }
+```
+
+Rerun `build_native.sh` whenever the Rust code changes. The editable
+install picks up the refreshed cdylib on the next import. Prebuilt
+wheels are on the roadmap.
 
 ### Code
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -31,7 +31,7 @@ streams each have their own pacing, codec path, and retransmission. On the
 wire you see four or more independent event streams arriving out of phase.
 
 Portal tags every outgoing frame and state packet with the **sender's clock**,
-then — on the operator side — matches them locally into `Observation`s. An
+then (on the operator side) matches them locally into `Observation`s. An
 observation fires only when every registered video track has a frame within
 the match window for a given state. Unmatched states are reported separately
 via `on_drop`.
@@ -95,26 +95,26 @@ sequenceDiagram
     R->>R: robot.send_action(...)
 ```
 
-## Synchronization — the short version
+## Synchronization in short
 
 For a head state with timestamp `S`, a frame at timestamp `F` on track `k` is a
 **candidate** iff `|S − F| < search_range`. Per state, Portal picks the
 *nearest* candidate per track and resolves the state one of three ways:
 
-- **Match** — every registered track has an in-range frame → emit
-  `Observation` via `on_observation`.
-- **Wait** — at least one track has no candidate yet, but its newest frame is
+- **Match**: every registered track has an in-range frame, so the
+  `Observation` is emitted via `on_observation`.
+- **Wait**: at least one track has no candidate yet, but its newest frame is
   still below the horizon (`buf.back().ts < S + R`). Newer frames may still
   land in range.
-- **Drop** — some track's newest frame is already past the horizon
+- **Drop**: some track's newest frame is already past the horizon
   (`buf.back().ts ≥ S + R`). No future frame can match (timestamps are
   monotonic), so the state is fired on `on_drop`.
 
 The search range and buffer sizes derive from a single `fps` knob plus a
-`slack` and `tolerance` — see [tuning.md](tuning.md).
+`slack` and `tolerance`. See [tuning.md](tuning.md).
 
-For the full algorithm — cursor rewind, blocker-gated sync, O(1) drop
-detection, eager cross-track drop — see
+For the full algorithm (cursor rewind, blocker-gated sync, O(1) drop
+detection, eager cross-track drop), see
 [synchronization.md](synchronization.md).
 
 ### Sender requirement
@@ -122,7 +122,7 @@ detection, eager cross-track drop — see
 Every received video frame must carry `user_timestamp` in its LiveKit
 packet-trailer metadata. Portal enables this automatically on tracks it
 publishes (`PacketTrailerFeatures.user_timestamp = true`). A subscribed track
-produced by anything that does *not* set this field is unsupported — either
+produced by anything that does *not* set this field is unsupported: either
 republish the source through Portal, or enable user-timestamp trailers on the
 upstream publisher.
 
@@ -133,9 +133,9 @@ per channel, no alpha. Layout is row-major and tightly packed
 (`stride = width * 3`), so an exact buffer is `width * height * 3` bytes.
 `width` and `height` must both be **even** (I420 chroma subsampling).
 
-This matches NumPy `uint8` arrays of shape `(H, W, 3)` in RGB order — the
-output of `PIL.Image.convert("RGB")` or OpenCV's
-`cvtColor(frame, COLOR_BGR2RGB)`.
+This matches NumPy `uint8` arrays of shape `(H, W, 3)` in RGB order, which is
+what `PIL.Image.convert("RGB")` or OpenCV's `cvtColor(frame, COLOR_BGR2RGB)`
+produces.
 
 Portal converts to I420 internally via libyuv's SIMD-optimized `RAWToI420`
 before handing the frame to WebRTC. Approximate cost on modern ARM64 (NEON)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -6,7 +6,7 @@ full detail, see [synchronization.md](synchronization.md).
 ## Roles
 
 Portal is a **two-role** system. Each side commits to one role at
-`PortalConfig` construction; calling the wrong send method returns `WrongRole`.
+`PortalConfig` construction. Calling the wrong send method returns `WrongRole`.
 
 | Role | Publishes | Subscribes |
 |------|-----------|------------|

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -1,9 +1,10 @@
 # Portal API
 
-The primary surface for using livekit-portal from any robotics stack. You
-construct a `PortalConfig`, hand it to a `Portal`, register callbacks, and
-push frames and state or actions. Everything else in this repository
-(including the optional lerobot plugins) is built on top of this API.
+The primary surface for using livekit-portal from any robotics stack.
+
+You construct a `PortalConfig`, hand it to a `Portal`, register callbacks,
+and push frames and state or actions. Everything else in this repository,
+including the optional lerobot plugins, is built on top of this API.
 
 ## Installation
 
@@ -64,7 +65,8 @@ async def main():
     portal = Portal(cfg)
 
     def on_action(action):
-        # action.values is the dict; action.timestamp_us is the sender's clock.
+        # action.values is the dict.
+        # action.timestamp_us is the sender's clock.
         robot.send_action(action.values)
 
     portal.on_action(on_action)
@@ -123,7 +125,7 @@ uint8. Width and height must both be even. Full details in
 - `portal.on_drop(cb)`: states that could not be matched (operator only).
 - `portal.on_action(cb)`: incoming actions (robot only).
 - `portal.on_state(cb)`: raw state firehose (operator only). Every packet
-  fires; if you want paced data, use `on_observation`.
+  fires. Use `on_observation` if you want paced data.
 - `portal.send_action(values, timestamp_us=...)`: operator only.
 - `portal.send_video_frame(name, frame, timestamp_us=...)`: robot only.
 - `portal.send_state(values, timestamp_us=...)`: robot only.
@@ -136,11 +138,11 @@ uint8. Width and height must both be even. Full details in
 
 ## Reference
 
-- [Concepts](concepts.md): roles, observation model, frame format.
-- [Tuning](tuning.md): `fps` / `slack` / `tolerance`, asymmetric rates.
-- [Synchronization deep dive](synchronization.md): the match algorithm.
-- [RPC](rpc.md): imperative commands on top of LiveKit RPC.
-- [`examples/python/basic/`](../examples/python/basic): the smallest
+- [Concepts](concepts.md). Roles, observation model, frame format.
+- [Tuning](tuning.md). `fps`, `slack`, `tolerance`, asymmetric rates.
+- [Synchronization deep dive](synchronization.md). The match algorithm.
+- [RPC](rpc.md). Imperative commands on top of LiveKit RPC.
+- [`examples/python/basic/`](../examples/python/basic). The smallest
   end-to-end script using this API, with synthetic video.
-- [lerobot integration](lerobot.md): the optional convenience plugins that
+- [lerobot integration](lerobot.md). The optional convenience plugins that
   wrap this API for lerobot users.

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -1,12 +1,9 @@
 # Portal API
 
-The raw `Portal` API is what the lerobot plugins wrap. Use it directly when
-your robotics stack isn't lerobot, when you need finer control than the
-plugins expose, or when you're binding Portal into a language other than
-Python.
-
-If you can use the plugins, prefer [lerobot integration](lerobot.md) — the
-plugin wraps exactly the code below.
+The primary surface for using livekit-portal from any robotics stack. You
+construct a `PortalConfig`, hand it to a `Portal`, register callbacks, and
+push frames and state or actions. Everything else in this repository
+(including the optional lerobot plugins) is built on top of this API.
 
 ## Installation
 
@@ -22,9 +19,9 @@ uv sync
 bash scripts/build_native.sh release
 ```
 
-`scripts/build_native.sh debug` is faster to iterate on. If the cdylib lives
-elsewhere (e.g. during Rust-side dev), point `LIVEKIT_PORTAL_FFI_LIB` at it
-and skip the copy step.
+`scripts/build_native.sh debug` is faster to iterate on. If the cdylib
+lives elsewhere (e.g. during Rust-side dev), point
+`LIVEKIT_PORTAL_FFI_LIB` at it and skip the copy step.
 
 ### Rust
 
@@ -33,19 +30,19 @@ and skip the copy step.
 livekit-portal = { path = "livekit-portal" }
 ```
 
-Python bindings ship via the `livekit-portal-ffi` crate (UniFFI + C ABI) and
-a pure-Python package in `python/packages/livekit-portal/`.
+Python bindings ship via the `livekit-portal-ffi` crate (UniFFI + C ABI)
+and a pure-Python package in `python/packages/livekit-portal/`.
 
 ## Role semantics
 
 Portal has two roles: `Role.ROBOT` and `Role.OPERATOR`. The role is fixed at
-`PortalConfig` construction. Calling a send method the role doesn't own
+`PortalConfig` construction. Calling a send method the role does not own
 returns `WrongRole`.
 
 | Role | Publishes | Subscribes |
 |------|-----------|------------|
 | `Role.ROBOT` | video frames, state | actions |
-| `Role.OPERATOR` | actions | video frames + state → synced observations |
+| `Role.OPERATOR` | actions | video frames + state, merged into synced observations |
 
 Both sides must register the same schema via `add_video` / `add_state` /
 `add_action`. Camera names and state/action field names must match across
@@ -111,8 +108,8 @@ async def main():
 asyncio.run(main())
 ```
 
-Callbacks fire on the asyncio loop that was running when you registered them —
-user code never runs on the tokio worker thread.
+Callbacks fire on the asyncio loop that was running when you registered
+them. User code never runs on the tokio worker thread.
 
 ## Frame format
 
@@ -122,25 +119,28 @@ uint8. Width and height must both be even. Full details in
 
 ## What else is on `Portal`
 
-- `portal.on_observation(cb)` — synced observations (operator only).
-- `portal.on_drop(cb)` — states that couldn't be matched (operator only).
-- `portal.on_action(cb)` — incoming actions (robot only).
-- `portal.on_state(cb)` — raw state firehose (operator only). Every packet
-  fires; if you want paced, use `on_observation`.
-- `portal.send_action(values, timestamp_us=...)` — operator only.
-- `portal.send_video_frame(name, frame, timestamp_us=...)` — robot only.
-- `portal.send_state(values, timestamp_us=...)` — robot only.
-- `portal.metrics()` — `PortalMetrics` snapshot (sync, transport, buffers, rtt).
-- `portal.register_rpc_method(name, handler)` / `portal.perform_rpc(name, ...)`
-  — see [rpc.md](rpc.md).
+- `portal.on_observation(cb)`: synced observations (operator only).
+- `portal.on_drop(cb)`: states that could not be matched (operator only).
+- `portal.on_action(cb)`: incoming actions (robot only).
+- `portal.on_state(cb)`: raw state firehose (operator only). Every packet
+  fires; if you want paced data, use `on_observation`.
+- `portal.send_action(values, timestamp_us=...)`: operator only.
+- `portal.send_video_frame(name, frame, timestamp_us=...)`: robot only.
+- `portal.send_state(values, timestamp_us=...)`: robot only.
+- `portal.metrics()`: `PortalMetrics` snapshot (sync, transport, buffers,
+  rtt).
+- `portal.register_rpc_method(name, handler)` /
+  `portal.perform_rpc(name, ...)`: see [rpc.md](rpc.md).
 - `await portal.connect(url, token)` / `await portal.disconnect()`.
-- `portal.close()` / `cfg.close()` — release native handles.
+- `portal.close()` / `cfg.close()`: release native handles.
 
 ## Reference
 
-- [Concepts](concepts.md) — roles, observation model, frame format.
-- [Tuning](tuning.md) — `fps` / `slack` / `tolerance`, asymmetric rates.
-- [Synchronization deep dive](synchronization.md) — the match algorithm.
-- [RPC](rpc.md) — imperative commands on top of LiveKit RPC.
-- [`examples/python/basic/`](../examples/python/basic) — the smallest
+- [Concepts](concepts.md): roles, observation model, frame format.
+- [Tuning](tuning.md): `fps` / `slack` / `tolerance`, asymmetric rates.
+- [Synchronization deep dive](synchronization.md): the match algorithm.
+- [RPC](rpc.md): imperative commands on top of LiveKit RPC.
+- [`examples/python/basic/`](../examples/python/basic): the smallest
   end-to-end script using this API, with synthetic video.
+- [lerobot integration](lerobot.md): the optional convenience plugins that
+  wrap this API for lerobot users.

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -8,27 +8,28 @@ including the optional lerobot plugins, is built on top of this API.
 
 ## Installation
 
-```bash
-uv pip install livekit-portal
-```
-
-From source:
+Portal is not on PyPI yet. You build from source. See the
+[Quickstart](quickstart.md#1-install) for the full flow. Summary:
 
 ```bash
-cd python/packages/livekit-portal
+git clone https://github.com/livekit/livekit-portal.git
+cd livekit-portal/python/packages/livekit-portal
+
 uv sync
-bash scripts/build_native.sh release
+bash scripts/build_native.sh release       # or `debug` for faster iteration
 ```
 
-`scripts/build_native.sh debug` is faster to iterate on. If the cdylib
-lives elsewhere (e.g. during Rust-side dev), point
+If the cdylib lives elsewhere (e.g. during Rust-side dev), point
 `LIVEKIT_PORTAL_FFI_LIB` at it and skip the copy step.
 
 ### Rust
 
+The core crate is usable directly without going through Python. From
+another Cargo workspace, depend on the path:
+
 ```toml
 [dependencies]
-livekit-portal = { path = "livekit-portal" }
+livekit-portal = { path = "path/to/livekit-portal/livekit-portal" }
 ```
 
 Python bindings ship via the `livekit-portal-ffi` crate (UniFFI + C ABI)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,9 +35,34 @@ platform cdylib (`liblivekit_portal_ffi.{dylib,so,dll}`) next to the
 Python package, and emits the matching UniFFI Python module. First build
 takes a couple of minutes. Subsequent builds are incremental.
 
-To use the package from another project, run `pip install .` (or
-`pip install -e .`) from the same directory after the native build.
-Prebuilt wheels are on the roadmap.
+### Use from another project
+
+After the native build, depend on the package by path. The
+[shipped examples](../examples/python/basic/pyproject.toml) do this with
+relative paths because they sit inside the repo. From another project,
+use an absolute path:
+
+```bash
+# uv
+uv add --editable /absolute/path/to/livekit-portal/python/packages/livekit-portal
+
+# pip
+pip install -e /absolute/path/to/livekit-portal/python/packages/livekit-portal
+```
+
+Or wire it directly into your `pyproject.toml`:
+
+```toml
+[project]
+dependencies = ["livekit-portal"]
+
+[tool.uv.sources]
+livekit-portal = { path = "/absolute/path/to/livekit-portal/python/packages/livekit-portal", editable = true }
+```
+
+Rerun `bash scripts/build_native.sh release` (in the Portal repo) whenever
+the Rust code changes. The editable install picks up the new cdylib on
+next import. Prebuilt wheels are on the roadmap.
 
 ## 2. Mint tokens
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,20 +1,20 @@
 # Quickstart
 
-Get a robot and an operator talking over LiveKit in ~5 minutes.
+Get a robot host and a control host talking over LiveKit in about 5 minutes
+using the Portal API directly.
 
-This page uses the **lerobot plugin path** — the shortest route. If your stack
-isn't lerobot-based, jump to the raw [Portal API reference](portal-api.md) once
-you're through this page.
+If you are already on lerobot, there is a one-line shortcut at the bottom of
+this page that wraps the same code.
 
 ## What you need
 
-- Python 3.12+ and [`uv`](https://docs.astral.sh/uv/)
-- A LiveKit server: [LiveKit Cloud](https://cloud.livekit.io) (free tier works) or
-  a local `livekit-server --dev`
+- Python 3.10+ and [`uv`](https://docs.astral.sh/uv/)
+- A LiveKit server: [LiveKit Cloud](https://cloud.livekit.io) (free tier
+  works) or a local `livekit-server --dev`
 - Your `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`
 
-You do **not** need a physical robot to try this — the first example below
-publishes a synthetic test pattern.
+You do **not** need a physical robot to try this. The first example publishes
+a synthetic test pattern.
 
 ## 1. Install
 
@@ -58,115 +58,136 @@ def mint(identity: str, room: str, key: str, secret: str) -> str:
 
 Identities must be unique within the room (e.g. `"robot"`, `"operator"`).
 
-## 3. Run it — lerobot plugin path
+## 3. Robot host
 
-Two scripts, one per machine. Both connect to the same room name.
-
-### Robot side (next to the hardware)
-
-Wrap your existing lerobot `Robot`:
+Runs next to the hardware. Declares what it will publish (video tracks,
+state fields) and what it will receive (action fields), then pumps frames
+and state at your capture rate.
 
 ```python
-from lerobot.robots.so100 import SO100Robot, SO100RobotConfig   # or your class
-from lerobot_teleoperator_livekit import (
-    LiveKitTeleoperator, LiveKitTeleoperatorConfig,
-)
+import asyncio, time
+from livekit.portal import Portal, PortalConfig, Role
 
-robot = SO100Robot(SO100RobotConfig(...))
-robot.connect()
+async def main():
+    cfg = PortalConfig("session-1", Role.ROBOT)
+    cfg.add_video("cam1")
+    cfg.add_state(["j1", "j2", "j3"])
+    cfg.add_action(["j1", "j2", "j3"])
+    cfg.set_fps(30)
 
-teleop = LiveKitTeleoperator(
-    LiveKitTeleoperatorConfig(
-        url="wss://your-project.livekit.cloud",
-        token=mint("robot", "session-1", API_KEY, API_SECRET),
-        session="session-1",
-        fps=30,
-    ),
-    robot=robot,                     # schema inferred from the robot
-)
-teleop.connect()
+    portal = Portal(cfg)
 
-try:
+    def on_action(a):
+        # a.values is the action dict; a.timestamp_us is the sender's clock
+        robot.send_action(a.values)
+
+    portal.on_action(on_action)
+    await portal.connect(URL, mint("robot", "session-1", API_KEY, API_SECRET))
+
     while running:
         obs = robot.get_observation()
-        teleop.send_feedback(obs)    # goes over the wire
-        action = teleop.get_action() # latest action from operator (may be {})
-        if action:
-            robot.send_action(action)
-        sleep(1 / 30)
-finally:
-    teleop.disconnect()
-    robot.disconnect()
+        ts = int(time.time() * 1_000_000)
+        portal.send_video_frame("cam1", obs.image, width, height, timestamp_us=ts)
+        portal.send_state(obs.state, timestamp_us=ts)
+        await asyncio.sleep(1 / 30)
+
+asyncio.run(main())
 ```
 
-### Operator side (workstation, trainer, policy host)
+`obs.image` must be a NumPy `uint8` array of shape `(H, W, 3)` in RGB.
 
-Wrap your local `Teleoperator` (leader arm, gamepad, or policy output):
+## 4. Control host
+
+Runs wherever your operator, trainer, or policy lives. Declares the same
+schema, then consumes synchronized observations and publishes actions.
 
 ```python
-from lerobot.teleoperators.leader import LeaderArmTeleop, LeaderArmTeleopConfig
-from lerobot_robot_livekit import LiveKitRobot, LiveKitRobotConfig
+import asyncio
+from livekit.portal import Portal, PortalConfig, Role
 
-leader = LeaderArmTeleop(LeaderArmTeleopConfig(...))
-leader.connect()
+async def main():
+    cfg = PortalConfig("session-1", Role.OPERATOR)
+    cfg.add_video("cam1")
+    cfg.add_state(["j1", "j2", "j3"])
+    cfg.add_action(["j1", "j2", "j3"])
+    cfg.set_fps(30)
+
+    portal = Portal(cfg)
+
+    def on_observation(obs):
+        # obs.frames: dict[str, np.ndarray]      # one per registered video track
+        # obs.state:  dict[str, float]
+        # obs.timestamp_us: int                  # sender clock
+        action = policy(obs)                     # or teleop.get_action(), etc.
+        portal.send_action(action)
+
+    portal.on_observation(on_observation)
+    await portal.connect(URL, mint("operator", "session-1", API_KEY, API_SECRET))
+
+    while running:
+        await asyncio.sleep(1)
+
+asyncio.run(main())
+```
+
+`policy(obs)` here is any function that turns an observation into an
+action dict. Teleoperation, imitation learning, VLA inference, a hand-written
+P controller: Portal does not care.
+
+## 5. Try the shipped examples
+
+Before wiring Portal into your real stack, run the basic example. It uses
+the exact API above, with synthetic video and a token minter already wired
+up.
+
+- [`examples/python/basic/`](../examples/python/basic): no hardware needed.
+  Ten-minute sanity check that your LiveKit credentials and native build
+  work.
+- [`examples/python/so101/`](../examples/python/so101): real hardware. Drive
+  a physical SO-101 follower from a remote SO-101 leader, with the camera
+  and joint state rendered in [rerun](https://rerun.io). Uses the lerobot
+  plugin shortcut (see below). Full calibration + wiring walkthrough in its
+  [README](../examples/python/so101/README.md).
+
+## Shortcut: lerobot users
+
+If your robot and control code already use the
+[lerobot](https://github.com/huggingface/lerobot) `Robot` / `Teleoperator`
+interfaces, two optional plugin packages wrap the Portal code above so you
+don't have to write it yourself.
+
+```python
+# robot host: wraps a local lerobot Robot
+from lerobot_teleoperator_livekit import LiveKitTeleoperator, LiveKitTeleoperatorConfig
+
+teleop = LiveKitTeleoperator(
+    LiveKitTeleoperatorConfig(url=URL, token=token, session="session-1", fps=30),
+    robot=my_robot,
+)
+teleop.connect()
+```
+
+```python
+# control host: wraps a local lerobot Teleoperator (or a policy)
+from lerobot_robot_livekit import LiveKitRobot, LiveKitRobotConfig
 
 robot = LiveKitRobot(
     LiveKitRobotConfig(
-        url="wss://your-project.livekit.cloud",
-        token=mint("operator", "session-1", API_KEY, API_SECRET),
-        session="session-1",
-        fps=30,
-        camera_names=("cam1",),
-        camera_height=480, camera_width=640,
+        url=URL, token=token, session="session-1", fps=30,
+        camera_names=("cam1",), camera_height=480, camera_width=640,
     ),
-    teleop=leader,                   # schema inferred from leader
+    teleop=my_leader,
 )
 robot.connect()
-
-try:
-    while running:
-        obs = robot.get_observation()   # synced {cameras, state, timestamp}
-        action = leader.get_action()    # or: policy(obs)
-        robot.send_action(action)
-        sleep(1 / 30)
-finally:
-    robot.disconnect()
-    leader.disconnect()
 ```
 
-The remote physical robot is now a local lerobot `Robot` to any downstream
-workflow — teleoperation, dataset recording, policy eval — none of it needs to
-know it's remote.
-
-## 4. Try the runnable examples first
-
-Before wiring Portal into your real stack, run the shipped examples:
-
-- [`examples/python/basic/`](../examples/python/basic) — no hardware needed.
-  Synthetic video + state on one terminal, subscriber on another. Ten-minute
-  sanity check that your LiveKit credentials and native build are good.
-- [`examples/python/so101/`](../examples/python/so101) — real hardware. Drive a
-  physical SO-101 follower from a remote SO-101 leader, with the camera and
-  joint state rendered in [rerun](https://rerun.io). Full calibration + wiring
-  walkthrough in its [README](../examples/python/so101/README.md).
-
-The examples are the fastest path to a known-good setup you can adapt.
-
-## Running a VLA policy instead of teleop
-
-Same setup — the operator side doesn't care *what* produces the action:
-
-```python
-while running:
-    obs = robot.get_observation()
-    action = policy(obs.frames, obs.state)   # or policy.select_action(obs)
-    robot.send_action(action)
-```
+The plugins are syntactic sugar over the Portal API above. Full reference
+and CLI mode: [lerobot integration](lerobot.md).
 
 ## Next steps
 
-- [Concepts](concepts.md) — roles, the observation model, frame format.
-- [Tuning](tuning.md) — `fps`, `slack`, `tolerance`, asymmetric rates, reliability.
-- [lerobot integration](lerobot.md) — full plugin config reference, CLI mode,
-  schema inference rules, troubleshooting.
-- [Portal API](portal-api.md) — the raw API, for stacks that aren't lerobot.
+- [Portal API](portal-api.md): the full surface. All callbacks, send
+  methods, role semantics.
+- [Concepts](concepts.md): roles, the observation model, frame format.
+- [Tuning](tuning.md): `fps`, `slack`, `tolerance`, asymmetric rates,
+  reliability.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,6 +8,7 @@ this page that wraps the same code.
 
 ## What you need
 
+- A [Rust toolchain](https://rustup.rs/) (stable `cargo`)
 - Python 3.10+ and [`uv`](https://docs.astral.sh/uv/)
 - A LiveKit server: [LiveKit Cloud](https://cloud.livekit.io) (free tier
   works) or a local `livekit-server --dev`
@@ -18,17 +19,25 @@ a synthetic test pattern.
 
 ## 1. Install
 
-```bash
-uv pip install livekit-portal
-```
-
-For local development from this repo:
+Portal is not on PyPI yet, and there are no prebuilt native binaries. You
+build from source.
 
 ```bash
-cd python/packages/livekit-portal
-uv sync
-bash scripts/build_native.sh release
+git clone https://github.com/livekit/livekit-portal.git
+cd livekit-portal/python/packages/livekit-portal
+
+uv sync                                    # install Python deps into .venv
+bash scripts/build_native.sh release       # compile cdylib + generate UniFFI bindings
 ```
+
+`build_native.sh` runs `cargo build -p livekit-portal-ffi`, drops the
+platform cdylib (`liblivekit_portal_ffi.{dylib,so,dll}`) next to the
+Python package, and emits the matching UniFFI Python module. First build
+takes a couple of minutes. Subsequent builds are incremental.
+
+To use the package from another project, run `pip install .` (or
+`pip install -e .`) from the same directory after the native build.
+Prebuilt wheels are on the roadmap.
 
 ## 2. Mint tokens
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,9 +60,11 @@ Identities must be unique within the room (e.g. `"robot"`, `"operator"`).
 
 ## 3. Robot host
 
-Runs next to the hardware. Declares what it will publish (video tracks,
-state fields) and what it will receive (action fields), then pumps frames
-and state at your capture rate.
+Runs next to the hardware.
+
+It declares what it will publish (video tracks, state fields) and what it
+will receive (action fields). Then it pumps frames and state at your
+capture rate.
 
 ```python
 import asyncio, time
@@ -78,7 +80,8 @@ async def main():
     portal = Portal(cfg)
 
     def on_action(a):
-        # a.values is the action dict; a.timestamp_us is the sender's clock
+        # a.values is the action dict.
+        # a.timestamp_us is the sender's clock.
         robot.send_action(a.values)
 
     portal.on_action(on_action)
@@ -98,8 +101,10 @@ asyncio.run(main())
 
 ## 4. Control host
 
-Runs wherever your operator, trainer, or policy lives. Declares the same
-schema, then consumes synchronized observations and publishes actions.
+Runs wherever your operator, trainer, or policy lives.
+
+It declares the same schema as the robot host. Then it consumes
+synchronized observations and publishes actions.
 
 ```python
 import asyncio
@@ -151,10 +156,9 @@ up.
 
 ## Shortcut: lerobot users
 
-If your robot and control code already use the
-[lerobot](https://github.com/huggingface/lerobot) `Robot` / `Teleoperator`
-interfaces, two optional plugin packages wrap the Portal code above so you
-don't have to write it yourself.
+Already using the [lerobot](https://github.com/huggingface/lerobot)
+`Robot` / `Teleoperator` interfaces? Two optional plugin packages wrap
+the Portal code above so you don't have to write it yourself.
 
 ```python
 # robot host: wraps a local lerobot Robot
@@ -186,8 +190,8 @@ and CLI mode: [lerobot integration](lerobot.md).
 
 ## Next steps
 
-- [Portal API](portal-api.md): the full surface. All callbacks, send
+- [Portal API](portal-api.md). The full surface. All callbacks, send
   methods, role semantics.
-- [Concepts](concepts.md): roles, the observation model, frame format.
-- [Tuning](tuning.md): `fps`, `slack`, `tolerance`, asymmetric rates,
+- [Concepts](concepts.md). Roles, the observation model, frame format.
+- [Tuning](tuning.md). `fps`, `slack`, `tolerance`, asymmetric rates,
   reliability.

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -2,8 +2,8 @@
 
 For imperative commands that don't fit the continuous state/action/observation
 loop (`home`, `start_recording`, `calibrate`, one-off configuration), Portal
-exposes the LiveKit RPC surface directly. Either side can register methods;
-either side can invoke.
+exposes the LiveKit RPC surface directly. Either side can register methods.
+Either side can invoke.
 
 ## Register and call
 
@@ -23,7 +23,7 @@ reply = await portal.perform_rpc("say", payload="hello")
 
 Handlers may be `def` or `async def` and **must return a string**.
 
-Handlers can be registered before or after `connect()`; the stored set is
+Handlers can be registered before or after `connect()`. The stored set is
 reapplied on every reconnect.
 
 ## Errors
@@ -70,5 +70,5 @@ SDK:
 
 Over-limit requests fail with transport error code 1402 (request) or 1504
 (response), not a handler exception. If you need binary, base64-encode it
-yourself; if you're pushing close to the limit continuously, that's a signal
+yourself. If you're pushing close to the limit continuously, that's a signal
 the data belongs on a stream, not in RPC.

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -1,14 +1,14 @@
 # RPC
 
 For imperative commands that don't fit the continuous state/action/observation
-loop — `home`, `start_recording`, `calibrate`, one-off configuration — Portal
+loop (`home`, `start_recording`, `calibrate`, one-off configuration), Portal
 exposes the LiveKit RPC surface directly. Either side can register methods;
 either side can invoke.
 
 ## Register and call
 
 ```python
-# Robot side — register a handler
+# Robot side: register a handler
 def say(data):
     print(f"operator says: {data.payload}")
     return "ok"
@@ -17,19 +17,19 @@ portal.register_rpc_method("say", say)
 ```
 
 ```python
-# Operator side — invoke it
+# Operator side: invoke it
 reply = await portal.perform_rpc("say", payload="hello")
 ```
 
 Handlers may be `def` or `async def` and **must return a string**.
 
-Handlers can be registered before or after `connect()` — the stored set is
+Handlers can be registered before or after `connect()`; the stored set is
 reapplied on every reconnect.
 
 ## Errors
 
 To signal an application error from a handler, raise
-`RpcError.Error(code, message, data)` — it's serialized and re-raised as
+`RpcError.Error(code, message, data)`. It is serialized and re-raised as
 `PortalError.Rpc` on the caller's side.
 
 ```python

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,6 +1,6 @@
 # Tuning
 
-Portal assumes **unified sampling** — the robot captures state and frames at
+Portal assumes **unified sampling**: the robot captures state and frames at
 the same tick. All sync parameters derive from a single `fps`, and all
 internal buffers share a single `slack` size.
 
@@ -65,7 +65,7 @@ config.set_action_reliable(True)   # actions typically want ordering
 
 ## Inspecting real behavior
 
-`portal.metrics()` exposes the live sync and transport counters — RTT
+`portal.metrics()` exposes the live sync and transport counters: RTT
 percentiles, match-delta percentiles, per-track frame jitter, buffer fill,
 observations emitted, states dropped. The examples under `examples/python/`
 print these periodically; adapt `periodic_metrics` from

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -12,7 +12,7 @@ config.set_tolerance(1.5)     # match window in tick units (default: 1.5)
 config.set_state_reliable(True)   # default: True
 config.set_action_reliable(True)  # default: True
 
-config.set_ping_ms(1000)      # RTT ping cadence; 0 disables (default: 1000)
+config.set_ping_ms(1000)      # RTT ping cadence. 0 disables. default: 1000.
 ```
 
 ## The three knobs
@@ -27,8 +27,8 @@ config.set_ping_ms(1000)      # RTT ping cadence; 0 disables (default: 1000)
 
 | Use case | Pick | Why |
 |---|---|---|
-| Real-time inference / control | `0.5` | A misaligned observation is silently wrong; a drop is an explicit signal. |
-| Data collection for VLA training | `1.5` | A ±1-tick misalignment (~16 ms @ 60 fps) is invisible to a trained model; a dropped observation is lost data. |
+| Real-time inference / control | `0.5` | A misaligned observation is silently wrong. A drop is an explicit signal. |
+| Data collection for VLA training | `1.5` | A ±1-tick misalignment (~16 ms @ 60 fps) is invisible to a trained model. A dropped observation is lost data. |
 | Teleop viewer | `1.5` | Visual continuity > frame-perfect alignment. |
 | Clean local network (<1% loss) | either | Drops are already rare. |
 | Lossy / cellular / wireless | `1.5` | Widening materially reduces drop rate under real loss. |
@@ -68,7 +68,7 @@ config.set_action_reliable(True)   # actions typically want ordering
 `portal.metrics()` exposes the live sync and transport counters: RTT
 percentiles, match-delta percentiles, per-track frame jitter, buffer fill,
 observations emitted, states dropped. The examples under `examples/python/`
-print these periodically; adapt `periodic_metrics` from
+print these periodically. Adapt `periodic_metrics` from
 [`examples/python/basic/_common.py`](../examples/python/basic/_common.py) for
 your own scripts.
 


### PR DESCRIPTION
## Summary

Restructures the top of the README so a first-time reader can see what Portal does, why it matters, and where to click next without scrolling past the fold. Takes cues from how other well-scanned robotics READMEs (lerobot, etc.) handle their landing.

### Top of page now has

1. Centered logo, title, badges.
2. A tagline description (one centered paragraph).
3. A single row of **quick links**: Show me, Install, Examples, Quickstart, Portal API, Concepts, Deep dive.
4. A **Features** section with four punchy one-line value props.
5. The **Your code does not change** before/after hook, showing both sides of the lerobot split (see below).

### Lerobot before/after: both files

The earlier revision only showed the control side. It now shows what actually happens: one file on the robot host, one file on the control host. The control-host file ends with the exact three lines of the classical local loop, which is the point.

```python
# robot_host.py
robot = MyRobot(config=...)
robot.connect()

teleop = LiveKitTeleoperator(..., robot=robot)
teleop.connect()

while running:
    teleop.send_feedback(robot.get_observation())
    if action := teleop.get_action():
        robot.send_action(action)
```

```python
# control_host.py
robot = LiveKitRobot(LiveKitRobotConfig(...))
robot.connect()

obs = robot.get_observation()
action = model.select_action(obs)
robot.send_action(action)
```

### Positioning preserved

The lerobot plugin is used for the before/after because it makes the diff a single import. The text right after the comparison still says Portal itself is the standalone library and the plugin is a thin wrap. The raw Portal API appears below as the 30-second sketch.

### Other changes

- Removed the "I want to..." table. The quick-links row and the Documentation table cover the same paths more compactly and are easier to scan.
- Documentation section is now a two-column table.
- No em dashes, no mid-line prose semicolons in any file this PR touches.

## Test plan

- [ ] README renders correctly on GitHub. The centered logo / badges / tagline / quick-links block looks like one visual unit.
- [ ] The four feature bullets are immediately visible above the fold on a standard viewport.
- [ ] The Features and "Your code does not change" sections render at the expected widths on mobile.
- [ ] All internal links resolve.
- [ ] \`rg ';' README.md docs/*.md\` (excluding lerobot.md / synchronization.md) returns nothing.
- [ ] \`rg '—' README.md docs/*.md\` (excluding lerobot.md / synchronization.md) returns nothing.