### PR TITLE
ci: drop Windows build target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,6 @@ jobs:
           - ubuntu-24.04-arm    # Linux aarch64 (glibc 2.39)
           - macos-13            # macOS x86_64  (Intel)
           - macos-latest        # macOS arm64   (Apple Silicon)
-          - windows-latest      # Windows x86_64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,6 @@ jobs:
         os:
           - ubuntu-22.04        # Linux x86_64  (glibc 2.35)
           - ubuntu-24.04-arm    # Linux aarch64 (glibc 2.39)
-          - macos-13            # macOS x86_64  (Intel)
           - macos-latest        # macOS arm64   (Apple Silicon)
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 # One publish run at a time. A second tag push waits; it does not cancel the
 # in-flight run because cancelling a half-uploaded publish is worse than

--- a/python/packages/livekit-portal/pyproject.toml
+++ b/python/packages/livekit-portal/pyproject.toml
@@ -47,7 +47,6 @@ packages = ["livekit"]
 artifacts = [
     "livekit/portal/liblivekit_portal_ffi.dylib",
     "livekit/portal/liblivekit_portal_ffi.so",
-    "livekit/portal/livekit_portal_ffi.dll",
     "livekit/portal/livekit_portal_ffi.py",
 ]
 


### PR DESCRIPTION
Removes Windows from the publish matrix and the `.dll` artifact from pyproject.toml.