### PR TITLE
Unify add_video and add_frame_video into one codec-driven method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 **Built for VLA inference.** First-class **action chunks** ship a `(horizon, n_fields)` tensor in one packet via byte streams (no 15 KB cap). Tag every action with `in_reply_to_ts_us` and `metrics.policy.e2e_us_p50/p95` derives true observation→action latency — not just ping. See [`examples/python/inference/`](examples/python/inference) for a runnable VLA-style loop.
 
-**Frame video for policies.** WebRTC video is lossy and resamples colorspace. For inference where pixels matter, [`add_frame_video`](docs/frame-video.md) ships each frame independently over a byte stream with `RAW`, `PNG`, or `MJPEG` codecs. Same `send_video_frame` / `on_video_frame` API, RGB on both ends. MJPEG q=90 sustains 30 fps at 720p.
+**Frame video for policies.** WebRTC video is lossy and resamples colorspace. For inference where pixels matter, pass a non-H264 codec to [`add_video`](docs/frame-video.md) (`RAW`, `PNG`, or `MJPEG`) and each frame ships independently over a reliable byte stream. Same `send_video_frame` / `on_video_frame` API, RGB on both ends. MJPEG q=90 sustains 30 fps at 720p.
 
 **Works with any stack.** A direct `Portal` API in Python and Rust. An optional [lerobot](https://github.com/huggingface/lerobot) plugin for a one-line wrap around your existing `Robot` or `Teleoperator`.
 

--- a/docs/frame-video.md
+++ b/docs/frame-video.md
@@ -5,20 +5,23 @@ codec. Use this when the frames feeding your policy must arrive as the
 same RGB bytes the camera produced — no I420 conversion, no temporal
 codec, no quality drift.
 
+Selected by passing a non-`H264` codec to `add_video`. The default
+codec is `VideoCodec.H264` (WebRTC); the byte-stream codecs are `RAW`,
+`PNG`, and `MJPEG`.
+
 ## When to use it
 
 | Goal | Pick |
 |------|------|
-| Live preview, teleop, video monitoring | `add_video` (WebRTC media path, lossy, low CPU) |
-| Closed-loop policy inference | `add_frame_video(codec=MJPEG)` |
-| Bit-exact frames for benchmarks or training data | `add_frame_video(codec=PNG)` |
-| Sub-15 KB frames you want byte-for-byte | `add_frame_video(codec=RAW)` |
+| Live preview, teleop, video monitoring | `add_video(name)` (default H264, WebRTC media path) |
+| Closed-loop policy inference | `add_video(name, codec=VideoCodec.MJPEG)` |
+| Bit-exact frames for benchmarks or training data | `add_video(name, codec=VideoCodec.PNG)` |
+| Sub-15 KB frames you want byte-for-byte | `add_video(name, codec=VideoCodec.RAW)` |
 
-`add_video` and `add_frame_video` use the **same** user-facing API:
-`send_video_frame(name, rgb)`, `on_video_frame(name, frame)`,
-`get_video_frame(name)`. `frame.data` is packed RGB24 in both directions
-regardless of transport. Track names must be unique across both
-declarations.
+Every codec uses the **same** user-facing API: `send_video_frame(name,
+rgb)`, `on_video_frame(name, frame)`, `get_video_frame(name)`.
+`frame.data` is packed RGB24 in both directions regardless of transport.
+Track names must be unique across all `add_video` calls.
 
 ## Quickstart
 
@@ -30,13 +33,13 @@ from livekit.portal import (
 
 cfg = PortalConfig("session", Role.ROBOT)
 
-# Lossy WebRTC video — adaptive bitrate, low CPU.
+# Lossy WebRTC video — adaptive bitrate, low CPU. Default codec is H264.
 cfg.add_video("preview")
 
-# Frame video — byte-stream transport, per-frame codec.
-cfg.add_frame_video("front", codec=VideoCodec.MJPEG, quality=90)
-cfg.add_frame_video("wrist", codec=VideoCodec.PNG)
-cfg.add_frame_video("debug", codec=VideoCodec.RAW)
+# Byte-stream video — reliable per-frame transport, per-frame codec.
+cfg.add_video("front", codec=VideoCodec.MJPEG, quality=90)
+cfg.add_video("wrist", codec=VideoCodec.PNG)
+cfg.add_video("debug", codec=VideoCodec.RAW)
 
 cfg.add_state_typed([("j1", DType.F32)])
 
@@ -117,10 +120,11 @@ drop fps, or drop a track.
 
 ## What about the regular WebRTC video path?
 
-`add_video` uses the WebRTC media channel: H.264 over RTP, adaptive
-bitrate, hardware-accelerated where available. It is the right call
-for live preview and teleop, where the operator is watching the video
-and bandwidth adapts to the link.
+`add_video(name)` defaults to `VideoCodec.H264` and uses the WebRTC
+media channel: H.264 over RTP, adaptive bitrate, hardware-accelerated
+where available. It is the right call for live preview and teleop,
+where the operator is watching the video and bandwidth adapts to the
+link.
 
 It is the wrong call when:
 
@@ -130,26 +134,28 @@ It is the wrong call when:
 - Frame rate must be deterministic. WebRTC's encoder will drop frames
   silently to fit a bitrate target.
 
-Frame video gives up adaptive bitrate in exchange for deterministic
-per-frame delivery and bit-exact RGB.
+Picking a non-H264 codec on the same `add_video` call routes the track
+through the byte-stream transport, trading adaptive bitrate for
+deterministic per-frame delivery and bit-exact RGB.
 
 ## Configuration
 
 ```python
-PortalConfig.add_frame_video(
+PortalConfig.add_video(
     name: str,
-    codec: VideoCodec = VideoCodec.MJPEG,
+    codec: VideoCodec = VideoCodec.H264,
     quality: int = 90,
 )
 ```
 
-- `codec` is one of `VideoCodec.RAW`, `VideoCodec.PNG`, `VideoCodec.MJPEG`.
-- `quality` is `1..=100` for MJPEG, ignored for RAW and PNG. Quality
-  90 is visually near-lossless on natural images and produces 10-20×
-  compression. Quality 70 trades visible artifacts for ~2× more
+- `codec` is one of `VideoCodec.H264` (WebRTC), `VideoCodec.RAW`,
+  `VideoCodec.PNG`, `VideoCodec.MJPEG` (byte-stream).
+- `quality` is `1..=100` for MJPEG, ignored for every other codec.
+  Quality 90 is visually near-lossless on natural images and produces
+  10-20× compression. Quality 70 trades visible artifacts for ~2× more
   compression. Quality below 50 is unusable for inference.
-- Track names are unique across `add_video` and `add_frame_video`. A
-  duplicate raises.
+- Track names must be unique across all `add_video` calls regardless
+  of codec. A duplicate raises.
 
 ## Metrics
 
@@ -191,7 +197,7 @@ One byte stream per frame on topic `portal_frame_video`. Header is
 Width and height fit in `u16` (max 65535×65535 — far beyond any real
 camera). Track name is capped at 256 bytes on send and receive. The
 receiver dispatches frames by track name in the header, so multiple
-frame-video tracks share one topic.
+byte-stream tracks share one topic.
 
 Frame loss is contained: byte streams are TCP-like, frames either
 arrive whole or do not arrive at all. A dropped frame does not affect

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -202,17 +202,17 @@ uint8. Width and height must both be even. Full details in
 
 ## Frame video (lossless or codec-of-your-choice)
 
-`add_video` uses the WebRTC media path (H.264, lossy). For policies that
-read the pixels — VLA inference, behavior cloning, any case where
-colorspace shift breaks the policy distribution — declare a frame-video
-track instead:
+`add_video(name)` defaults to `VideoCodec.H264`, the WebRTC media path
+(lossy). For policies that read the pixels — VLA inference, behavior
+cloning, any case where colorspace shift breaks the policy distribution
+— pass a non-H264 codec on the same call:
 
 ```python
 from livekit.portal import VideoCodec
 
-cfg.add_frame_video("front", codec=VideoCodec.MJPEG, quality=90)
-cfg.add_frame_video("wrist", codec=VideoCodec.PNG)
-cfg.add_frame_video("debug", codec=VideoCodec.RAW)
+cfg.add_video("front", codec=VideoCodec.MJPEG, quality=90)
+cfg.add_video("wrist", codec=VideoCodec.PNG)
+cfg.add_video("debug", codec=VideoCodec.RAW)
 ```
 
 The user-facing API is identical — `send_video_frame`, `on_video_frame`,

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -52,26 +52,36 @@ impl From<core::Role> for Role {
     }
 }
 
-/// Frame-video codec. Selected per-track at config time (see
-/// `PortalConfig::add_frame_video`). Mirrors `livekit_portal::Codec`.
+/// Video codec. Selected per-track at config time via
+/// `PortalConfig::add_video`. Codec choice picks both the encoding and the
+/// wire transport: `H264` rides the WebRTC media path; the rest ride a
+/// reliable per-frame byte-stream channel. Mirrors `livekit_portal::Codec`.
 ///
 /// **Foreign binding casing**: UniFFI emits enum variants in the host
-/// language's idiomatic case. Python code uses `VideoCodec.RAW` /
-/// `VideoCodec.PNG` / `VideoCodec.MJPEG` (UPPER), not the Rust spelling.
+/// language's idiomatic case. Python code uses `VideoCodec.H264` /
+/// `VideoCodec.RAW` / `VideoCodec.PNG` / `VideoCodec.MJPEG` (UPPER), not
+/// the Rust spelling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum VideoCodec {
-    /// Uncompressed RGB24. Largest payload, zero encode cost.
+    /// WebRTC H.264. Real-time RTP/SRTP transport, lossy, best-effort.
+    /// `quality` is ignored — libwebrtc picks the operating bitrate.
+    H264,
+    /// Uncompressed RGB24. Largest payload, zero encode cost. Byte-stream
+    /// transport.
     Raw,
-    /// PNG, lossless. ~2-3x compression on natural images.
+    /// PNG, lossless. ~2-3x compression on natural images. Byte-stream
+    /// transport.
     Png,
     /// Motion JPEG, lossy. ~10-20x compression at quality 90. Each frame is
-    /// an independent JPEG so frame loss is contained.
+    /// an independent JPEG so frame loss is contained. Byte-stream
+    /// transport.
     Mjpeg,
 }
 
 impl From<VideoCodec> for core::Codec {
     fn from(c: VideoCodec) -> Self {
         match c {
+            VideoCodec::H264 => core::Codec::H264,
             VideoCodec::Raw => core::Codec::Raw,
             VideoCodec::Png => core::Codec::Png,
             VideoCodec::Mjpeg => core::Codec::Mjpeg,
@@ -82,6 +92,7 @@ impl From<VideoCodec> for core::Codec {
 impl From<core::Codec> for VideoCodec {
     fn from(c: core::Codec) -> Self {
         match c {
+            core::Codec::H264 => VideoCodec::H264,
             core::Codec::Raw => VideoCodec::Raw,
             core::Codec::Png => VideoCodec::Png,
             core::Codec::Mjpeg => VideoCodec::Mjpeg,
@@ -144,10 +155,11 @@ pub struct FieldSpec {
     pub dtype: DType,
 }
 
-/// One declared frame-video track: name, codec, and per-codec quality.
-/// Crosses the FFI boundary so bindings can pass these to
-/// `PortalConfig.add_frame_video`. `quality` is meaningful for
-/// `VideoCodec.Mjpeg` (1..=100) and ignored for `Raw` / `Png`.
+/// One declared byte-stream video track: name, codec, and per-codec
+/// quality. Crosses the FFI boundary so bindings can introspect tracks
+/// declared via `PortalConfig.add_video` with a non-`H264` codec.
+/// `quality` is meaningful for `VideoCodec.Mjpeg` (1..=100) and ignored for
+/// `Raw` / `Png`.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct FrameVideoSpec {
     pub name: String,
@@ -454,17 +466,14 @@ impl PortalConfig {
         Arc::new(Self { inner: Mutex::new(core::PortalConfig::new(session, role.into())) })
     }
 
-    pub fn add_video(&self, name: String) {
-        self.inner.lock().add_video(name);
-    }
-
-    /// Declare a frame-video track. Frames go over a reliable byte-stream
-    /// channel (not the WebRTC media path), encoded with `codec`. The
+    /// Declare a video track. `codec` picks both the encoding and the wire
+    /// transport: `H264` rides the WebRTC media path; `Mjpeg`, `Png`, and
+    /// `Raw` ride a reliable per-frame byte-stream channel and the
     /// receiver decodes back to RGB so the user-facing frame API is
-    /// identical to plain video. `quality` is `1..=100` for `Mjpeg` and
-    /// ignored for `Raw` / `Png`.
-    pub fn add_frame_video(&self, name: String, codec: VideoCodec, quality: u8) {
-        self.inner.lock().add_frame_video(name, codec.into(), quality);
+    /// identical. `quality` is `1..=100` for `Mjpeg` and ignored for
+    /// `H264` / `Raw` / `Png`.
+    pub fn add_video(&self, name: String, codec: VideoCodec, quality: u8) {
+        self.inner.lock().add_video(name, codec.into(), quality);
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {

--- a/livekit-portal/src/codec.rs
+++ b/livekit-portal/src/codec.rs
@@ -15,13 +15,20 @@ use image::codecs::jpeg::JpegEncoder;
 use image::codecs::png::{CompressionType, FilterType as PngFilterType, PngEncoder};
 use image::{ExtendedColorType, ImageEncoder};
 
-/// Codec used by a frame-video track.
+/// Codec used by a video track.
 ///
-/// Selected per-track at config time (see `PortalConfig::add_frame_video`).
-/// Choice drives the wire size and CPU cost; the user-facing payload is RGB
-/// in every case.
+/// Selected per-track at config time via `PortalConfig::add_video`. The codec
+/// also picks the wire transport: `H264` rides the WebRTC media path, every
+/// other variant rides a reliable byte-stream channel and is encoded by this
+/// module. The user-facing payload is RGB in every case.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Codec {
+    /// WebRTC H.264, lossy. Real-time RTP/SRTP transport with libwebrtc's
+    /// adaptive bitrate. Best-effort delivery — frames may drop or arrive
+    /// late. Lowest end-to-end latency at scale. Encoded by libwebrtc,
+    /// not this module — the byte-stream encode/decode helpers below panic
+    /// for `H264`.
+    H264,
     /// Uncompressed RGB24. Largest payload, zero encode cost. Use when CPU is
     /// scarce or you want bit-exact frames with no codec dependency.
     Raw,
@@ -32,6 +39,14 @@ pub enum Codec {
     /// decode. Each frame is an independent JPEG (no temporal coding), so
     /// frame loss is contained.
     Mjpeg,
+}
+
+impl Codec {
+    /// Whether this codec rides the WebRTC media path. The remaining codecs
+    /// ride the per-frame byte-stream path.
+    pub fn is_webrtc(self) -> bool {
+        matches!(self, Codec::H264)
+    }
 }
 
 /// Decoded frame: RGB24 bytes plus the dimensions parsed from the payload
@@ -108,13 +123,16 @@ pub fn estimated_encoded_size(width: u32, height: u32, codec: Codec) -> usize {
         Codec::Raw => raw,
         Codec::Png => raw,
         Codec::Mjpeg => (raw / 8).max(1024),
+        Codec::H264 => unreachable!(
+            "Codec::H264 rides the WebRTC media path, not the byte-stream encode path"
+        ),
     }
 }
 
 /// Encode an RGB24 frame to the wire payload for `codec`. `quality` is in
 /// `1..=100` for `Mjpeg` and is ignored for `Raw` and `Png`.
 ///
-/// Quality range is enforced at config time by `PortalConfig::add_frame_video`,
+/// Quality range is enforced at config time by `PortalConfig::add_video`,
 /// so this hot-path encode skips re-validation.
 ///
 /// Allocates a fresh `Vec`. Prefer `encode_frame_into` when you already
@@ -176,6 +194,9 @@ pub fn encode_frame_into(
                 .map_err(|e| CodecError::EncodeFailed(e.to_string()))?;
             Ok(())
         }
+        Codec::H264 => unreachable!(
+            "Codec::H264 rides the WebRTC media path, not the byte-stream encode path"
+        ),
     }
 }
 
@@ -212,6 +233,9 @@ pub fn decode_frame(
             image::ImageFormat::Jpeg,
             declared_width,
             declared_height,
+        ),
+        Codec::H264 => unreachable!(
+            "Codec::H264 rides the WebRTC media path, not the byte-stream decode path"
         ),
     }
 }

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -2,7 +2,7 @@ use crate::codec::Codec;
 use crate::dtype::DType;
 use crate::types::{Role, SyncConfig};
 
-/// Default JPEG quality for `add_frame_video` when MJPEG is selected without an
+/// Default JPEG quality for `add_video` when MJPEG is selected without an
 /// explicit value. Tuned for inference workloads: visually near-lossless on
 /// natural images, ~10-20x compression versus raw RGB.
 pub const DEFAULT_MJPEG_QUALITY: u8 = 90;
@@ -37,13 +37,15 @@ impl From<FieldSpec> for (String, DType) {
     }
 }
 
-/// One frame-video track declaration: name, codec, and per-codec quality.
+/// One byte-stream video track declaration: name, codec, and per-codec
+/// quality.
 ///
-/// Frame-video tracks bypass the WebRTC media path and ride a reliable
-/// byte-stream channel instead. Each frame is encoded once on the sender
-/// (Raw / PNG / MJPEG) and decoded back to RGB on the receiver. The
-/// user-facing API is identical to plain video — `send_video_frame` /
-/// `on_video_frame` / `get_video_frame` — only the wire transport differs.
+/// These tracks bypass the WebRTC media path and ride a reliable byte-stream
+/// channel instead. Each frame is encoded once on the sender (Raw / PNG /
+/// MJPEG) and decoded back to RGB on the receiver. The user-facing API is
+/// identical to WebRTC video — `send_video_frame` / `on_video_frame` /
+/// `get_video_frame` — only the wire transport differs. Selected at config
+/// time by passing a non-`H264` codec to `PortalConfig::add_video`.
 ///
 /// `quality` is honored for `Mjpeg` (1..=100) and ignored for `Raw` and
 /// `Png`.
@@ -127,44 +129,35 @@ impl PortalConfig {
         }
     }
 
-    pub fn add_video(&mut self, name: impl Into<String>) {
+    /// Declare a video track.
+    ///
+    /// `codec` picks both the encoding and the wire transport:
+    ///
+    /// - `Codec::H264` rides the WebRTC media path (RTP/SRTP, lossy,
+    ///   best-effort delivery, lowest latency at scale). `quality` is
+    ///   ignored — libwebrtc picks the operating bitrate.
+    /// - `Codec::Mjpeg`, `Codec::Png`, `Codec::Raw` ride a reliable
+    ///   per-frame byte-stream channel. The receiver decodes back to RGB so
+    ///   the user-facing `on_video_frame` / `get_video_frame` API is
+    ///   identical to H264. `quality` is in `1..=100` for `Mjpeg` and
+    ///   ignored for `Raw` / `Png`. Use `DEFAULT_MJPEG_QUALITY` (90) when
+    ///   in doubt.
+    ///
+    /// Track names must be unique across all `add_video` calls regardless
+    /// of codec; a duplicate panics.
+    ///
+    /// **Byte-stream latency**: frames on the byte-stream path pay roughly
+    /// `1 ms + 2 ms × ⌈size / BYTE_STREAM_CHUNK_SIZE⌉` per frame, set by
+    /// the SCTP data channel drain rate (not Portal's encode cost). Pick a
+    /// codec whose encoded size fits in one chunk for low-latency
+    /// closed-loop work. MJPEG at 224×224 to 480p typically does. Raw at
+    /// anything above ~70×70 spills into multiple chunks.
+    pub fn add_video(&mut self, name: impl Into<String>, codec: Codec, quality: u8) {
         let name = name.into();
         assert!(
             !self.has_track(&name),
             "video track '{name}' already declared (each track name must be unique \
-             across add_video and add_frame_video)"
-        );
-        self.video_tracks.push(name);
-    }
-
-    /// Declare a frame-video track. Frame-video tracks deliver each frame
-    /// independently over a reliable byte-stream channel, encoded with
-    /// `codec`. The receiver decodes back to RGB so the user-facing
-    /// `on_video_frame` / `get_video_frame` API matches plain video.
-    ///
-    /// `quality` is in `1..=100` for `Codec::Mjpeg` and ignored for `Codec::Raw`
-    /// / `Codec::Png`. Use `DEFAULT_MJPEG_QUALITY` (90) when in doubt.
-    ///
-    /// Track names must be unique across all `add_video` and
-    /// `add_frame_video` calls; a duplicate panics.
-    ///
-    /// **Latency**: byte-stream frames pay roughly `1 ms + 2 ms × ⌈size /
-    /// BYTE_STREAM_CHUNK_SIZE⌉` per frame, set by the SCTP data channel
-    /// drain rate (not Portal's encode cost). Pick a codec whose
-    /// encoded size fits in one chunk for low-latency closed-loop work.
-    /// MJPEG at 224×224 to 480p typically does. Raw at anything above
-    /// ~70×70 spills into multiple chunks.
-    pub fn add_frame_video(
-        &mut self,
-        name: impl Into<String>,
-        codec: Codec,
-        quality: u8,
-    ) {
-        let name = name.into();
-        assert!(
-            !self.has_track(&name),
-            "frame-video track '{name}' already declared (each track name must be \
-             unique across add_video and add_frame_video)"
+             across add_video calls)"
         );
         if codec == Codec::Mjpeg {
             assert!(
@@ -172,7 +165,11 @@ impl PortalConfig {
                 "MJPEG quality must be in 1..=100, got {quality}"
             );
         }
-        self.frame_video_tracks.push(FrameVideoSpec::new(name, codec, quality));
+        if codec.is_webrtc() {
+            self.video_tracks.push(name);
+        } else {
+            self.frame_video_tracks.push(FrameVideoSpec::new(name, codec, quality));
+        }
     }
 
     fn has_track(&self, name: &str) -> bool {

--- a/livekit-portal/src/frame_video.rs
+++ b/livekit-portal/src/frame_video.rs
@@ -112,6 +112,9 @@ fn codec_id(c: Codec) -> u8 {
         Codec::Raw => 0,
         Codec::Png => 1,
         Codec::Mjpeg => 2,
+        Codec::H264 => unreachable!(
+            "Codec::H264 rides the WebRTC media path, not the byte-stream wire format"
+        ),
     }
 }
 

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -351,10 +351,10 @@ impl Portal {
         timestamp_us: Option<u64>,
     ) -> PortalResult<()> {
         // Two transports, one user-facing method. WebRTC publishers and
-        // frame-video publishers are populated by the corresponding
-        // `add_video` / `add_frame_video` declarations at config time, and
-        // names are unique across both, so a track lives in exactly one
-        // map.
+        // frame-video publishers are populated by `add_video` at config
+        // time — codec selection routes the spec to one list or the
+        // other — and names are unique across both, so a track lives in
+        // exactly one map.
         if let Some(publisher) = self.video_publishers.lock().get(track_name).cloned() {
             return publisher.send_frame(rgb_data, width, height, timestamp_us);
         }

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -17,7 +17,15 @@ from typing import Any
 from lerobot.robots.config import RobotConfig
 from lerobot.robots.robot import Robot
 
-from livekit.portal import DType, Portal, PortalConfig, Role, frame_bytes_to_numpy_rgb
+from livekit.portal import (
+    DEFAULT_MJPEG_QUALITY,
+    DType,
+    Portal,
+    PortalConfig,
+    Role,
+    VideoCodec,
+    frame_bytes_to_numpy_rgb,
+)
 
 
 @RobotConfig.register_subclass("livekit")
@@ -33,6 +41,15 @@ class LiveKitRobotConfig(RobotConfig):
     camera_names: tuple[str, ...] = ()
     camera_height: int = 480
     camera_width: int = 640
+
+    # Video transport. `H264` rides the WebRTC media path (default).
+    # `MJPEG` / `PNG` / `RAW` ride a reliable per-frame byte stream — pick
+    # one of those for policy-grade pixels. `video_quality` is honored only
+    # for `MJPEG`. Both peers must agree, so set the same values on the
+    # operator's `LiveKitRobotConfig` and the robot's
+    # `LiveKitTeleoperatorConfig`.
+    video_codec: VideoCodec = VideoCodec.H264
+    video_quality: int = DEFAULT_MJPEG_QUALITY
 
     # Portal tuning.
     slack: int | None = None
@@ -130,7 +147,11 @@ class LiveKitRobot(Robot):
 
         self._portal_cfg = PortalConfig(self.config.session or "lerobot", Role.OPERATOR)
         for cam in self._camera_names:
-            self._portal_cfg.add_video(cam)
+            self._portal_cfg.add_video(
+                cam,
+                codec=self.config.video_codec,
+                quality=self.config.video_quality,
+            )
         if self._state_motors:
             self._portal_cfg.add_state_typed(
                 [(name, DType.F64) for name in self._state_motors]

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
@@ -11,14 +11,21 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 from lerobot.teleoperators.config import TeleoperatorConfig
 from lerobot.teleoperators.teleoperator import Teleoperator
 
-from livekit.portal import DType, Portal, PortalConfig, Role
+from livekit.portal import (
+    DEFAULT_MJPEG_QUALITY,
+    DType,
+    Portal,
+    PortalConfig,
+    Role,
+    VideoCodec,
+)
 
 
 @TeleoperatorConfig.register_subclass("livekit")
@@ -34,6 +41,15 @@ class LiveKitTeleoperatorConfig(TeleoperatorConfig):
     # Ignored when a robot is provided.
     motors: tuple[str, ...] = ()
     camera_names: tuple[str, ...] = ()
+
+    # Video transport. `H264` rides the WebRTC media path (default).
+    # `MJPEG` / `PNG` / `RAW` ride a reliable per-frame byte stream — pick
+    # one of those for policy-grade pixels. `video_quality` is honored only
+    # for `MJPEG`. Both peers must agree, so set the same values on the
+    # robot's `LiveKitTeleoperatorConfig` and the operator's
+    # `LiveKitRobotConfig`.
+    video_codec: VideoCodec = VideoCodec.H264
+    video_quality: int = DEFAULT_MJPEG_QUALITY
 
     # Portal tuning.
     slack: int | None = None
@@ -145,7 +161,11 @@ class LiveKitTeleoperator(Teleoperator):
 
         self._portal_cfg = PortalConfig(self.config.session or "lerobot", Role.ROBOT)
         for cam in self._camera_names:
-            self._portal_cfg.add_video(cam)
+            self._portal_cfg.add_video(
+                cam,
+                codec=self.config.video_codec,
+                quality=self.config.video_quality,
+            )
         if self._state_motors:
             self._portal_cfg.add_state_typed(
                 [(name, DType.F64) for name in self._state_motors]

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -57,8 +57,8 @@ PortalError = _ffi.PortalError
 RpcInvocationData = _ffi.RpcInvocationData
 RpcError = _ffi.RpcError
 
-# Default JPEG quality for `add_frame_video` when no explicit value is given.
-# Mirrors the Rust core's `DEFAULT_MJPEG_QUALITY`.
+# Default JPEG quality for `add_video` with `VideoCodec.MJPEG` when no
+# explicit value is given. Mirrors the Rust core's `DEFAULT_MJPEG_QUALITY`.
 DEFAULT_MJPEG_QUALITY: int = 90
 
 # A schema entry accepted by add_state_typed/add_action_typed. Either a
@@ -633,48 +633,51 @@ class PortalConfig:
         """All declared action chunks, in declaration order."""
         return list(self._action_chunks)
 
-    def add_video(self, name: str) -> None:
-        self._inner.add_video(name)
-        self._video_tracks.append(name)
-
-    def add_frame_video(
+    def add_video(
         self,
         name: str,
-        codec: VideoCodec = VideoCodec.MJPEG,
+        codec: VideoCodec = VideoCodec.H264,
         quality: int = DEFAULT_MJPEG_QUALITY,
     ) -> None:
-        """Declare a frame-video track.
+        """Declare a video track.
 
-        Frames travel over a reliable byte-stream channel rather than the
-        WebRTC media path, encoded per-frame with `codec`. The user-facing
-        send/receive API is identical to plain video — `send_video_frame`
-        accepts RGB, `on_video_frame` / `get_video_frame` deliver RGB.
+        `codec` picks both the encoding and the wire transport. The
+        user-facing send/receive API is identical regardless of codec —
+        `send_video_frame` accepts RGB and `on_video_frame` /
+        `get_video_frame` deliver RGB.
 
-        `codec`:
-          * `VideoCodec.RAW` — uncompressed RGB24, largest payload, zero
-            encode cost.
-          * `VideoCodec.PNG` — lossless, ~2-3x compression on natural images.
-          * `VideoCodec.MJPEG` (default) — lossy per-frame JPEG, ~10-20x
+          * `VideoCodec.H264` (default) — WebRTC media path. Real-time
+            RTP/SRTP, lossy, best-effort. Lowest end-to-end latency at
+            scale. `quality` is ignored.
+          * `VideoCodec.RAW` — byte-stream, uncompressed RGB24. Largest
+            payload, zero encode cost. `quality` is ignored.
+          * `VideoCodec.PNG` — byte-stream, lossless. ~2-3x compression on
+            natural images. `quality` is ignored.
+          * `VideoCodec.MJPEG` — byte-stream, lossy per-frame JPEG. ~10-20x
             compression at quality 90, sub-millisecond decode. Use for
             inference where frame independence matters but bit-exactness
             doesn't.
 
         `quality` is in 1..=100 and is honored for `VideoCodec.MJPEG`. It is
-        ignored for `RAW` and `PNG`. Track names must be unique across all
-        `add_video` and `add_frame_video` calls; a duplicate raises.
+        ignored for every other codec. Track names must be unique across
+        all `add_video` calls; a duplicate raises.
 
-        **Latency**: each frame's byte-stream payload is fragmented at the
-        LiveKit chunk size (15 KB) and shipped over a single SCTP data
-        channel. Per-frame latency is roughly `1 ms + 2 ms × ⌈encoded_size
-        / 15 KB⌉` on localhost, set by the data-channel drain rate (not
-        Portal's encode cost). Pick a codec whose encoded output fits in
-        one chunk for low-latency closed-loop work — at typical inference
-        resolutions (224×224 to 480p) MJPEG q=80–95 usually does.
+        **Byte-stream latency** (non-H264 codecs): each frame's payload is
+        fragmented at the LiveKit chunk size (15 KB) and shipped over a
+        single SCTP data channel. Per-frame latency is roughly `1 ms + 2 ms
+        × ⌈encoded_size / 15 KB⌉` on localhost, set by the data-channel
+        drain rate (not Portal's encode cost). Pick a codec whose encoded
+        output fits in one chunk for low-latency closed-loop work — at
+        typical inference resolutions (224×224 to 480p) MJPEG q=80–95
+        usually does.
         """
-        self._inner.add_frame_video(name, codec, quality)
-        self._frame_video_tracks.append(
-            FrameVideoSpec(name=name, codec=codec, quality=quality)
-        )
+        self._inner.add_video(name, codec, quality)
+        if codec == VideoCodec.H264:
+            self._video_tracks.append(name)
+        else:
+            self._frame_video_tracks.append(
+                FrameVideoSpec(name=name, codec=codec, quality=quality)
+            )
 
     def add_state_typed(self, schema: Iterable[SchemaEntry]) -> None:
         """Declare state fields with per-field dtype.

--- a/python/packages/livekit-portal/tests/integration/test_frame_video.py
+++ b/python/packages/livekit-portal/tests/integration/test_frame_video.py
@@ -1,16 +1,17 @@
-"""Integration tests for frame-video tracks against a live LiveKit server.
+"""Integration tests for byte-stream video tracks against a live LiveKit server.
 
-Frame video bypasses the WebRTC media path and ships each frame as a
-byte-stream payload (codec=Raw|Png|Mjpeg). The receiver decodes back to
-RGB so consumer code calls `on_video_frame` / `get_video_frame` /
-`on_observation` exactly the same way as plain `add_video`.
+Selecting a non-H264 codec on `add_video` bypasses the WebRTC media path
+and ships each frame as a byte-stream payload (Raw, Png, Mjpeg). The
+receiver decodes back to RGB so consumer code calls `on_video_frame` /
+`get_video_frame` / `on_observation` exactly the same way as the H264
+WebRTC path.
 
 These scenarios exercise the parts most likely to misbehave in production:
   * RGB roundtrip integrity (Raw, Png byte-exact; Mjpeg close enough)
   * Codec mismatch — wrong codec on receive must drop, not crash
   * Track name mismatch — frames for an undeclared track must drop
-  * Mixed transports — `add_video` and `add_frame_video` cohabiting one
-    Portal both feed the sync buffer
+  * Mixed transports — H264 and byte-stream tracks cohabiting one Portal
+    both feed the sync buffer
   * Pre-first-frame state buffering and observation emission
   * Burst publish — overflow path drops newest frames without hanging
   * Boundary dimensions (8x8 floor, multi-megapixel ceiling)
@@ -70,8 +71,8 @@ def _gradient(width: int, height: int, seed: int = 0) -> np.ndarray:
 @pytest.mark.parametrize("codec", [VideoCodec.RAW, VideoCodec.PNG])
 async def test_lossless_codec_roundtrip_byte_exact(pair, codec):
     """Raw and PNG must deliver the publisher's bytes verbatim."""
-    pair.robot_cfg.add_frame_video("cam", codec=codec)
-    pair.operator_cfg.add_frame_video("cam", codec=codec)
+    pair.robot_cfg.add_video("cam", codec=codec)
+    pair.operator_cfg.add_video("cam", codec=codec)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -93,8 +94,8 @@ async def test_lossless_codec_roundtrip_byte_exact(pair, codec):
 
 async def test_mjpeg_roundtrip_close(pair):
     """MJPEG is lossy by design; assert avg per-pixel error is small."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=95)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=95)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=95)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=95)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -125,8 +126,8 @@ async def test_codec_mismatch_drops(pair):
     the header disagrees with the operator's spec; the dispatcher must
     drop the frame and not call the callback.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.MJPEG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -148,8 +149,8 @@ async def test_unknown_track_drops_silently(pair):
     track-name header doesn't match any operator spec; receiver drops,
     no callback fires on either name.
     """
-    pair.robot_cfg.add_frame_video("cam_a", codec=VideoCodec.RAW)
-    pair.operator_cfg.add_frame_video("cam_b", codec=VideoCodec.RAW)
+    pair.robot_cfg.add_video("cam_a", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video("cam_b", codec=VideoCodec.RAW)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -170,8 +171,8 @@ async def test_unknown_track_drops_silently(pair):
 async def test_observation_emits_for_frame_video_track(pair):
     """A frame-video track behaves exactly like a webrtc track from the
     sync buffer's POV: state + matching frame → one observation."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
     # state schema from conftest is `[("j", F32)]`.
 
     obs: list[Observation] = []
@@ -195,9 +196,9 @@ async def test_mixed_transports_in_one_portal(pair):
     frames once both arrive within tolerance.
     """
     pair.robot_cfg.add_video("cam_webrtc")
-    pair.robot_cfg.add_frame_video("cam_data", codec=VideoCodec.MJPEG, quality=80)
+    pair.robot_cfg.add_video("cam_data", codec=VideoCodec.MJPEG, quality=80)
     pair.operator_cfg.add_video("cam_webrtc")
-    pair.operator_cfg.add_frame_video("cam_data", codec=VideoCodec.MJPEG, quality=80)
+    pair.operator_cfg.add_video("cam_data", codec=VideoCodec.MJPEG, quality=80)
 
     obs: list[Observation] = []
     await pair.start()
@@ -231,8 +232,8 @@ async def test_mixed_transports_in_one_portal(pair):
 async def test_tiny_frame_8x8(pair):
     """8x8 RGB — smallest sensible frame. Verifies the wire format
     survives below typical block boundaries that codecs assume."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -254,8 +255,8 @@ async def test_large_frame_above_data_packet_cap(pair):
     Byte streams fragment under the hood, so the receive side should
     reassemble cleanly.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.RAW)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -277,8 +278,8 @@ async def test_odd_dimensions_supported(pair):
     """Frame video has no parity constraint (unlike I420 → libwebrtc).
     Odd-on-both-axes frames must encode and roundtrip cleanly.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -296,8 +297,8 @@ async def test_odd_dimensions_supported(pair):
 async def test_mjpeg_quality_boundaries(pair, quality):
     """MJPEG accepts 1..=100. Both endpoints must encode without panic
     and decode to a frame of the right dimensions."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=quality)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=quality)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=quality)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=quality)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -319,8 +320,8 @@ async def test_burst_does_not_hang(pair):
     """Send 200 frames as fast as possible. Some may drop at the
     publish-queue boundary (cap=60) — the rest must arrive without the
     publisher hanging or panicking."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=70)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=70)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=70)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=70)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -344,8 +345,8 @@ async def test_disconnect_midstream_leaves_clean_state(pair):
     more frames. The original publisher's drainer task must abort
     cleanly; a leaked task would either keep the room open or panic on
     a torn-down LocalParticipant."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -369,8 +370,8 @@ async def test_get_video_frame_after_send(pair):
     """`get_video_frame` returns the latest received frame for the named
     track. After one send, the operator's pull-side slot must populate.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
     await pair.start()
 
     rgb = _gradient(32, 32, seed=9)
@@ -389,8 +390,8 @@ async def test_state_buffered_until_first_frame(pair):
     timestamp. The sync buffer should hold the state, then emit when the
     frame arrives — no observation drop.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     obs: list[Observation] = []
     drops: list = []
@@ -424,8 +425,8 @@ async def test_state_buffered_until_first_frame(pair):
 async def test_uniform_fill_byte_exact(pair, fill):
     """Pathological uniform frames stress the codec's entropy coder
     boundary. Lossless codecs must still be byte-exact."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -449,8 +450,8 @@ async def test_operator_send_video_frame_wrong_role(pair):
     surface as `WrongRole`, not as the misleading `UnknownVideoTrack` it
     used to return.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
     await pair.start()
 
     sent = _gradient(8, 8)
@@ -470,8 +471,8 @@ async def test_publisher_full_metric_increments_on_burst(pair):
     will be dropped at the queue cap (60), and the metric must reflect
     that count.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.RAW)
     await pair.start()
 
     rgb = _gradient(320, 240, seed=5)
@@ -495,8 +496,8 @@ async def test_random_noise_byte_exact(pair):
     """High-entropy noise. PNG can't compress this much, exercising the
     largest typical PNG payload size on the wire.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()

--- a/python/packages/livekit-portal/tests/integration/test_frame_video_stress.py
+++ b/python/packages/livekit-portal/tests/integration/test_frame_video_stress.py
@@ -79,8 +79,8 @@ async def test_4k_frame_roundtrip(pair, codec):
       * Dimensions match.
       * For lossless codecs (Raw, PNG), bytes are exact.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=codec, quality=90)
-    pair.operator_cfg.add_frame_video("cam", codec=codec, quality=90)
+    pair.robot_cfg.add_video("cam", codec=codec, quality=90)
+    pair.operator_cfg.add_video("cam", codec=codec, quality=90)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -122,8 +122,8 @@ async def test_sustained_30fps_mjpeg_540p_for_5s(pair):
       * No publisher-queue drops at this rate.
       * No more than 1 dropped frame at the publisher under steady state.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=85)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=85)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=85)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=85)
 
     received: list[int] = []  # store timestamps to detect ordering / loss
     await pair.start()
@@ -182,8 +182,8 @@ async def test_three_tracks_concurrent(pair):
         ("over",  VideoCodec.RAW,   0),
     ]
     for name, codec, q in cams:
-        pair.robot_cfg.add_frame_video(name, codec=codec, quality=q)
-        pair.operator_cfg.add_frame_video(name, codec=codec, quality=q)
+        pair.robot_cfg.add_video(name, codec=codec, quality=q)
+        pair.operator_cfg.add_video(name, codec=codec, quality=q)
 
     received: dict[str, list[VideoFrameData]] = {n: [] for n, _, _ in cams}
     await pair.start()
@@ -223,8 +223,8 @@ async def test_three_tracks_concurrent(pair):
 async def test_minimal_dims_lossless(pair, w, h):
     """1×1 RGB roundtrip — codec must not have a hidden block-size floor.
     Lossless only, since MJPEG's 8×8 DCT block can't represent a 1×1 sample."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -250,8 +250,8 @@ async def test_minimal_dims_lossless(pair, w, h):
 async def test_extreme_aspect_ratio(pair, w, h):
     """Very wide / very tall frames. Stresses the codec's stride
     handling and the wire format's u16 width/height fields."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     received: list[VideoFrameData] = []
     await pair.start()
@@ -280,8 +280,8 @@ async def test_operator_joins_after_robot_starts_sending():
     from integration.conftest import URL, _make_token, Pair
 
     p = Pair()
-    p.robot_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
-    p.operator_cfg.add_frame_video("cam", codec=VideoCodec.PNG)
+    p.robot_cfg.add_video("cam", codec=VideoCodec.PNG)
+    p.operator_cfg.add_video("cam", codec=VideoCodec.PNG)
 
     try:
         # Robot connects first, sends a few "pre-operator" frames.
@@ -331,8 +331,8 @@ async def test_sustained_overrate_drops_bounded(pair):
     in the metric. Memory must not balloon (heap-bounded by queue cap +
     in-flight payload).
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.RAW)
     await pair.start()
 
     rgb = _gradient(640, 480)
@@ -374,8 +374,8 @@ async def test_dim_above_u16_rejected_at_send(pair):
     silently truncate or panic. This is a property of the wire format,
     so the actual server flow doesn't matter — we just want a clean
     error from `send_video_frame`."""
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.RAW)
     await pair.start()
 
     # Construct a frame whose dimensions fit Python ints but exceed u16.
@@ -425,8 +425,8 @@ async def test_raw_latency_vs_chunk_count(pair, w, h):
     Prints chunk count + p50/p95 + cumulative bytes_sent so the
     relationship is visible. No tight upper bound — networks vary.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.RAW)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.RAW)
 
     samples_us: list[int] = []
     arrival_event = asyncio.Event()
@@ -497,8 +497,8 @@ async def test_latency_profile_640x480(pair, codec, quality):
     a bottleneck. Asserts a soft ceiling so a regression that doubles
     latency would be loud.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=codec, quality=quality)
-    pair.operator_cfg.add_frame_video("cam", codec=codec, quality=quality)
+    pair.robot_cfg.add_video("cam", codec=codec, quality=quality)
+    pair.operator_cfg.add_video("cam", codec=codec, quality=quality)
 
     samples_us: list[int] = []
     arrival_event = asyncio.Event()
@@ -571,8 +571,8 @@ async def test_rss_does_not_balloon_under_sustained_load(pair):
     A real leak would make the second delta similar to or bigger than
     the first because each frame keeps allocating without ever freeing.
     """
-    pair.robot_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=85)
-    pair.operator_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=85)
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=85)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=85)
 
     received_count = 0
 
@@ -647,8 +647,8 @@ async def test_repeated_reconnect_no_leak():
 
     for cycle in range(5):
         p = Pair()
-        p.robot_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=80)
-        p.operator_cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=80)
+        p.robot_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=80)
+        p.operator_cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=80)
         try:
             p.robot = Portal(p.robot_cfg)
             p.operator = Portal(p.operator_cfg)


### PR DESCRIPTION
## Summary
- Replace `add_video(name)` and `add_frame_video(name, codec, quality)` with a single `add_video(name, codec, quality)`. Codec selects the wire transport: `H264` rides the WebRTC media path (default), `Mjpeg` / `Png` / `Raw` ride the per-frame byte-stream path.
- Lerobot configs (`LiveKitRobotConfig`, `LiveKitTeleoperatorConfig`) gain `video_codec` and `video_quality` fields so cameras can opt out of WebRTC without dropping into raw Portal.
- Track names stay unique across both transports. Byte-stream encode and wire-format helpers reject `H264` via `unreachable!`, since the config layer routes H264 specs to the WebRTC list before they can reach those helpers.

## Migration
- `cfg.add_video("cam")` continues to work and still selects H264.
- `cfg.add_frame_video("cam", codec=VideoCodec.MJPEG, quality=80)` becomes `cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=80)`.

## Test plan
- [x] `cargo check -p livekit-portal -p livekit-portal-ffi`
- [x] `pytest tests/test_config.py` — 26 passed
- [x] Smoke check that H264 routes to `video_tracks`, byte-stream codecs route to `frame_video_tracks`, and the cross-codec name uniqueness assert still fires.
- [x] Integration suite against a local LiveKit server:
  - `tests/integration/test_frame_video.py` — 22 passed
  - `tests/integration/test_frame_video_stress.py` — 23 passed (4K roundtrip, sustained 30 fps at 540p, three concurrent tracks, late-subscribe operator, RSS stability, repeated reconnect)
  - `tests/integration/test_chunks.py` — 15 passed