### PR TITLE
fix(lerobot-robot-livekit): update frame conversion function name

### DIFF
--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -17,7 +17,7 @@ from typing import Any
 from lerobot.robots.config import RobotConfig
 from lerobot.robots.robot import Robot
 
-from livekit.portal import DType, Portal, PortalConfig, Role, i420_bytes_to_numpy_rgb
+from livekit.portal import DType, Portal, PortalConfig, Role, frame_bytes_to_numpy_rgb
 
 
 @RobotConfig.register_subclass("livekit")
@@ -189,7 +189,7 @@ class LiveKitRobot(Robot):
         for cam in self._camera_names:
             frame = obs.frames.get(cam)
             if frame is not None:
-                out[cam] = i420_bytes_to_numpy_rgb(
+                out[cam] = frame_bytes_to_numpy_rgb(
                     frame.data, frame.width, frame.height
                 )
         return out


### PR DESCRIPTION
## Summary

- `livekit-portal` renamed `i420_bytes_to_numpy_rgb` → `frame_bytes_to_numpy_rgb` when lossless video was added (the function now handles both I420 WebRTC frames and codec-decoded frames, so the old name was wrong)
- `lerobot-robot-livekit` was still importing and calling the old name, causing an `ImportError` at runtime for anyone pairing the latest PyPI releases of both packages

## Test plan

- [ ] Import check: `from livekit.portal import frame_bytes_to_numpy_rgb` succeeds with the current `livekit-portal`
- [ ] Run `lerobot-robot-livekit` end-to-end with a camera stream and confirm observations contain RGB arrays