### PR TITLE
fix: force platform wheel tag for livekit-portal native wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,17 +149,32 @@ jobs:
       id-token: write  # required for OIDC trusted publisher
 
     steps:
-      - name: Download all distribution artifacts
+      - name: Download livekit-portal artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: dist-*
-          path: dist
+          pattern: dist-native-*
+          path: dist/livekit-portal
           merge-multiple: true
 
-      - name: Show collected distributions
-        run: ls -lh dist/
+      - name: Download lerobot artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-pure
+          path: dist/lerobot
 
-      - name: Publish to PyPI
+      - name: Show collected distributions
+        run: ls -lhR dist/
+
+      # Published separately so a missing pending publisher on one package
+      # does not block the others. skip-existing makes re-runs safe.
+      - name: Publish livekit-portal
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: dist/
+          packages-dir: dist/livekit-portal/
+          skip-existing: true
+
+      - name: Publish lerobot packages
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/lerobot/
+          skip-existing: true

--- a/python/packages/livekit-portal/hatch_build.py
+++ b/python/packages/livekit-portal/hatch_build.py
@@ -1,0 +1,13 @@
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version, build_data):
+        if self.target_name == "wheel":
+            # The wheel contains a platform-specific cdylib loaded via ctypes.
+            # Hatchling does not detect ctypes libraries as native extensions,
+            # so it would tag the wheel py3-none-any. Force the correct tag.
+            build_data["pure_python"] = False
+            build_data["infer_tag"] = True

--- a/python/packages/livekit-portal/pyproject.toml
+++ b/python/packages/livekit-portal/pyproject.toml
@@ -42,6 +42,8 @@ testpaths = ["tests"]
 # coexist with livekit-api (`livekit.api`), livekit-protocol (`livekit.protocol`),
 # etc. Listing `livekit` as the package keeps hatchling's editable .pth pointed
 # at the package root so `from livekit.portal import ...` resolves.
+[tool.hatch.build.hooks.custom]
+
 [tool.hatch.build.targets.wheel]
 packages = ["livekit"]
 artifacts = [


### PR DESCRIPTION
Hatchling does not detect ctypes-loaded shared libraries as native extensions, so it tagged the wheel `py3-none-any` despite containing a platform-specific `.so`/`.dylib`. Adds a build hook that sets `pure_python=False` and `infer_tag=True` so the wheel gets the correct platform tag (e.g. `cp312-cp312-linux_x86_64`).