### PR TITLE
Pin uniffi to git rev with Python buffer perf fix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,51 @@
+name: Python tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: python-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest on ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Rust is needed to build the livekit-portal-ffi cdylib and regenerate
+      # the UniFFI-generated Python module (both live next to the package
+      # source; the wheel ships them together).
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # uniffi is pinned to a git rev, so cache by the ffi crate's
+          # Cargo.toml + the lockfile rather than the default workspace-wide
+          # key. Avoids a full rebuild when unrelated Rust files change.
+          workspaces: ". -> target"
+          key: ffi-${{ hashFiles('Cargo.lock', 'livekit-portal-ffi/Cargo.toml') }}
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build FFI cdylib and generate Python bindings
+        run: bash scripts/build_ffi_python.sh release
+
+      - name: Install workspace (livekit-portal + dev deps)
+        working-directory: python
+        run: uv sync --group dev
+
+      - name: Run pytest
+        working-directory: python
+        run: uv run pytest packages/livekit-portal/tests -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Python tests
+name: tests
 
 on:
   push:
@@ -7,12 +7,28 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: python-tests-${{ github.ref }}
+  group: tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: pytest on ubuntu
+  rust:
+    name: cargo test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Separate cache key from the python job so a failure on one
+          # side doesn't poison the other's incremental artifacts.
+          key: rust-tests
+      - name: cargo test --workspace
+        run: cargo test --workspace --locked
+
+  python:
+    name: pytest
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -29,7 +45,6 @@ jobs:
           # uniffi is pinned to a git rev, so cache by the ffi crate's
           # Cargo.toml + the lockfile rather than the default workspace-wide
           # key. Avoids a full rebuild when unrelated Rust files change.
-          workspaces: ". -> target"
           key: ffi-${{ hashFiles('Cargo.lock', 'livekit-portal-ffi/Cargo.toml') }}
 
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,25 @@ concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
 
+# Everything linked into the livekit Rust SDK's WebRTC pipeline needs these on
+# Ubuntu — `glib-sys` surfaces first via pkg-config (`glib-2.0.pc`), the rest
+# come from the media/capture transitive deps. Matches livekit/rust-sdks' own
+# CI recipe, minus the desktop-capture and NVIDIA bits we don't compile.
+env:
+  LINUX_SYSTEM_DEPS: >-
+    libssl-dev
+    libglib2.0-dev
+    libx11-dev
+    libxext-dev
+    libxfixes-dev
+    libxdamage-dev
+    libxrandr-dev
+    libxcomposite-dev
+    libgl1-mesa-dev
+    libgbm-dev
+    libdrm-dev
+    libva-dev
+
 jobs:
   rust:
     name: cargo test
@@ -18,12 +37,26 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y $LINUX_SYSTEM_DEPS
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "25.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: dtolnay/rust-toolchain@stable
+
       - uses: Swatinem/rust-cache@v2
         with:
           # Separate cache key from the python job so a failure on one
           # side doesn't poison the other's incremental artifacts.
           key: rust-tests
+
       - name: cargo test --workspace
         run: cargo test --workspace --locked
 
@@ -34,6 +67,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y $LINUX_SYSTEM_DEPS
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "25.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Rust is needed to build the livekit-portal-ffi cdylib and regenerate
       # the UniFFI-generated Python module (both live next to the package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,11 +51,11 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "9b8246bcbf8eb97abef10c2d92166449680d41d55c0fc6978a91dec2e3619608"
 dependencies = [
- "askama_derive",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "2f9670bc84a28bb3da91821ef74226949ab63f1265aff7c751634f1dd0e6f97c"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -80,15 +80,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "f0756b45480437dded0565dfc568af62ccce146fb6cfe902e808ba86e445f44f"
 dependencies = [
- "memchr",
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0af3691ba3af77949c0b5a3925444b85cb58a0184cc7fec16c68ba2e7be868"
+dependencies = [
+ "rustc-hash",
  "serde",
  "serde_derive",
- "winnow 0.7.15",
+ "unicode-ident",
+ "winnow",
 ]
 
 [[package]]
@@ -263,18 +273,19 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -902,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
@@ -3194,7 +3205,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "version-compare",
 ]
 
@@ -3408,21 +3419,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -3430,19 +3426,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -3461,9 +3448,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -3472,7 +3459,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -3597,8 +3584,8 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "anyhow",
  "camino",
@@ -3612,8 +3599,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "anyhow",
  "askama",
@@ -3628,7 +3615,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -3637,8 +3624,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3649,8 +3636,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3661,8 +3648,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "camino",
  "fs-err",
@@ -3671,14 +3658,14 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -3688,8 +3675,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -3700,8 +3687,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+version = "0.31.1"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -3934,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=bd74c376547cff78e1364dd678ddb277927c14a8#bd74c376547cff78e1364dd678ddb277927c14a8"
 dependencies = [
  "nom",
 ]
@@ -4259,15 +4246,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "askama"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
  "itoa",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "askama_parser"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
  "serde",
@@ -3065,9 +3065,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -3408,11 +3408,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3424,10 +3430,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3446,7 +3461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.2",
 ]
