### PR TITLE
fix: add search_parent_directories for hatch-vcs in monorepo

### DIFF
--- a/python/packages/lerobot-robot-livekit/pyproject.toml
+++ b/python/packages/lerobot-robot-livekit/pyproject.toml
@@ -23,3 +23,4 @@ packages = ["lerobot_robot_livekit"]
 [tool.hatch.version]
 source = "vcs"
 tag-pattern = "^v(?P<version>.+)$"
+raw-options = { search_parent_directories = true }

--- a/python/packages/lerobot-teleoperator-livekit/pyproject.toml
+++ b/python/packages/lerobot-teleoperator-livekit/pyproject.toml
@@ -23,3 +23,4 @@ packages = ["lerobot_teleoperator_livekit"]
 [tool.hatch.version]
 source = "vcs"
 tag-pattern = "^v(?P<version>.+)$"
+raw-options = { search_parent_directories = true }

--- a/python/packages/livekit-portal/pyproject.toml
+++ b/python/packages/livekit-portal/pyproject.toml
@@ -56,5 +56,5 @@ exclude = ["tests", "examples", ".venv", ".pytest_cache"]
 
 [tool.hatch.version]
 source = "vcs"
-# Strip the leading "v" from the tag (v0.3.0 → 0.3.0).
 tag-pattern = "^v(?P<version>.+)$"
+raw-options = { search_parent_directories = true }


### PR DESCRIPTION
setuptools_scm runs from within each package subdirectory and can't find the .git at the repo root. Adding `search_parent_directories = true` to all three packages fixes the build.