### PR TITLE
Move FFI Python build script to repo-root scripts/

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Today you build from source. The flow is one clone, one build, one sync.
 
 ```bash
 git clone https://github.com/livekit/livekit-portal.git
-cd livekit-portal/python/packages/livekit-portal
+cd livekit-portal
 
-uv sync                                    # install Python deps into .venv
-bash scripts/build_native.sh release       # compile cdylib + generate UniFFI bindings
+bash scripts/build_ffi_python.sh release   # compile cdylib + generate UniFFI bindings
+cd python/packages/livekit-portal && uv sync   # install Python deps into .venv
 ```
 
-`build_native.sh` calls `cargo build -p livekit-portal-ffi`, drops the
+`build_ffi_python.sh` calls `cargo build -p livekit-portal-ffi`, drops the
 resulting `liblivekit_portal_ffi.{dylib,so,dll}` next to the Python
 sources, and runs `uniffi-bindgen` to emit the matching Python module. On
 a cold machine this takes a couple of minutes.
@@ -93,7 +93,7 @@ dependencies = ["livekit-portal"]
 livekit-portal = { path = "/absolute/path/to/livekit-portal/python/packages/livekit-portal", editable = true }
 ```
 
-Rerun `build_native.sh` whenever the Rust code changes. The editable
+Rerun `build_ffi_python.sh` whenever the Rust code changes. The editable
 install picks up the refreshed cdylib on the next import. Prebuilt
 wheels are on the roadmap.
 

--- a/docs/lerobot.md
+++ b/docs/lerobot.md
@@ -12,12 +12,11 @@ Both plugins do Portal sync for you: timestamp-matched observations, reliable st
 The packages live in this repo's `python/` uv workspace. For a consumer repo, depend on them directly; for local development:
 
 ```bash
-cd python
-uv sync                                                  # resolves everything
-./packages/livekit-portal/scripts/build_native.sh release
+bash scripts/build_ffi_python.sh release                 # build the cdylib
+cd python && uv sync                                     # resolves everything
 ```
 
-`build_native.sh` compiles the Rust FFI crate and drops the cdylib into `packages/livekit-portal/livekit/portal/`, where `ctypes` loads it at import time. Skip it only if you've set `LIVEKIT_PORTAL_FFI_LIB` to a prebuilt binary.
+`build_ffi_python.sh` compiles the Rust FFI crate and drops the cdylib into `python/packages/livekit-portal/livekit/portal/`, where `ctypes` loads it at import time. Skip it only if you've set `LIVEKIT_PORTAL_FFI_LIB` to a prebuilt binary.
 
 Standalone install (once published):
 
@@ -213,7 +212,7 @@ The loop also handles Portal's callback dispatch, so if you ever want to registe
 
 | Symptom | Likely cause |
 |---|---|
-| `ffi not initialized` | cdylib didn't load. Rerun `build_native.sh` or set `LIVEKIT_PORTAL_FFI_LIB`. |
+| `ffi not initialized` | cdylib didn't load. Rerun `build_ffi_python.sh` or set `LIVEKIT_PORTAL_FFI_LIB`. |
 | `LiveKit*Config.url and .token are required` | Token mint returned empty string, or you forgot to set them in the config. |
 | Observations always empty | First sync hasn't happened yet. Confirm both sides joined the same room, camera names match, and `fps` is identical. |
 | High `states_dropped` | Encoder is throttling or a camera stopped publishing. Compare `portal.metrics().transport.frames_received` (operator) with `frames_sent` (robot). |

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -13,10 +13,10 @@ Portal is not on PyPI yet. You build from source. See the
 
 ```bash
 git clone https://github.com/livekit/livekit-portal.git
-cd livekit-portal/python/packages/livekit-portal
+cd livekit-portal
 
-uv sync
-bash scripts/build_native.sh release       # or `debug` for faster iteration
+bash scripts/build_ffi_python.sh release   # or `debug` for faster iteration
+cd python/packages/livekit-portal && uv sync
 ```
 
 If the cdylib lives elsewhere (e.g. during Rust-side dev), point

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,13 +24,13 @@ build from source.
 
 ```bash
 git clone https://github.com/livekit/livekit-portal.git
-cd livekit-portal/python/packages/livekit-portal
+cd livekit-portal
 
