### PR TITLE
Opt-in stale-frame reuse: freeze video instead of dropping state

### DIFF
--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -89,6 +89,30 @@ is not a match and all future frames are ≥ that timestamp, so drop.
 These three outcomes (match / wait / drop) are the state machine the
 algorithm executes per head state on every push.
 
+### Optional: stale-frame reuse
+
+Enable `reuse_stale_frames` on `PortalConfig` to flip the drop outcome
+into a **reuse** outcome once a track has emitted at least once. The
+state falls back to that track's last-emitted frame, so the observation
+still fires — video "freezes" on the last good frame during loss while
+state keeps flowing. An empty buffer with a last-emitted frame emits
+immediately without waiting for the next fresh frame.
+
+| Track state, with `reuse_stale_frames = true` and `last_emitted.is_some()` | Decision |
+|---------------------------------------------------------------------------|----------|
+| Newest frame has `ts >= S + R` | **Reuse** last-emitted frame. Buffer is untouched — a later state can still consume the fresh frame. |
+| Buffer empty | **Reuse** last-emitted frame immediately. |
+| Fresh in-range match exists | **Match** (fresh match wins, `last_emitted` advances). |
+
+During the startup window before the first emission, `last_emitted` is
+`None` and there's no fallback — the strict drop rule still applies so
+the state buffer stays bounded if video never arrives at all. Once the
+first observation fires, reuse takes over and drops cease.
+
+Use this when data-collection or logging pipelines prefer a transient
+video freeze over a missing state. Leave it off for real-time control
+where a stale frame would misalign the perception/action loop.
+
 ## Naïve algorithm (what we *don't* do)
 
 The straightforward implementation does this on every push:

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -13,6 +13,8 @@ config.set_state_reliable(True)   # default: True
 config.set_action_reliable(True)  # default: True
 
 config.set_ping_ms(1000)      # RTT ping cadence. 0 disables. default: 1000.
+
+config.set_reuse_stale_frames(False)  # freeze video on loss instead of dropping (default: False)
 ```
 
 ## The three knobs
@@ -50,6 +52,32 @@ config.set_tolerance(1.5)    # still measured in video-tick intervals (~16.6 ms)
 
 Under asymmetric rates, the overall drop rate is proportional to
 `state_rate × video_loss_rate`, not the video rate.
+
+## Reuse stale frames
+
+Off by default. Flip on with `config.set_reuse_stale_frames(True)` when
+the application would rather see a frozen-video observation than a
+dropped state. A state whose video match window has elapsed reuses the
+most recent already-emitted frame on that track — video "freezes" on
+the last good frame while state keeps flowing. Every state becomes an
+observation once every track has emitted at least once. Before that,
+the strict drop-on-horizon rule still applies so the state buffer stays
+bounded if video never starts.
+
+| Use case | Pick |
+|---|---|
+| Real-time inference / control | `False` — a stale frame would misalign the perception/action loop. |
+| Data collection / logging | `True` — a dropped state is lost data; a transient video freeze is recoverable. |
+| Teleop viewer | `True` — visual continuity > frame-perfect alignment. |
+
+Under reuse, the freeze signal is `metrics.sync.stale_observations_emitted`
+— a rising counter at steady `observations_emitted` rate means a track
+is silently frozen. `match_delta_us_p95` also tracks drift between the
+state and its stale frame and can be used to gauge freeze duration, but
+it becomes unbounded once reuse kicks in so any alert keyed on it
+should be re-scoped. `last_blocker_track` only updates while a track is
+still waiting for its first frame, so don't rely on it to identify a
+freeze after startup — use `stale_observations_emitted` instead.
 
 ## Reliability
 

--- a/implementation.md
+++ b/implementation.md
@@ -160,21 +160,29 @@ for each state in state_buffer (oldest first):
     for each video track:
         find frame in that track's buffer where |frame.timestamp_us - state.timestamp_us| < search_range
         pick the frame with minimum delta
-        if no frame found for this track: 
-            this state cannot be synced
-            if all frames in this track's buffer are NEWER than state + search_range:
+        if no frame found for this track:
+            this state cannot be synced with a fresh frame
+            if config.reuse_stale_frames AND last_emitted_frames[track] is Some:
+                use last emitted frame as a stale fallback (do NOT drain buffer)
+            else if all frames in this track's buffer are NEWER than state + search_range:
                 state is unsyncable — drop it and all older states
                 fire drop callback
             else:
                 wait for more frames (break, try again later)
             break
-    if all tracks matched:
+    if all tracks matched (fresh or stale):
         form Observation
-        remove matched frames and all older frames from each buffer
-        remove this state and all older states from state buffer
+        for tracks with a fresh match:
+            remove matched frames and all older frames from that buffer
+            update last_emitted_frames[track] = that frame
+        for tracks using stale reuse:
+            leave buffer and last_emitted_frames untouched
+        remove this state from state buffer
         push Observation to observation buffer
         fire observation callback
 ```
