### PR TITLE
Add PyPI publish workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,163 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# One publish run at a time. A second tag push waits; it does not cancel the
+# in-flight run because cancelling a half-uploaded publish is worse than
+# letting it finish.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+# System libraries required to link the livekit-portal Rust cdylib on Linux.
+# Mirrors the list in tests.yml so the two stay in sync.
+env:
+  LINUX_SYSTEM_DEPS: >-
+    libssl-dev
+    libglib2.0-dev
+    libx11-dev
+    libxext-dev
+    libxfixes-dev
+    libxdamage-dev
+    libxrandr-dev
+    libxcomposite-dev
+    libgl1-mesa-dev
+    libgbm-dev
+    libdrm-dev
+    libva-dev
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build — native wheels (per platform) + pure Python wheels/sdists.
+  #
+  # fetch-depth: 0 is required on every build job: hatch-vcs walks the full
+  # git history to derive the package version from the triggering tag. A
+  # shallow clone produces a dev/fallback version instead of the real one.
+  # ---------------------------------------------------------------------------
+
+  build-native:
+    name: Build native wheel (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04        # Linux x86_64  (glibc 2.35)
+          - ubuntu-24.04-arm    # Linux aarch64 (glibc 2.39)
+          - macos-13            # macOS x86_64  (Intel)
+          - macos-latest        # macOS arm64   (Apple Silicon)
+          - windows-latest      # Windows x86_64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so hatch-vcs resolves the version tag
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y $LINUX_SYSTEM_DEPS
+
+      # protoc is needed to compile proto-based Rust dependencies.
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "25.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: publish-${{ matrix.os }}-${{ hashFiles('Cargo.lock', 'livekit-portal-ffi/Cargo.toml') }}
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # Compile the Rust cdylib and generate the UniFFI Python module.
+      # Both land in livekit/portal/ so hatchling picks them up as wheel
+      # artifacts (see [tool.hatch.build.targets.wheel] in pyproject.toml).
+      - name: Build FFI cdylib and generate Python bindings
+        run: bash scripts/build_ffi_python.sh release
+        shell: bash
+
+      - name: Build livekit-portal wheel
+        working-directory: python
+        run: uv build --package livekit-portal --wheel
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-native-${{ matrix.os }}
+          path: python/dist/*.whl
+
+  build-pure:
+    name: Build pure Python packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so hatch-vcs resolves the version tag
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # uv build replaces the workspace source for livekit-portal with a
+      # plain PyPI dependency in the generated wheel metadata.
+      - name: Build lerobot-robot-livekit
+        working-directory: python
+        run: uv build --package lerobot-robot-livekit
+
+      - name: Build lerobot-teleoperator-livekit
+        working-directory: python
+        run: uv build --package lerobot-teleoperator-livekit
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-pure
+          path: python/dist/
+
+  # ---------------------------------------------------------------------------
+  # Publish — upload every collected artifact to PyPI.
+  #
+  # Uses OIDC trusted publishing: no API key is stored in GitHub secrets.
+  # Configure each package's trusted publisher at pypi.org with:
+  #   Repository: <owner>/livekit-portal
+  #   Workflow:   publish.yml
+  #   Environment: pypi
+  # ---------------------------------------------------------------------------
+  publish:
+    name: Publish to PyPI
+    needs: [build-native, build-pure]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for OIDC trusted publisher
+
+    steps:
+      - name: Download all distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
+      - name: Show collected distributions
+        run: ls -lh dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 # One publish run at a time. A second tag push waits; it does not cancel the
 # in-flight run because cancelling a half-uploaded publish is worse than
 # letting it finish.
+permissions:
+  contents: read
+
 concurrency:
   group: publish
   cancel-in-progress: false

--- a/examples/python/so101/uv.lock
+++ b/examples/python/so101/uv.lock
@@ -356,7 +356,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -615,14 +615,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/c3/e4a9656f3cdb280f5dc65a68cc6fc46e79f897d27c1a36bbb4f0f47aaac5/gitpython-3.1.48.tar.gz", hash = "sha256:b7c49ff4a49946fce38ac84116efa311b15e7dad06dc3787fc9e206bf9ef75e1", size = 217288, upload-time = "2026-04-28T05:35:45.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/94/50/bb9703c364c00e7be67ccda03536f3d684766ce109d184c9d1f072d866ca/gitpython-3.1.48-py3-none-any.whl", hash = "sha256:737698b05889cca0f9aba7054d796620df2092c68926ee1470e5c7f5ac886680", size = 209800, upload-time = "2026-04-28T05:35:42.543Z" },
 ]
 
 [[package]]
@@ -903,19 +903,18 @@ version = "0.1.0"
 source = { editable = "../../../python/packages/livekit-portal" }
 dependencies = [
     { name = "numpy" },
-    { name = "protobuf" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "livekit-api", marker = "extra == 'examples'", specifier = ">=0.7" },
+    { name = "livekit-api", marker = "extra == 'integration'", specifier = ">=0.7" },
     { name = "numpy", specifier = ">=1.24" },
-    { name = "protobuf", specifier = ">=5,<6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", marker = "extra == 'examples'", specifier = ">=1" },
 ]
-provides-extras = ["dev", "examples"]
+provides-extras = ["dev", "examples", "integration"]
 
 [[package]]
 name = "livekit-portal-so101-example"
@@ -1266,7 +1265,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1277,7 +1276,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -1304,9 +1303,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -1317,7 +1316,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -1899,10 +1898,10 @@ name = "pyobjc-framework-applicationservices"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coretext" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-coretext", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/6a/d4e613c8e926a5744fc47a9e9fea08384a510dc4f27d844f7ad7a2d793bd/pyobjc_framework_applicationservices-12.1.tar.gz", hash = "sha256:c06abb74f119bc27aeb41bf1aef8102c0ae1288aec1ac8665ea186a067a8945b", size = 103247, upload-time = "2025-11-14T10:08:52.18Z" }
 wheels = [
@@ -1918,7 +1917,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -1934,9 +1933,9 @@ name = "pyobjc-framework-coretext"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/da/682c9c92a39f713bd3c56e7375fa8f1b10ad558ecb075258ab6f1cdd4a6d/pyobjc_framework_coretext-12.1.tar.gz", hash = "sha256:e0adb717738fae395dc645c9e8a10bb5f6a4277e73cba8fa2a57f3b518e71da5", size = 90124, upload-time = "2025-11-14T10:14:38.596Z" }
 wheels = [
@@ -1952,8 +1951,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [

--- a/python/packages/lerobot-robot-livekit/pyproject.toml
+++ b/python/packages/lerobot-robot-livekit/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.20"]
+requires = ["hatchling>=1.20", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "lerobot-robot-livekit"
-version = "0.1.0"
+dynamic = ["version"]
 description = "LiveKit Portal robot plugin for lerobot (operator-side)"
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
@@ -19,3 +19,7 @@ livekit-portal = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["lerobot_robot_livekit"]
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^v(?P<version>.+)$"

--- a/python/packages/lerobot-teleoperator-livekit/pyproject.toml
+++ b/python/packages/lerobot-teleoperator-livekit/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.20"]
+requires = ["hatchling>=1.20", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "lerobot-teleoperator-livekit"
-version = "0.1.0"
+dynamic = ["version"]
 description = "LiveKit Portal teleoperator plugin for lerobot (robot-side)"
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
@@ -19,3 +19,7 @@ livekit-portal = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["lerobot_teleoperator_livekit"]
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^v(?P<version>.+)$"

--- a/python/packages/livekit-portal/pyproject.toml
+++ b/python/packages/livekit-portal/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.20"]
+requires = ["hatchling>=1.20", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "livekit-portal"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Python bindings for livekit-portal. robot ↔ operator sync over LiveKit"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
@@ -53,3 +53,8 @@ artifacts = [
 
 [tool.hatch.build]
 exclude = ["tests", "examples", ".venv", ".pytest_cache"]
+
+[tool.hatch.version]
+source = "vcs"
+# Strip the leading "v" from the tag (v0.3.0 → 0.3.0).
+tag-pattern = "^v(?P<version>.+)$"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -614,14 +614,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/c3/e4a9656f3cdb280f5dc65a68cc6fc46e79f897d27c1a36bbb4f0f47aaac5/gitpython-3.1.48.tar.gz", hash = "sha256:b7c49ff4a49946fce38ac84116efa311b15e7dad06dc3787fc9e206bf9ef75e1", size = 217288, upload-time = "2026-04-28T05:35:45.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/94/50/bb9703c364c00e7be67ccda03536f3d684766ce109d184c9d1f072d866ca/gitpython-3.1.48-py3-none-any.whl", hash = "sha256:737698b05889cca0f9aba7054d796620df2092c68926ee1470e5c7f5ac886680", size = 209800, upload-time = "2026-04-28T05:35:42.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` triggered on `v*` tag pushes
- Two-stage pipeline: **Build** (native wheels per platform + pure Python wheels/sdists) → **Publish** (OIDC trusted publisher, no stored API key)
- Migrates all three packages from hardcoded `version = "0.1.0"` to `hatch-vcs` so pushing a tag like `v0.3.0` automatically sets the package version

## Setup required before first tag push

1. Create a `pypi` environment in GitHub repo settings (Settings → Environments)
2. Add a trusted publisher at pypi.org for each of the three packages (`livekit-portal`, `lerobot-robot-livekit`, `lerobot-teleoperator-livekit`) with:
   - Repository: `livekit/livekit-portal`
   - Workflow filename: `publish.yml`
   - Environment: `pypi`