@@ -3582,9 +3597,8 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "anyhow",
  "camino",
@@ -3598,9 +3612,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "anyhow",
  "askama",
@@ -3615,7 +3628,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.5.11",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -3624,9 +3637,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3637,9 +3649,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3650,9 +3661,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "camino",
  "fs-err",
@@ -3661,15 +3671,14 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml 0.5.11",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -3679,9 +3688,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -3692,9 +3700,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -3927,8 +3934,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=86a8c0041fc58bb43075dfde349a731d11711188#86a8c0041fc58bb43075dfde349a731d11711188"
 dependencies = [
  "nom",
 ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <h1 align="center">livekit-portal</h1>
 
 <p align="center">
+  <a href="https://github.com/livekit/livekit-portal/actions/workflows/python-tests.yml"><img src="https://github.com/livekit/livekit-portal/actions/workflows/python-tests.yml/badge.svg?branch=main" alt="Python tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-stable-orange" alt="Rust"></a>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">livekit-portal</h1>
 
 <p align="center">
-  <a href="https://github.com/livekit/livekit-portal/actions/workflows/python-tests.yml"><img src="https://github.com/livekit/livekit-portal/actions/workflows/python-tests.yml/badge.svg?branch=main" alt="Python tests"></a>
+  <a href="https://github.com/livekit/livekit-portal/actions/workflows/tests.yml"><img src="https://github.com/livekit/livekit-portal/actions/workflows/tests.yml/badge.svg?branch=main" alt="tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-stable-orange" alt="Rust"></a>

--- a/livekit-portal-ffi/Cargo.toml
+++ b/livekit-portal-ffi/Cargo.toml
@@ -15,13 +15,19 @@ path = "uniffi-bindgen.rs"
 
 [dependencies]
 livekit-portal = { path = "../livekit-portal" }
-# Pinned to main past PR #2824 ("Performance improvement by fixing python
-# loop over bytes"): the Python generator emits per-byte loops for
-# `_UniffiRustBufferBuilder.write` / `_pack_into`, which stalls the GIL
-# for tens of milliseconds per video frame. Fix is merged but not yet in
-# a crates.io release (latest published is 0.31.1, branched before the
-# fix). Drop this back to a version req once a release ships with it.
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "86a8c0041fc58bb43075dfde349a731d11711188", features = ["cli", "tokio"] }
+# Pinned to main past two fixes neither of which is in a crates.io
+# release yet (latest 0.31.1 branched before both):
+#   - PR #2824 (2026-02-23): `_UniffiRustBufferBuilder.write` / `_pack_into`
+#     switch from a per-byte Python loop to `ctypes.memmove`, recovering
+#     tens of ms of GIL time per video frame.
+#   - baf24e77b5 (2026-03-19): `Box<T>::visit_children` now visits the
+#     inner `T` instead of skipping to its grandchildren. Without this,
+#     the pipeline's `namespace.visit::<Type>` never reaches the inner
+#     types of `Map`/`Sequence`/`Optional`, so `_UniffiFfiConverterFloat64`
+#     is referenced but never emitted when f64 only appears inside a
+#     `HashMap<String, f64>` (which is our state/action wire format).
+# Drop this back to a version req once a release ships with both.
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "bd74c376547cff78e1364dd678ddb277927c14a8", features = ["cli", "tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 thiserror = "2"
 parking_lot = "0.12"

--- a/livekit-portal-ffi/Cargo.toml
+++ b/livekit-portal-ffi/Cargo.toml
@@ -15,7 +15,13 @@ path = "uniffi-bindgen.rs"
 
 [dependencies]
 livekit-portal = { path = "../livekit-portal" }
-uniffi = { version = "0.29", features = ["cli", "tokio"] }
+# Pinned to main past PR #2824 ("Performance improvement by fixing python
+# loop over bytes"): the Python generator emits per-byte loops for
+# `_UniffiRustBufferBuilder.write` / `_pack_into`, which stalls the GIL
+# for tens of milliseconds per video frame. Fix is merged but not yet in
+# a crates.io release (latest published is 0.31.1, branched before the
+# fix). Drop this back to a version req once a release ships with it.
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "86a8c0041fc58bb43075dfde349a731d11711188", features = ["cli", "tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 thiserror = "2"
 parking_lot = "0.12"

--- a/python/packages/livekit-portal/tests/test_roundtrip.py
+++ b/python/packages/livekit-portal/tests/test_roundtrip.py
@@ -1,0 +1,164 @@
+"""Random values survive the send-receive round trip for every dtype.
+
+What this covers, and what it can't:
+
+* **Send side** (`test_send_reaches_ffi_for_every_dtype`) actually crosses
+  the FFI with a payload that uses every declared dtype. If the uniffi
+  generator forgets a primitive converter (the `_UniffiFfiConverterFloat64`
+  regression we hit at pin 86a8c0041f), `send_action` raises `NameError`
+  here instead of the `PortalError.WrongRole` it should get from the
+  role check further down the stack.
+
+* **Receive side** (`test_random_values_roundtrip_through_wrapper`) runs
+  per-dtype with random in-range inputs and simulates what the core
+  delivers: narrow to the dtype, widen back to f64 via
+  `TypedValue::as_f64`, hand that to the Python wrapper, and assert the
+  wrapper reconstructs the original value. We can't reach a real peer
+  in-process, so this stops at the FFI receive boundary; anything below
+  it is covered by the core crate's Rust tests.
+"""
+from __future__ import annotations
+
+import random
+import struct
+from typing import Any, List, Tuple
+
+import pytest
+
+from livekit.portal import (
+    DType,
+    FieldSpec,
+    Portal,
+    PortalConfig,
+    PortalError,
+    Role,
+    _wrap_action,
+)
+from livekit.portal import livekit_portal_ffi as _ffi
+
+
+# Every dtype the wire format supports. Kept as a flat list so a single
+# parametrize sweeps them all.
+_ALL_DTYPES: List[DType] = [
+    DType.F64,
+    DType.F32,
+    DType.I32,
+    DType.I16,
+    DType.I8,
+    DType.U32,
+    DType.U16,
+    DType.U8,
+    DType.BOOL,
+]
+
+# (min, max) inclusive for each integer dtype, used for random sampling.
+_INT_RANGES = {
+    DType.I32: (-(2**31), 2**31 - 1),
+    DType.I16: (-(2**15), 2**15 - 1),
+    DType.I8: (-(2**7), 2**7 - 1),
+    DType.U32: (0, 2**32 - 1),
+    DType.U16: (0, 2**16 - 1),
+    DType.U8: (0, 2**8 - 1),
+}
+
+
+def _f32_round(x: float) -> float:
+    """Narrow an f64 to f32 and widen back — same as the core's
+    `value as f32 as f64`. IEEE 754 pack/unpack is the canonical way."""
+    return struct.unpack("<f", struct.pack("<f", x))[0]
+
+
+def _random_value(dtype: DType, rng: random.Random) -> Any:
+    if dtype == DType.BOOL:
+        return rng.choice([True, False])
+    if dtype == DType.F64:
+        return rng.uniform(-1e9, 1e9)
+    if dtype == DType.F32:
+        # Sampled in f64 but will be narrowed downstream — we compare
+        # against the f32-rounded expectation, so any value works.
+        return rng.uniform(-1e6, 1e6)
+    lo, hi = _INT_RANGES[dtype]
+    return rng.randint(lo, hi)
+
+
+def _simulate_delivered_f64(dtype: DType, value: Any) -> float:
+    """What the core puts in the delivered `Dict[str, float]` after the
+    dtype round trip (`TypedValue::as_f64`)."""
+    if dtype == DType.BOOL:
+        return 1.0 if value else 0.0
+    if dtype == DType.F32:
+        return _f32_round(value)
+    return float(value)
+
+
+def _expected_typed(dtype: DType, value: Any) -> Any:
+    """What the wrapper's `_cast_values` should return for that delivery."""
+    if dtype == DType.BOOL:
+        return bool(value)
+    if dtype == DType.F32:
+        return _f32_round(value)
+    if dtype == DType.F64:
+        return float(value)
+    return int(value)
+
+
+# --- send: every dtype crosses the FFI without a NameError ----------------
+
+
+def _all_dtypes_portal(role: Role) -> Tuple[Portal, List[FieldSpec]]:
+    schema = [
+        FieldSpec(name=f"v_{d.name.lower()}", dtype=d) for d in _ALL_DTYPES
+    ]
+    cfg = PortalConfig("roundtrip", role)
+    cfg.add_state_typed(list(schema))
+    cfg.add_action_typed(list(schema))
+    return Portal(cfg), schema
+
+
+def _sample_payload(schema: List[FieldSpec], seed: int):
+    rng = random.Random(seed)
+    return {f.name: _random_value(f.dtype, rng) for f in schema}
+
+
+def test_send_reaches_ffi_for_every_dtype():
+    portal, schema = _all_dtypes_portal(Role.OPERATOR)
+    payload = _sample_payload(schema, seed=0xA11D7)
+    try:
+        portal.send_action(payload)
+    except PortalError.DtypeMismatch as e:
+        pytest.fail(f"random in-range payload rejected by validator: {e}")
+    except PortalError:
+        # WrongRole (portal isn't connected to a peer). Confirms the FFI
+        # boundary was crossed cleanly — every map/primitive converter
+        # the payload touches exists.
+        pass
+
+
+# --- receive: wrapper reconstructs random values per dtype -----------------
+
+
+@pytest.mark.parametrize("dtype", _ALL_DTYPES, ids=lambda d: d.name)
+def test_random_values_roundtrip_through_wrapper(dtype):
+    # Fresh rng per dtype keeps one failure's diagnostics independent of
+    # the others while still being fully deterministic.
+    rng = random.Random(0xC0FFEE ^ hash(dtype.name))
+    schema = [FieldSpec(name="v", dtype=dtype)]
+
+    for _ in range(128):
+        value = _random_value(dtype, rng)
+        delivered = _simulate_delivered_f64(dtype, value)
+        expected = _expected_typed(dtype, value)
+
+        ffi_action = _ffi.Action(values={"v": delivered}, timestamp_us=0)
+        got = _wrap_action(ffi_action, schema).values["v"]
+
+        assert got == expected, (
+            f"{dtype.name}: input={value!r} delivered={delivered!r} "
+            f"wrapped={got!r} expected={expected!r}"
+        )
+        # bool / int / float are all truthy-equal to each other; the type
+        # check is what keeps a BOOL from smuggling through an int field.
+        assert type(got) is type(expected), (
+            f"{dtype.name}: wrapped type {type(got).__name__} "
+            f"!= expected {type(expected).__name__}"
+        )


### PR DESCRIPTION
## Summary

- Switches the `uniffi` dep in `livekit-portal-ffi` from crates.io `0.29` to a git source pinned at `mozilla/uniffi-rs@86a8c004` — the commit that merges [uniffi-rs#2824](https://github.com/mozilla/uniffi-rs/pull/2824) ("Performance improvement by fixing python loop over bytes"). Resolves to uniffi 0.31.0.
- The upstream generator previously emitted per-byte Python loops for `_UniffiRustBufferBuilder.write` and `_pack_into`. For a 480x640x3 video frame that is 921,600 Python bytecode iterations per `send_video_frame`, holding the GIL long enough to starve motor-bus workers and surface as `[TxRxResult] There is no status packet!` on blocking `serial.read()`.
- The fix replaces both loops with a single `ctypes.memmove`. Merged upstream on 2026-02-23 but not in a crates.io release yet — latest 0.31.1 was branched off `main` before PR #2824 landed, so a git rev is the only way to pick it up.
- Verified the regenerated `livekit_portal_ffi.py` contains `ctypes.memmove` in both `write` and `_pack_into`. Drop this pin back to a version req once a release ships with the fix.

### Breaking-change audit for the 0.29 → 0.31 jump

- v0.30: UDL-based trait interfaces require `#[uniffi::trait_interface]`. Not applicable — this crate is proc-macro only (no `.udl`).
- v0.30: Python trait-interface impls must inherit from the trait base class. Already the case for `_Dispatcher(_ffi.PortalCallbacks)` and `_RpcHandlerAdapter(_ffi.RpcHandler)`.
- v0.31: `uniffi-bindgen --lib-file` removed. `scripts/build_ffi_python.sh` already uses `--library`.

`cargo check -p livekit-portal-ffi` and the full `bash scripts/build_ffi_python.sh debug` (cdylib + bindgen) pass clean.

## Test plan

- [ ] `cargo build -p livekit-portal-ffi --release`
- [ ] `bash scripts/build_ffi_python.sh release`
- [ ] Confirm `grep memmove python/packages/livekit-portal/livekit/portal/livekit_portal_ffi.py` shows the fix in `write` and `_pack_into`
- [ ] Smoke-run an operator + robot example, watch for motor-bus timeouts while video is flowing