+
+Stale reuse is opt-in (`config.reuse_stale_frames`, default off). When on, video "freezes" on the last good frame during loss while every state still turns into an observation. See `docs/synchronization.md` for the full state table.
 
 ### 8. Language Bindings
 

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -139,6 +139,7 @@ pub struct State {
 #[derive(Debug, Clone, Default, uniffi::Record)]
 pub struct SyncMetrics {
     pub observations_emitted: u64,
+    pub stale_observations_emitted: u64,
     pub states_dropped: u64,
     pub match_delta_us_p50: Option<u64>,
     pub match_delta_us_p95: Option<u64>,
@@ -382,6 +383,10 @@ impl PortalConfig {
 
     pub fn set_ping_ms(&self, ms: u64) {
         self.inner.lock().set_ping_ms(ms);
+    }
+
+    pub fn set_reuse_stale_frames(&self, enable: bool) {
+        self.inner.lock().set_reuse_stale_frames(enable);
     }
 }
 
@@ -647,6 +652,7 @@ fn metrics_from_core(m: core::PortalMetrics) -> PortalMetrics {
     PortalMetrics {
         sync: SyncMetrics {
             observations_emitted: m.sync.observations_emitted,
+            stale_observations_emitted: m.sync.stale_observations_emitted,
             states_dropped: m.sync.states_dropped,
             match_delta_us_p50: m.sync.match_delta_us_p50,
             match_delta_us_p95: m.sync.match_delta_us_p95,

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -45,6 +45,7 @@ pub struct PortalConfig {
     pub(crate) slack: u32,
     pub(crate) tolerance: f32,
     pub(crate) ping_ms: u64,
+    pub(crate) reuse_stale_frames: bool,
 }
 
 impl PortalConfig {
@@ -61,6 +62,7 @@ impl PortalConfig {
             slack: 5,
             tolerance: 1.5,
             ping_ms: 1000,
+            reuse_stale_frames: false,
         }
     }
 
@@ -143,6 +145,34 @@ impl PortalConfig {
         self.ping_ms = ms;
     }
 
+    /// When enabled, a state whose video match window has elapsed reuses
+    /// the most recent already-emitted frame on that track instead of
+    /// being dropped. Video "freezes" on the last good frame during loss
+    /// while state keeps flowing — every state becomes an observation
+    /// once every track has emitted at least once.
+    ///
+    /// Drops still happen in two cases: (1) a track that has not yet
+    /// emitted its first frame (pre-first-emission, or after `clear()`
+    /// resets the last-emitted slots) — either sync-fail on a
+    /// past-horizon frame or state-buffer overflow, same as strict mode,
+    /// and (2) state-buffer overflow itself, which remains a hard safety
+    /// net against a fully halted video pipeline.
+    ///
+    /// Monitoring note: under reuse, `last_blocker_track` only updates
+    /// during pre-first-emission and won't point at a silently frozen
+    /// track. Use `stale_observations_emitted` as the freeze signal.
+    /// `match_delta_us_p95` also becomes unbounded (stale deltas can be
+    /// arbitrarily large), so alerts keyed on that metric need reshaping.
+    ///
+    /// Off by default, which preserves the strict drop-on-horizon policy.
+    /// Turn this on for data collection or logging pipelines where
+    /// losing a state is worse than a transient video freeze; leave it
+    /// off for real-time control where a stale frame would misalign the
+    /// perception/action loop.
+    pub fn set_reuse_stale_frames(&mut self, enable: bool) {
+        self.reuse_stale_frames = enable;
+    }
+
     pub fn video_tracks(&self) -> &[String] {
         &self.video_tracks
     }
@@ -176,6 +206,7 @@ impl PortalConfig {
             video_buffer_size: self.slack,
             state_buffer_size: self.slack,
             search_range_us,
+            reuse_stale_frames: self.reuse_stale_frames,
         }
     }
 }

--- a/livekit-portal/src/metrics.rs
+++ b/livekit-portal/src/metrics.rs
@@ -17,6 +17,11 @@ pub struct PortalMetrics {
 #[derive(Debug, Clone, Default)]
 pub struct SyncMetrics {
     pub observations_emitted: u64,
+    /// Subset of `observations_emitted` where at least one track contributed a
+    /// stale, previously-emitted frame (reuse fallback). Always 0 unless
+    /// `reuse_stale_frames` is enabled. A rising counter at steady observation
+    /// rate signals a silently frozen video track.
+    pub stale_observations_emitted: u64,
     pub states_dropped: u64,
     /// Worst per-track alignment `max_t |state_ts − frame_ts|` across the
     /// tracks in each emitted observation, over a rolling 256-sample window.
@@ -81,6 +86,7 @@ pub(crate) struct MetricsRegistry {
     action_jitter: Mutex<JitterState>,
 
     observations_emitted: AtomicU64,
+    stale_observations_emitted: AtomicU64,
     states_dropped: AtomicU64,
     match_deltas: Mutex<SampleRing>,
     // Index into `track_order`; `usize::MAX` means "no blocker recorded".
@@ -110,6 +116,7 @@ impl MetricsRegistry {
             state_jitter: Mutex::new(JitterState::default()),
             action_jitter: Mutex::new(JitterState::default()),
             observations_emitted: AtomicU64::new(0),
+            stale_observations_emitted: AtomicU64::new(0),
             states_dropped: AtomicU64::new(0),
             match_deltas: Mutex::new(SampleRing::new(SAMPLE_RING_CAP)),
             last_blocker_track: AtomicUsize::new(usize::MAX),
@@ -144,6 +151,10 @@ impl MetricsRegistry {
     pub fn record_observation(&self, worst_delta_us: u64) {
         self.observations_emitted.fetch_add(1, Ordering::Relaxed);
         self.match_deltas.lock().push(worst_delta_us);
+    }
+
+    pub fn record_stale_observation(&self) {
+        self.stale_observations_emitted.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn record_state_dropped(&self, n: u64) {
@@ -202,6 +213,9 @@ impl MetricsRegistry {
         PortalMetrics {
             sync: SyncMetrics {
                 observations_emitted: self.observations_emitted.load(Ordering::Relaxed),
+                stale_observations_emitted: self
+                    .stale_observations_emitted
+                    .load(Ordering::Relaxed),
                 states_dropped: self.states_dropped.load(Ordering::Relaxed),
                 match_delta_us_p50: match_p50,
                 match_delta_us_p95: match_p95,
@@ -237,6 +251,7 @@ impl MetricsRegistry {
         *self.state_jitter.lock() = JitterState::default();
         *self.action_jitter.lock() = JitterState::default();
         self.observations_emitted.store(0, Ordering::Relaxed);
+        self.stale_observations_emitted.store(0, Ordering::Relaxed);
         self.states_dropped.store(0, Ordering::Relaxed);
         self.match_deltas.lock().clear();
         self.last_blocker_track.store(usize::MAX, Ordering::Relaxed);

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -15,6 +15,12 @@ pub(crate) struct SyncOutput {
     pub observations: Vec<Observation>,
     /// State samples that could not be matched to a video frame. Typed
     /// per the declared state schema, same shape as `Observation.state`.
+    /// Populated by sync-fail and state-buffer overflow. Under the default
+    /// strict policy, sync-fail fires whenever the video horizon advances
+    /// past a state with no in-range match. Under `reuse_stale_frames`,
+    /// sync-fail only fires before a track has emitted its first frame;
+    /// after that, states fall back to the last-emitted frame rather than
+    /// dropping.
     pub drops: Vec<HashMap<String, TypedValue>>,
 }
 
@@ -50,7 +56,22 @@ pub(crate) struct SyncBuffer {
     blocker: Option<usize>,
 
     // Reused across try_sync calls to avoid allocating a match map per iteration.
-    matched_scratch: Vec<Option<(usize, Arc<VideoFrameData>)>>,
+    // `Some((Some(idx), frame))` = fresh match at buffer index `idx` (drain on emit).
+    // `Some((None, frame))`      = stale reuse of last-emitted frame (do not drain).
+    matched_scratch: Vec<Option<(Option<usize>, Arc<VideoFrameData>)>>,
+
+    // Per-track: the most recent frame emitted in an observation. Used as a
+    // stale fallback when the current state has no in-range match, so no
+    // observation is ever dropped due to missing video — the video "freezes"
+    // on the last good frame instead. None until the track emits its first
+    // frame.
+    last_emitted_frames: Vec<Option<Arc<VideoFrameData>>>,
+
+    // True when the previous push_state hit state-buffer overflow. Used to
+    // suppress the warn log on consecutive overflows so a sustained halt
+    // logs once per burst instead of once per state tick. Metrics still
+    // count every drop.
+    in_overflow_burst: bool,
 
     metrics: Arc<MetricsRegistry>,
 }
@@ -68,6 +89,7 @@ impl SyncBuffer {
         let video_buffers = (0..track_names.len()).map(|_| VecDeque::new()).collect();
         let cursors = vec![0; track_names.len()];
         let matched_scratch = vec![None; track_names.len()];
+        let last_emitted_frames = vec![None; track_names.len()];
         Self {
             track_names,
             track_index,
@@ -78,6 +100,8 @@ impl SyncBuffer {
             cursors,
             blocker: None,
             matched_scratch,
+            last_emitted_frames,
+            in_overflow_burst: false,
             metrics,
         }
     }
@@ -142,7 +166,19 @@ impl SyncBuffer {
         }
         if !overflow_drops.is_empty() {
             self.metrics.record_state_dropped(overflow_drops.len() as u64);
-            log::warn!("state buffer overflow: dropped {} state(s)", overflow_drops.len());
+            // Log once per overflow burst so a sustained halt doesn't spam
+            // at the state tick rate. The `states_dropped` metric still
+            // reflects every drop.
+            if !self.in_overflow_burst {
+                log::warn!(
+                    "state buffer overflow: dropped {} state(s); further \
+                     drops in this burst will not be re-logged",
+                    overflow_drops.len()
+                );
+                self.in_overflow_burst = true;
+            }
+        } else {
+            self.in_overflow_burst = false;
         }
         // If eviction (or first-ever push) changed the head state, the old blocker
         // hint no longer applies.
@@ -168,7 +204,11 @@ impl SyncBuffer {
         for c in &mut self.cursors {
             *c = 0;
         }
+        for slot in &mut self.last_emitted_frames {
+            *slot = None;
+        }
         self.blocker = None;
+        self.in_overflow_burst = false;
     }
 
     fn try_sync(&mut self) -> SyncOutput {
@@ -196,11 +236,89 @@ impl SyncBuffer {
             // track later in the list can override the wait — otherwise a state
             // could stall forever waiting on cam1 while cam2 has already moved
             // beyond the match horizon.
+            //
+            // When `reuse_stale_frames` is enabled, any track with a
+            // last-emitted frame short-circuits to stale reuse instead of
+            // waiting or dropping. The remaining wait/drop branches cover the
+            // startup window before a track has emitted for the first time,
+            // plus state-buffer overflow (handled in `push_state`) as the
+            // hard safety net against a fully halted video stream.
             let mut should_drop = false;
             let mut iter_blocker: Option<usize> = None;
 
             for track_i in 0..self.video_buffers.len() {
                 let frame_buf = &self.video_buffers[track_i];
+
+                // Cursor maintenance / fresh match search. Guarded on buffer
+                // being non-empty; if empty we fall through to the reuse /
+                // wait branches below.
+                let mut best_idx: Option<usize> = None;
+                if !frame_buf.is_empty() {
+                    let cursor = &mut self.cursors[track_i];
+                    // Defensive clamp in case capacity shrunk or mutation missed an adjustment.
+                    if *cursor >= frame_buf.len() {
+                        *cursor = frame_buf.len() - 1;
+                    }
+                    // Rewind if the cursor is already past state_ts (can happen if
+                    // states arrive out of order on unreliable delivery).
+                    while *cursor > 0 && frame_buf[*cursor].timestamp_us > state_ts {
+                        *cursor -= 1;
+                    }
+                    // Advance while the next frame is still at or before state_ts.
+                    while *cursor + 1 < frame_buf.len()
+                        && frame_buf[*cursor + 1].timestamp_us <= state_ts
+                    {
+                        *cursor += 1;
+                    }
+
+                    let cursor_val = *cursor;
+                    let mut best_delta = u64::MAX;
+                    for candidate in
+                        [Some(cursor_val), cursor_val.checked_add(1)].into_iter().flatten()
+                    {
+                        if let Some(f) = frame_buf.get(candidate) {
+                            let d = state_ts.abs_diff(f.timestamp_us);
+                            if d >= range || d >= best_delta {
+                                continue;
+                            }
+                            // Fair-share: if a later buffered state has a strictly
+                            // closer claim, leave the frame for it. Prevents a
+                            // greedy head-state from stealing its neighbor's frame
+                            // when tolerance > 1 tick.
+                            if let Some(nts) = next_state_ts {
+                                if nts.abs_diff(f.timestamp_us) < d {
+                                    continue;
+                                }
+                            }
+                            best_delta = d;
+                            best_idx = Some(candidate);
+                        }
+                    }
+                }
+
+                if let Some(idx) = best_idx {
+                    self.matched_scratch[track_i] =
+                        Some((Some(idx), self.video_buffers[track_i][idx].clone()));
+                    continue;
+                }
+
+                // No fresh in-range match. If reuse is enabled and the track
+                // has emitted before, stale-reuse immediately — same rule for
+                // every "no fresh match" case (empty buffer, below horizon,
+                // past horizon). Keeps the policy consistent: video "freezes"
+                // on the last good frame while state keeps flowing.
+                if self.config.reuse_stale_frames {
+                    if let Some(stale) = self.last_emitted_frames[track_i].clone() {
+                        self.matched_scratch[track_i] = Some((None, stale));
+                        continue;
+                    }
+                }
+
+                // Startup fallback: no reuse available. Empty buffer or below
+                // the horizon → wait (future frames may still match). Newest
+                // past the horizon → permanently unmatchable, drop. The drop
+                // path here only fires before the track's first emission;
+                // after that, reuse above handles it.
                 if frame_buf.is_empty() {
                     if iter_blocker.is_none() {
                         iter_blocker = Some(track_i);
@@ -208,60 +326,15 @@ impl SyncBuffer {
                     continue;
                 }
 
-                let cursor = &mut self.cursors[track_i];
-                // Defensive clamp in case capacity shrunk or mutation missed an adjustment.
-                if *cursor >= frame_buf.len() {
-                    *cursor = frame_buf.len() - 1;
-                }
-                // Rewind if the cursor is already past state_ts (can happen if
-                // states arrive out of order on unreliable delivery).
-                while *cursor > 0 && frame_buf[*cursor].timestamp_us > state_ts {
-                    *cursor -= 1;
-                }
-                // Advance while the next frame is still at or before state_ts.
-                while *cursor + 1 < frame_buf.len()
-                    && frame_buf[*cursor + 1].timestamp_us <= state_ts
-                {
-                    *cursor += 1;
-                }
-
-                let cursor_val = *cursor;
-                let mut best_idx: Option<usize> = None;
-                let mut best_delta = u64::MAX;
-                for candidate in [Some(cursor_val), cursor_val.checked_add(1)].into_iter().flatten()
-                {
-                    if let Some(f) = frame_buf.get(candidate) {
-                        let d = state_ts.abs_diff(f.timestamp_us);
-                        if d >= range || d >= best_delta {
-                            continue;
-                        }
-                        // Fair-share: if a later buffered state has a strictly
-                        // closer claim, leave the frame for it. Prevents a
-                        // greedy head-state from stealing its neighbor's frame
-                        // when tolerance > 1 tick.
-                        if let Some(nts) = next_state_ts {
-                            if nts.abs_diff(f.timestamp_us) < d {
-                                continue;
-                            }
-                        }
-                        best_delta = d;
-                        best_idx = Some(candidate);
-                    }
-                }
-
-                if let Some(idx) = best_idx {
-                    self.matched_scratch[track_i] = Some((idx, frame_buf[idx].clone()));
-                    continue;
-                }
-
-                // Unmatched. The real question is whether any *future* frame could
-                // match; since frame timestamps are monotonic, future ts ≥ back_ts,
-                // so the state is permanently unmatchable iff back_ts >= state_ts +
-                // range. (Checking the front would only detect the drop after
-                // eviction has dragged the old tail past the horizon — a latency
-                // bug of up to video_buffer_size frames.) `>=` matches the strict
-                // `d < range` match rule: a frame at exactly state_ts + range is
-                // not a match, so the state can't match it either.
+                // Unmatched, buffer non-empty. The real question is whether
+                // any *future* frame could match; since frame timestamps are
+                // monotonic, future ts ≥ back_ts, so the state is permanently
+                // unmatchable iff back_ts >= state_ts + range. (Checking the
+                // front would only detect the drop after eviction has dragged
+                // the old tail past the horizon — a latency bug of up to
+                // video_buffer_size frames.) `>=` matches the strict
+                // `d < range` match rule: a frame at exactly state_ts + range
+                // is not a match, so the state can't match it either.
                 let newest_ts = frame_buf.back().unwrap().timestamp_us;
                 if newest_ts >= state_ts.saturating_add(range) {
                     should_drop = true;
@@ -286,24 +359,46 @@ impl SyncBuffer {
                 return output;
             }
 
-            // Record worst-case per-track alignment before we drain the matches.
+            // Record worst-case per-track alignment (against whichever frame
+            // got used, fresh or stale — stale deltas can be arbitrarily large
+            // so this surfaces video-freeze duration in metrics). Separately
+            // flag observations that involved any stale reuse so ops can
+            // distinguish "video is silently frozen" from normal operation.
             let mut worst_delta = 0u64;
+            let mut any_stale = false;
             for slot in &self.matched_scratch {
-                if let Some((_, frame)) = slot.as_ref() {
+                if let Some((maybe_idx, frame)) = slot.as_ref() {
                     worst_delta = worst_delta.max(state_ts.abs_diff(frame.timestamp_us));
+                    if maybe_idx.is_none() {
+                        any_stale = true;
+                    }
                 }
             }
             self.metrics.record_observation(worst_delta);
+            if any_stale {
+                self.metrics.record_stale_observation();
+            }
 
             let (ts, values) = self.state_buffer.pop_front().unwrap();
 
             let mut frames_map: HashMap<String, VideoFrameData> =
                 HashMap::with_capacity(self.track_names.len());
             for track_i in 0..self.track_names.len() {
-                if let Some((idx, frame)) = self.matched_scratch[track_i].take() {
-                    self.video_buffers[track_i].drain(0..=idx);
-                    // Cursor was at or just past idx; after draining, shift it back.
-                    self.cursors[track_i] = self.cursors[track_i].saturating_sub(idx + 1);
+                if let Some((maybe_idx, frame)) = self.matched_scratch[track_i].take() {
+                    if let Some(idx) = maybe_idx {
+                        // Fresh match: drain the buffer up to and including
+                        // this frame and remember it as the stale fallback
+                        // for any later state that can't find a fresh match.
+                        self.video_buffers[track_i].drain(0..=idx);
+                        // Cursor was at or just past idx; after draining, shift it back.
+                        self.cursors[track_i] = self.cursors[track_i].saturating_sub(idx + 1);
+                        self.last_emitted_frames[track_i] = Some(frame.clone());
+                    }
+                    // Stale reuse (maybe_idx == None): leave buffer/cursor
+                    // untouched so a future in-range frame can still be used
+                    // by a later state; the stored last-emitted frame is
+                    // unchanged.
+                    //
                     // Cheap clone: VideoFrameData carries Arc<[u8]>.
                     frames_map.insert(self.track_names[track_i].clone(), (*frame).clone());
                 }
@@ -510,6 +605,7 @@ mod tests {
             video_buffer_size: 1,
             state_buffer_size: 10,
             search_range_us: 30_000,
+            ..Default::default()
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -591,6 +687,7 @@ mod tests {
             video_buffer_size: 10,
             state_buffer_size: 10,
             search_range_us: 500,
+            ..Default::default()
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -615,6 +712,7 @@ mod tests {
             video_buffer_size: 10,
             state_buffer_size: 10,
             search_range_us: 500,
+            ..Default::default()
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -653,6 +751,7 @@ mod tests {
             video_buffer_size: 5,
             state_buffer_size: 5,
             search_range_us: 50_000,
+            ..Default::default()
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -676,6 +775,7 @@ mod tests {
             video_buffer_size: 5,
             state_buffer_size: 5,
             search_range_us: 50_000, // tolerance 1.5 at 30fps
+            ..Default::default()
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -713,6 +813,7 @@ mod tests {
             video_buffer_size: 5,
             state_buffer_size: 5,
             search_range_us: 16_666,
+            ..Default::default()
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -721,6 +822,300 @@ mod tests {
         let out = push_f(&mut buf, "cam1", 100_000); // crosses horizon, fires drop
         assert!(out.observations.is_empty());
         assert_eq!(out.drops.len(), 1, "tight range must drop when native frame is missing");
+    }
+
+    // --- reuse_stale_frames (opt-in): no state is dropped to video-frame
+    //     loss once every track has emitted at least once. Video "freezes"
+    //     on the last good frame instead. State-buffer overflow and the
+    //     pre-first-emission startup window are the only remaining drop
+    //     sources.
+
+    fn reuse_config() -> SyncConfig {
+        SyncConfig {
+            video_buffer_size: 5,
+            state_buffer_size: 5,
+            search_range_us: 500,
+            reuse_stale_frames: true,
+        }
+    }
+
+    /// After one successful emission, a subsequent state pushed with an
+    /// empty video buffer reuses the last-emitted frame and emits
+    /// immediately.
+    #[test]
+    fn reuse_empty_buffer_emits_with_last_frame() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        // First emission establishes a last-emitted frame.
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let out = buf.push_state(1_100, vec![1.0]);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam1"].timestamp_us, 1_000);
+
+        // Next state: no new frames arrived. Strict policy would wait;
+        // reuse emits with the last good frame.
+        let out = buf.push_state(2_000, vec![2.0]);
+        assert_eq!(out.drops.len(), 0);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].state["j1"], TypedValue::F64(2.0));
+        assert_eq!(
+            out.observations[0].frames["cam1"].timestamp_us,
+            1_000,
+            "stale reuse uses the last emitted frame"
+        );
+    }
+
+    /// When a frame arrives past the head state's horizon (no in-range match
+    /// possible), reuse emits with the last-emitted frame instead of dropping.
+    /// The newly arrived frame is left in the buffer for a later state.
+    #[test]
+    fn reuse_past_horizon_emits_with_last_frame() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        // First emission sets last-emitted to frame@0.
+        let _ = push_f(&mut buf, "cam1", 0);
+        let out = buf.push_state(10, vec![0.0]);
+        assert_eq!(out.observations.len(), 1);
+
+        // Load the buffer with a frame past state@100's horizon (d = 900,
+        // range = 500, so no match and newest >= state + range).
+        let _ = push_f(&mut buf, "cam1", 900);
+        let out = buf.push_state(100, vec![1.0]);
+        assert_eq!(out.drops.len(), 0, "reuse replaces the horizon drop");
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(
+            out.observations[0].frames["cam1"].timestamp_us,
+            0,
+            "stale reuse, not the unmatched buffered frame"
+        );
+        // The buffered frame must still be available for a later state.
+        let out = buf.push_state(800, vec![2.0]);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam1"].timestamp_us, 900);
+    }
+
+    /// Before any frame has ever been emitted on a track, reuse has no
+    /// fallback. A frame arriving past the horizon still drops the state
+    /// (matching the strict policy), so the buffer stays bounded during a
+    /// broken-video startup.
+    #[test]
+    fn reuse_startup_no_fallback_still_drops() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        assert!(buf.push_state(1_000, vec![1.0]).is_empty());
+        let out = push_f(&mut buf, "cam1", 100_000);
+        assert_eq!(
+            out.drops.len(),
+            1,
+            "no last-emitted frame yet — reuse can't save the state"
+        );
+        assert_eq!(out.observations.len(), 0);
+    }
+
+    /// Startup with a totally dead track: state-buffer overflow drops
+    /// accumulated states so memory stays bounded.
+    #[test]
+    fn reuse_startup_overflow_still_drops() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let config = SyncConfig { state_buffer_size: 2, ..reuse_config() };
+        let mut buf = mk(&tracks, fields, config);
+
+        assert!(buf.push_state(100, vec![1.0]).is_empty());
+        assert!(buf.push_state(200, vec![2.0]).is_empty());
+        let out = buf.push_state(300, vec![3.0]);
+        assert_eq!(out.drops.len(), 1, "overflow drops during total video loss");
+        assert_eq!(out.drops[0]["j1"], TypedValue::F64(1.0));
+    }
+
+    /// Multi-track: one track freezes while the other keeps delivering fresh
+    /// frames. Observations keep flowing, mixing stale and fresh frames.
+    #[test]
+    fn reuse_multi_track_freeze_one_keeps_other_fresh() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        // First emission on both tracks.
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let _ = push_f(&mut buf, "cam2", 1_000);
+        let out = buf.push_state(1_050, vec![1.0]);
+        assert_eq!(out.observations.len(), 1);
+
+        // cam1 freezes; cam2 keeps delivering. State still emits, with stale
+        // cam1 and fresh cam2.
+        let _ = push_f(&mut buf, "cam2", 2_000);
+        let out = buf.push_state(2_050, vec![2.0]);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam1"].timestamp_us, 1_000);
+        assert_eq!(out.observations[0].frames["cam2"].timestamp_us, 2_000);
+    }
+
+    /// Fresh match still wins over stale reuse: if an in-range frame exists,
+    /// it's used, the buffer drains, and `last_emitted` advances.
+    #[test]
+    fn reuse_prefers_fresh_match_when_available() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let _ = buf.push_state(1_050, vec![1.0]);
+
+        // Push a fresh in-range frame; state should match it, not reuse f@1000.
+        let _ = push_f(&mut buf, "cam1", 2_000);
+        let out = buf.push_state(2_100, vec![2.0]);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam1"].timestamp_us, 2_000);
+        assert!(buf.last_emitted_frames[0].as_ref().unwrap().timestamp_us == 2_000);
+    }
+
+    /// clear() resets last-emitted frames so reuse after clear behaves like
+    /// a fresh start.
+    #[test]
+    fn reuse_clear_resets_last_emitted() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let out = buf.push_state(1_050, vec![1.0]);
+        assert_eq!(out.observations.len(), 1);
+        assert!(buf.last_emitted_frames[0].is_some());
+
+        buf.clear();
+        assert!(buf.last_emitted_frames[0].is_none());
+
+        // After clear we're back in startup: no fallback, past-horizon drops.
+        assert!(buf.push_state(2_000, vec![2.0]).is_empty());
+        let out = push_f(&mut buf, "cam1", 100_000);
+        assert_eq!(out.drops.len(), 1);
+    }
+
+    /// Below-horizon case: buffer holds only frames too old to match, newest
+    /// is still below `state_ts + range` (future frames could match under
+    /// strict). Under reuse, the state emits with the stale frame right
+    /// away instead of waiting — matches the rest of the reuse policy.
+    #[test]
+    fn reuse_below_horizon_emits_with_last_frame() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        // First emission sets last_emitted = f@0.
+        let _ = push_f(&mut buf, "cam1", 0);
+        let out = buf.push_state(10, vec![0.0]);
+        assert_eq!(out.observations.len(), 1);
+
+        // Buffer holds f@200 (too old for state@5_000 under range=500) but
+        // newest_ts (200) < state_ts + range (5_500) — strict would wait.
+        // Reuse emits immediately with f@0, leaving f@200 in the buffer.
+        let _ = push_f(&mut buf, "cam1", 200);
+        let out = buf.push_state(5_000, vec![1.0]);
+        assert_eq!(out.drops.len(), 0);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam1"].timestamp_us, 0);
+        // f@200 untouched — still in buffer for whoever can use it.
+        assert_eq!(buf.video_buffers[0].len(), 1);
+        assert_eq!(buf.video_buffers[0][0].timestamp_us, 200);
+    }
+
+    /// `stale_observations_emitted` counts only observations that used a
+    /// reused frame. Fresh emissions leave the counter alone.
+    #[test]
+    fn reuse_stale_metric_counts_only_stale_emissions() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let metrics = Arc::new(MetricsRegistry::new(&tracks));
+        let schema: Vec<FieldSpec> =
+            fields.into_iter().map(|n| FieldSpec::new(n, DType::F64)).collect();
+        let mut buf = SyncBuffer::new(&tracks, schema, reuse_config(), metrics.clone());
+
+        // Fresh emission #1.
+        let _ = buf.push_frame("cam1", Arc::new(VideoFrameData {
+            width: 2, height: 2, data: Arc::from(vec![0u8; 6]), timestamp_us: 1_000,
+        }));
+        let _ = buf.push_state(1_050, vec![1.0]);
+
+        // Fresh emission #2.
+        let _ = buf.push_frame("cam1", Arc::new(VideoFrameData {
+            width: 2, height: 2, data: Arc::from(vec![0u8; 6]), timestamp_us: 2_000,
+        }));
+        let _ = buf.push_state(2_050, vec![2.0]);
+
+        let snap = metrics.snapshot(HashMap::new(), 0);
+        assert_eq!(snap.sync.observations_emitted, 2);
+        assert_eq!(snap.sync.stale_observations_emitted, 0);
+
+        // Stale emission: no new frame, state reuses f@2_000.
+        let _ = buf.push_state(3_000, vec![3.0]);
+        let snap = metrics.snapshot(HashMap::new(), 0);
+        assert_eq!(snap.sync.observations_emitted, 3);
+        assert_eq!(snap.sync.stale_observations_emitted, 1);
+    }
+
+    /// Under reuse, once every track has emitted at least once, any
+    /// push_state emits immediately (fresh match or stale reuse) — states
+    /// never linger in the buffer for the eviction-escape hatch to save.
+    /// Verified here: a long run of pushes with one track fully frozen
+    /// produces an observation per state and zero drops, and the state
+    /// buffer stays empty.
+    #[test]
+    fn reuse_steady_state_keeps_state_buffer_empty() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        // First emission on both tracks.
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let _ = push_f(&mut buf, "cam2", 1_000);
+        let out = buf.push_state(1_050, vec![0.0]);
+        assert_eq!(out.observations.len(), 1);
+
+        // cam1 freezes; cam2 keeps delivering. Each state must emit with a
+        // fresh cam2 frame and a stale cam1 frame, leaving the state buffer
+        // empty after every push.
+        let mut emitted = 0;
+        for i in 1..10u64 {
+            let ts = 1_000 + i * 1_000;
+            let _ = push_f(&mut buf, "cam2", ts);
+            let out = buf.push_state(ts + 50, vec![i as f64]);
+            emitted += out.observations.len();
+            assert_eq!(out.drops.len(), 0);
+            assert_eq!(buf.state_fill(), 0, "state buffer should not accumulate under reuse");
+        }
+        assert_eq!(emitted, 9);
+    }
+
+    /// Default config (reuse off) preserves strict drop-on-horizon behavior
+    /// even when a last-emitted frame exists.
+    #[test]
+    fn reuse_off_by_default_preserves_strict_drop() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let config = SyncConfig {
+            video_buffer_size: 5,
+            state_buffer_size: 5,
+            search_range_us: 500,
+            // reuse_stale_frames default: false
+            ..Default::default()
+        };
+        let mut buf = mk(&tracks, fields, config);
+
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let _ = buf.push_state(1_050, vec![1.0]);
+
+        // Past-horizon frame must drop the state under strict policy.
+        let _ = push_f(&mut buf, "cam1", 2_000);
+        let out = buf.push_state(100, vec![2.0]);
+        assert_eq!(out.observations.len(), 0);
+        assert_eq!(out.drops.len(), 1);
     }
 
     /// Sanity: inputs that stress the binary/cursor path with many empty and

--- a/livekit-portal/src/types.rs
+++ b/livekit-portal/src/types.rs
@@ -160,6 +160,13 @@ pub struct SyncConfig {
     pub video_buffer_size: u32,
     pub state_buffer_size: u32,
     pub search_range_us: u64,
+    /// When true, a state whose video match window has elapsed reuses the
+    /// most recently emitted frame on that track instead of being dropped.
+    /// Video effectively "freezes" during frame loss while state keeps
+    /// flowing — every state becomes an observation once every track has
+    /// emitted at least once. Default is `false`, preserving the strict
+    /// drop-on-horizon behavior.
+    pub reuse_stale_frames: bool,
 }
 
 impl Default for SyncConfig {
@@ -168,6 +175,7 @@ impl Default for SyncConfig {
             video_buffer_size: 5,    // ~83ms at 60fps
             state_buffer_size: 5,    // ~83ms at 60fps
             search_range_us: 10_000, // 10ms — half a frame interval at 60fps
+            reuse_stale_frames: false,
         }
     }
 }

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -39,6 +39,7 @@ class LiveKitRobotConfig(RobotConfig):
     tolerance: float | None = None
     state_reliable: bool = True
     action_reliable: bool = True
+    reuse_stale_frames: bool = False
 
 
 class LiveKitRobot(Robot):
@@ -145,6 +146,7 @@ class LiveKitRobot(Robot):
             self._portal_cfg.set_tolerance(self.config.tolerance)
         self._portal_cfg.set_state_reliable(self.config.state_reliable)
         self._portal_cfg.set_action_reliable(self.config.action_reliable)
+        self._portal_cfg.set_reuse_stale_frames(self.config.reuse_stale_frames)
 
         self._portal = Portal(self._portal_cfg)
         self._run(self._portal.connect(self.config.url, self.config.token))

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
@@ -40,6 +40,7 @@ class LiveKitTeleoperatorConfig(TeleoperatorConfig):
     tolerance: float | None = None
     state_reliable: bool = True
     action_reliable: bool = True
+    reuse_stale_frames: bool = False
 
 
 def _split_observation_features(
@@ -160,6 +161,7 @@ class LiveKitTeleoperator(Teleoperator):
             self._portal_cfg.set_tolerance(self.config.tolerance)
         self._portal_cfg.set_state_reliable(self.config.state_reliable)
         self._portal_cfg.set_action_reliable(self.config.action_reliable)
+        self._portal_cfg.set_reuse_stale_frames(self.config.reuse_stale_frames)
 
         self._portal = Portal(self._portal_cfg)
         self._run(self._portal.connect(self.config.url, self.config.token))

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -522,6 +522,19 @@ class PortalConfig:
     def set_ping_ms(self, ms: int) -> None:
         self._inner.set_ping_ms(ms)
 
+    def set_reuse_stale_frames(self, enable: bool) -> None:
+        """Reuse the most recent already-emitted frame on a track when the
+        current state has no in-range match. Video "freezes" on the last good
+        frame during loss, but state keeps flowing — every state becomes an
+        observation once every track has emitted at least once.
+
+        Off by default (strict drop-on-horizon). Turn on for data collection
+        or logging where losing state is worse than a transient video freeze.
+        Leave off for real-time control where a stale frame would misalign
+        the perception/action loop.
+        """
+        self._inner.set_reuse_stale_frames(enable)
+
     def close(self) -> None:
         """No-op: UniFFI releases the Rust-side handle when Python GC drops
         the last reference. Kept for backwards compatibility with callers

--- a/spec.md
+++ b/spec.md
@@ -137,9 +137,13 @@ config.set_state_reliable(True)  # default: True. reliable = lossless ordered de
 config.set_action_reliable(True) # default: True. use False for high-frequency inference where latest value matters most
 
 config.set_ping_ms(1000)         # default: 1000. set 0 to disable RTT pinging on this side
+
+config.set_reuse_stale_frames(False)  # default: False. True = freeze video on frame loss instead of dropping the state
 ```
 
 **Tolerance tradeoff**: at `tolerance=0.5`, a state only matches a frame within half a tick — a single lost frame drops the observation (precision over recovery). At the default `tolerance=1.5`, a state can fall back to the adjacent frame (T±1) if its own was lost, preserving the observation at the cost of ±1 tick of misalignment. A fair-share check prevents an earlier state from stealing a frame that a later state in the buffer has a closer claim to. Values `>2.0` allow T±2 fallback (rarely worth it). Pick **tight (≤1.0)** for real-time control where misalignment is unsafe; pick **widened (≥1.5)** for data collection or lossy links where dropping is worse than slight misalignment.
+
+**Reuse stale frames**: default off. When on, a state whose video match window has elapsed reuses the most recent already-emitted frame on that track instead of dropping. Video "freezes" on the last good frame during loss while state keeps flowing. Every state becomes an observation once every track has emitted at least once. Before that, the strict drop-on-horizon rule still applies so the state buffer stays bounded if video never starts. Turn on for data collection or logging where losing a state is worse than a transient video freeze. Leave off for real-time control where a stale frame would misalign the perception/action loop.
 
 ### Metrics
 
@@ -155,6 +159,7 @@ The snapshot is grouped into four sections:
 ```
 metrics.sync
   observations_emitted        # cumulative synced observations delivered
+  stale_observations_emitted  # subset of observations_emitted where any track reused its last frame (reuse_stale_frames only)
   states_dropped              # cumulative: sync-fail drops + state-buffer overflow drops
   match_delta_us_p50/p95      # worst per-track alignment within each observation, rolling window
   last_blocker_track          # sticky: most recent track that stalled sync
@@ -182,9 +187,11 @@ Jitter is the RFC 3550 EWMA on inter-arrival deltas: `J += (|D| − J) / 16`, wh
 
 Percentiles are computed from a bounded ring of 256 recent samples — fast, bounded memory, accurate enough for health monitoring rather than SLO reporting.
 
+**Under `reuse_stale_frames`**: `last_blocker_track` only updates while a track is still waiting for its first frame. Once every track has emitted, reuse replaces the wait, so a later freeze leaves `last_blocker_track` pinned to its last startup value — use `stale_observations_emitted` as the freeze signal instead. `match_delta_us_p95` also becomes unbounded (stale deltas can be seconds long), so alerts keyed on that metric need reshaping.
+
 ### Drop Policy
 
-When the video frame buffer cannot satisfy sync for a state, all states up to and including that state are dropped. When states are dropped, the drop callback fires.
+Under the default strict policy, when the video frame buffer cannot satisfy sync for a state, all states up to and including that state are dropped. When states are dropped, the drop callback fires.
 
 ```python
 inference_portal.on_drop(callback)  # called with the dropped states, fires on both sync failure and buffer overflow
@@ -192,11 +199,13 @@ inference_portal.on_drop(callback)  # called with the dropped states, fires on b
 
 The drop callback is informational — the application decides what to do (e-stop, log degradation, custom recovery). Portal does not impose any safety policy on the robot; the user controls the robot loop and knows best how to react.
 
+With `set_reuse_stale_frames(True)`, sync-fail drops are replaced by stale-frame reuse once a track has emitted at least once. Only two drop sources remain: (1) state-buffer overflow during the pre-first-emission startup window, and (2) a past-horizon frame arriving before any emission has happened for the blocked track.
+
 ### Sync Internals
 
 Once a state and video frames are synced into an observation, all video frames up to that point are removed from the buffer.
 
-If the video frame buffer cannot satisfy sync for a state (no frame from every track within the search range), all states up to and including that state are dropped and the drop callback fires.
+Under the default strict policy, if the video frame buffer cannot satisfy sync for a state (no frame from every track within the search range), all states up to and including that state are dropped and the drop callback fires. Under the reuse policy, the state falls back to that track's most recently emitted frame and the observation fires normally — the video buffer is left untouched so a later state can still consume the fresh frame.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Adds `PortalConfig.set_reuse_stale_frames(bool)` (default **off**). When on, a state with no in-range video match reuses the most recently emitted frame on that track instead of being dropped — video "freezes" on the last good frame during loss, while every state still becomes an observation.
- State-buffer overflow and pre-first-emission drops remain, serving as hard safety nets against a fully halted video pipeline and the startup window.
- New `metrics.sync.stale_observations_emitted` counter surfaces silent video freezes (subset of `observations_emitted` where any track contributed a stale frame).
- Flag is plumbed through the FFI, the Python wrapper, and both lerobot wrappers. Default off preserves strict drop-on-horizon behavior for every existing caller.

### Why

Occasional frame loss is common in real WAN conditions. Under the strict policy, a single frame past the horizon drops the whole observation — for data-collection and logging pipelines, that's lost state. This gives users an opt-in to trade a transient video freeze for full state continuity.

### Behavior summary

| Condition | Strict (default) | `reuse_stale_frames = true` |
|---|---|---|
| Fresh in-range match | emit | emit |
| Past-horizon, track has emitted before | drop | reuse last-emitted frame |
| Below-horizon, track has emitted before | wait | reuse last-emitted frame |
| Empty buffer, track has emitted before | wait | reuse last-emitted frame |
| Any no-match before track's first emission | wait / drop / overflow | unchanged |
| State-buffer overflow (halt safety net) | drop | drop |

### Monitoring notes (documented in `spec.md` and `docs/tuning.md`)

Under reuse:
- `last_blocker_track` only updates during pre-first-emission; it won't point at a silently frozen track after startup.
- `match_delta_us_p95` becomes unbounded (stale deltas can be arbitrarily large); alerts keyed on it need reshaping.
- Use `stale_observations_emitted` as the freeze signal instead.

## Test plan

- [x] `cargo test -p livekit-portal --lib` — **52/52 pass** (23 pre-existing + 29 sync_buffer tests, including 11 new reuse tests)
- [x] `cargo build -p livekit-portal -p livekit-portal-ffi` — clean
- [x] Default-off: pre-existing tests unchanged
- [x] Unit coverage for reuse: empty-buffer / below-horizon / past-horizon reuse; startup drops preserved; fresh matches win; `clear()` resets; stale-only metric; steady-state no pile-up
- [ ] End-to-end Python integration test with a live Portal session — flag plumbing is trivial (bool through to `SyncConfig`), so not blocking, but worth exercising before a release