-uv sync                                    # install Python deps into .venv
-bash scripts/build_native.sh release       # compile cdylib + generate UniFFI bindings
+bash scripts/build_ffi_python.sh release   # compile cdylib + generate UniFFI bindings
+cd python/packages/livekit-portal && uv sync   # install Python deps into .venv
 ```
 
-`build_native.sh` runs `cargo build -p livekit-portal-ffi`, drops the
+`build_ffi_python.sh` runs `cargo build -p livekit-portal-ffi`, drops the
 platform cdylib (`liblivekit_portal_ffi.{dylib,so,dll}`) next to the
 Python package, and emits the matching UniFFI Python module. First build
 takes a couple of minutes. Subsequent builds are incremental.
@@ -60,9 +60,9 @@ dependencies = ["livekit-portal"]
 livekit-portal = { path = "/absolute/path/to/livekit-portal/python/packages/livekit-portal", editable = true }
 ```
 
-Rerun `bash scripts/build_native.sh release` (in the Portal repo) whenever
-the Rust code changes. The editable install picks up the new cdylib on
-next import. Prebuilt wheels are on the roadmap.
+Rerun `bash scripts/build_ffi_python.sh release` (in the Portal repo)
+whenever the Rust code changes. The editable install picks up the new
+cdylib on next import. Prebuilt wheels are on the roadmap.
 
 ## 2. Mint tokens
 

--- a/examples/python/so101/README.md
+++ b/examples/python/so101/README.md
@@ -24,7 +24,7 @@ They connect to the **same LiveKit room** and sync via Portal.
   own USB-serial controller
 - One OpenCV-compatible camera on the robot side
 - The Portal native library built once at the repo root:
-  `cd python/packages/livekit-portal && bash scripts/build_native.sh`
+  `bash scripts/build_ffi_python.sh`
 
 ---
 
@@ -174,7 +174,7 @@ macOS, the first time you run it the OS may prompt for camera permission —
 accept and rerun.
 
 **`ImportError: cannot find liblivekit_portal_ffi`** — build the native
-library: `cd ../../packages/livekit-portal && bash scripts/build_native.sh`.
+library: `cd ../../.. && bash scripts/build_ffi_python.sh`.
 
 ---
 

--- a/python/packages/livekit-portal/pyproject.toml
+++ b/python/packages/livekit-portal/pyproject.toml
@@ -23,8 +23,9 @@ examples = [
 ]
 
 # The Rust cdylib and generated UniFFI module are built out-of-band via
-# `scripts/build_native.sh` and dropped into `livekit/portal/`. Both must
-# live next to each other for UniFFI's runtime CDLL lookup to resolve.
+# the repo-root `scripts/build_ffi_python.sh` and dropped into
+# `livekit/portal/`. Both must live next to each other for UniFFI's
+# runtime CDLL lookup to resolve.
 
 # PEP 420 implicit namespace package: `livekit` has no __init__.py so it can
 # coexist with livekit-api (`livekit.api`), livekit-protocol (`livekit.protocol`),

--- a/scripts/build_ffi_python.sh
+++ b/scripts/build_ffi_python.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 # Build the livekit-portal-ffi cdylib and regenerate the UniFFI Python
 # bindings. The cdylib and generated module both land next to the package
-# source (livekit/portal/) so the wheel ships them together.
+# source (python/packages/livekit-portal/livekit/portal/) so the wheel
+# ships them together.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-# scripts/ lives at packages/livekit-portal/scripts/ under the python workspace,
-# so repo root is four levels up from here.
-REPO_ROOT="$(cd "$HERE/../../../.." && pwd)"
-PKG_DIR="$HERE/../livekit/portal"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+PKG_DIR="$REPO_ROOT/python/packages/livekit-portal/livekit/portal"
 
 MODE="${1:-release}"
 if [[ "$MODE" != "release" && "$MODE" != "debug" ]]; then


### PR DESCRIPTION
## Summary
- Moved `python/packages/livekit-portal/scripts/build_native.sh` to `scripts/build_ffi_python.sh` at the repo root. The Rust cdylib serves the whole repo, not just the Python package, so a top-level location fits better. Renamed to name what it produces.
- Script resolves paths relative to the repo root so it runs from any cwd.
- Updated README, `docs/quickstart.md`, `docs/portal-api.md`, `docs/lerobot.md`, `examples/python/so101/README.md`, and the package `pyproject.toml` comment to reference the new path.

## Test plan
- [x] `bash scripts/build_ffi_python.sh debug` runs end-to-end, copies the cdylib into `python/packages/livekit-portal/livekit/portal/`, and writes `livekit_portal_ffi.py` next to it
- [x] `grep -r build_native` across tracked files is empty