### PR TITLE
feat: add shared-key E2EE support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ build/
 **/livekit/portal/livekit_portal_ffi.dll
 **/livekit/portal/livekit_portal_ffi.py
 
+# Claude Code
+.claude/
+
 # OS
 .DS_Store

--- a/docs/e2ee.md
+++ b/docs/e2ee.md
@@ -1,0 +1,65 @@
+# End-to-end encryption
+
+Portal supports end-to-end encryption (E2EE) for both media tracks and data
+channels. When enabled, content is encrypted before it leaves the sender and
+decrypted only at the receiver. The LiveKit server cannot read the payload.
+
+## How it works
+
+E2EE uses AES-GCM with a shared secret. Both peers supply the same key before
+connecting. Encryption is applied by libwebrtc on each RTP frame and on every
+data channel packet, so it covers H264 video, byte-stream frame video, state,
+and actions.
+
+## Setup
+
+Call `set_e2ee_key` on `PortalConfig` before `connect`. Both peers must use the
+same key.
+
+```python
+import os
+from livekit.portal import Portal, PortalConfig, Role
+
+cfg = PortalConfig("session-1", Role.ROBOT)
+cfg.set_e2ee_key(os.environ["PORTAL_E2EE_KEY"].encode())
+# ... add_video, add_state_typed, add_action_typed ...
+
+portal = Portal(cfg)
+await portal.connect(url, token)
+```
+
+The operator side is identical. Replace `Role.ROBOT` with `Role.OPERATOR` and
+supply the same key.
+
+## Key generation and distribution
+
+Generate a key with `os.urandom(32)` (256 bits). Treat it like any other
+secret. Common patterns:
+
+- Load from an environment variable or secret manager at startup.
+- Derive per-session keys from a master secret and the session name.
+- Pass through job metadata when dispatching a remote policy.
+
+Do not hardcode keys in source.
+
+## What is and is not covered
+
+| Traffic | Covered |
+|---|---|
+| H264 video (WebRTC media path) | Yes |
+| Byte-stream video (MJPEG, PNG, RAW) | Yes |
+| State packets (data channel) | Yes |
+| Action packets (data channel) | Yes |
+| RPC calls | Yes |
+| Token exchange with the LiveKit server | No (TLS only) |
+| Signaling metadata (track names, participant info) | No |
+
+The LiveKit server sees participant identities and room metadata but cannot
+read media or data payloads when E2EE is active.
+
+## Mismatched or missing key
+
+If one peer connects without a key or with a different key, media arrives but
+decryption fails silently. Video will be black or corrupted. State and action
+packets will not parse. There is no handshake error. Check that both sides load
+the same key bytes if data stops flowing after enabling E2EE.

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -245,6 +245,21 @@ format, and metrics surface.
 - `await portal.connect(url, token)` / `await portal.disconnect()`.
 - `portal.close()` / `cfg.close()`: release native handles.
 
+## End-to-end encryption
+
+Call `cfg.set_e2ee_key(key: bytes)` before `connect`. Both peers must use the
+same key. All media tracks and data channels (state, actions, RPC) are
+encrypted with AES-GCM.
+
+```python
+import os
+
+cfg.set_e2ee_key(os.environ["PORTAL_E2EE_KEY"].encode())
+```
+
+See [e2ee.md](e2ee.md) for key generation, distribution patterns, and coverage
+details.
+
 ## Reference
 
 - [Concepts](concepts.md). Roles, observation model, frame format.
@@ -253,6 +268,7 @@ format, and metrics surface.
 - [Tuning](tuning.md). `fps`, `slack`, `tolerance`, asymmetric rates.
 - [Synchronization deep dive](synchronization.md). The match algorithm.
 - [RPC](rpc.md). Imperative commands on top of LiveKit RPC.
+- [E2EE](e2ee.md). Shared-key end-to-end encryption.
 - [`examples/python/basic/`](../examples/python/basic). The smallest
   end-to-end script using this API, with synthetic video.
 - [lerobot integration](lerobot.md). The optional convenience plugins that

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -526,6 +526,10 @@ impl PortalConfig {
     pub fn set_reuse_stale_frames(&self, enable: bool) {
         self.inner.lock().set_reuse_stale_frames(enable);
     }
+
+    pub fn set_e2ee_key(&self, key: Vec<u8>) {
+        self.inner.lock().set_e2ee_key(key);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -107,6 +107,7 @@ pub struct PortalConfig {
     pub(crate) tolerance: f32,
     pub(crate) ping_ms: u64,
     pub(crate) reuse_stale_frames: bool,
+    pub(crate) shared_key: Option<Vec<u8>>,
 }
 
 impl PortalConfig {
@@ -126,7 +127,15 @@ impl PortalConfig {
             tolerance: 1.5,
             ping_ms: 1000,
             reuse_stale_frames: false,
+            shared_key: None,
         }
+    }
+
+    /// Set a shared E2EE key. Both peers must call this with the same key
+    /// before connecting. The key is used as a GCM-AES shared secret for all
+    /// media tracks and data channels.
+    pub fn set_e2ee_key(&mut self, key: Vec<u8>) {
+        self.shared_key = Some(key);
     }
 
     /// Declare a video track.

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -271,6 +271,12 @@ impl Portal {
 
         let mut options = RoomOptions::default();
         options.auto_subscribe = true;
+        if let Some(key) = &self.config.shared_key {
+            use livekit::e2ee::{key_provider::{KeyProvider, KeyProviderOptions}, EncryptionType};
+            use livekit::E2eeOptions;
+            let key_provider = KeyProvider::with_shared_key(KeyProviderOptions::default(), key.clone());
+            options.encryption = Some(E2eeOptions { key_provider, encryption_type: EncryptionType::Gcm });
+        }
 
         log::info!("[{}] connecting as {:?} to {}", self.config.session, self.config.role, url);
 

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -300,7 +300,7 @@ def _wrap_action(
 ) -> Action:
     return Action(
         values=_cast_values(action.values, schema),
-        raw_values=dict(action.values),
+        raw_values=action.values,
         timestamp_us=action.timestamp_us,
         in_reply_to_ts_us=action.in_reply_to_ts_us,
     )
@@ -335,7 +335,7 @@ def _wrap_action_chunk(
     don't pay an unwanted widening on receipt.
     """
     fields = schema_by_name.get(chunk.name, [])
-    raw_data: Dict[str, List[float]] = {k: list(v) for k, v in chunk.data.items()}
+    raw_data: Dict[str, List[float]] = chunk.data
     if _np is None:
         # numpy is a hard runtime dep on this package, so this branch only
         # exists for hypothetical embedded builds. Hand back the raw lists
@@ -364,7 +364,7 @@ def _wrap_state(
 ) -> State:
     return State(
         values=_cast_values(state.values, schema),
-        raw_values=dict(state.values),
+        raw_values=state.values,
         timestamp_us=state.timestamp_us,
     )
 
@@ -374,8 +374,8 @@ def _wrap_observation(
 ) -> Observation:
     return Observation(
         state=_cast_values(obs.state, state_schema),
-        raw_state=dict(obs.state),
-        frames=dict(obs.frames),
+        raw_state=obs.state,
+        frames=obs.frames,
         timestamp_us=obs.timestamp_us,
     )
 
@@ -739,6 +739,13 @@ class PortalConfig:
 
     def set_ping_ms(self, ms: int) -> None:
         self._inner.set_ping_ms(ms)
+
+    def set_e2ee_key(self, key: bytes) -> None:
+        """Set a shared E2EE key. Both peers must call this with the same key
+        before connecting. The key is used as a GCM-AES shared secret for all
+        media tracks and data channels.
+        """
+        self._inner.set_e2ee_key(list(key))
 
     def set_reuse_stale_frames(self, enable: bool) -> None:
         """Reuse the most recent already-emitted frame on a track when the

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -745,7 +745,7 @@ class PortalConfig:
         before connecting. The key is used as a GCM-AES shared secret for all
         media tracks and data channels.
         """
-        self._inner.set_e2ee_key(list(key))
+        self._inner.set_e2ee_key(bytes(key))
 
     def set_reuse_stale_frames(self, enable: bool) -> None:
         """Reuse the most recent already-emitted frame on a track when the

--- a/python/packages/livekit-portal/livekit/portal/_frame.py
+++ b/python/packages/livekit-portal/livekit/portal/_frame.py
@@ -34,20 +34,18 @@ def normalize_rgb(
             raise ValueError(f"width mismatch: array is {w}, argument is {width}")
         if height is not None and height != h:
             raise ValueError(f"height mismatch: array is {h}, argument is {height}")
-        contiguous = np.ascontiguousarray(frame)
-        return contiguous.tobytes(), w, h
+        return frame.tobytes(), w, h
 
     if isinstance(frame, (bytes, bytearray, memoryview)):
         if width is None or height is None:
             raise ValueError("width and height are required when frame is raw bytes")
-        data = bytes(frame)
         expected = width * height * 3
-        if len(data) != expected:
+        if len(frame) != expected:
             raise ValueError(
                 f"raw RGB frame size mismatch: expected {expected} bytes "
-                f"(W*H*3 = {width}*{height}*3), got {len(data)}"
+                f"(W*H*3 = {width}*{height}*3), got {len(frame)}"
             )
-        return data, width, height
+        return frame if isinstance(frame, bytes) else bytes(frame), width, height
 
     raise TypeError(
         f"unsupported frame type: {type(frame).__name__}. Pass bytes or np.ndarray (H,W,3) uint8."

--- a/python/packages/livekit-portal/tests/integration/conftest.py
+++ b/python/packages/livekit-portal/tests/integration/conftest.py
@@ -36,7 +36,7 @@ API_SECRET = os.environ.get("LIVEKIT_API_SECRET", "secret")
 collect_ignore = (
     []
     if URL
-    else ["test_chunks.py", "test_frame_video.py", "test_frame_video_stress.py"]
+    else ["test_chunks.py", "test_frame_video.py", "test_frame_video_stress.py", "test_e2ee.py"]
 )
 
 

--- a/python/packages/livekit-portal/tests/integration/test_e2ee.py
+++ b/python/packages/livekit-portal/tests/integration/test_e2ee.py
@@ -1,0 +1,207 @@
+"""Integration tests for E2EE shared-key support against a live LiveKit server.
+
+Three scenarios:
+
+  * Matching key on both sides — state and frames arrive, observations form.
+  * Mismatched keys — encrypted packets arrive but decrypt as garbage;
+    Portal's deserialization rejects them and no observations form.
+  * No key on one side — unencrypted packets can't be read by an E2EE-enabled
+    peer (or vice versa); no observations form.
+
+Skipped automatically when `LIVEKIT_URL` isn't set (see conftest).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+import numpy as np
+import pytest
+
+from livekit.portal import (
+    DType,
+    Observation,
+    Portal,
+    PortalConfig,
+    Role,
+    VideoCodec,
+)
+
+pytestmark = pytest.mark.asyncio
+
+KEY_A = os.urandom(32)
+KEY_B = os.urandom(32)  # guaranteed different from A (astronomically)
+
+# E2EE adds frame-cryptor setup on track publish/subscribe; give it more
+# settle time than plain data-channel tests need.
+SETTLE_S = 1.2
+
+
+def _rgb_frame(seed: int = 0) -> np.ndarray:
+    x = np.arange(32, dtype=np.int32)
+    y = np.arange(32, dtype=np.int32)[:, None]
+    r = np.broadcast_to((x + seed) % 256, (32, 32)).astype(np.uint8)
+    g = np.broadcast_to((y + seed) % 256, (32, 32)).astype(np.uint8)
+    b = np.broadcast_to((x + y + seed) % 256, (32, 32)).astype(np.uint8)
+    return np.stack([r, g, b], axis=-1)
+
+
+_URL = os.environ.get("LIVEKIT_URL")
+_API_KEY = os.environ.get("LIVEKIT_API_KEY", "devkey")
+_API_SECRET = os.environ.get("LIVEKIT_API_SECRET", "secret")
+
+
+def _e2ee_pair(key: bytes | None, operator_key: bytes | None = "same") -> tuple:
+    """Return (robot_cfg, operator_cfg, url, robot_tok, op_tok) for a fresh room.
+    `operator_key` defaults to `"same"` meaning use the same key as robot.
+    Pass an explicit bytes value (or None) to override."""
+    import datetime
+    from livekit import api
+
+    URL, API_KEY, API_SECRET = _URL, _API_KEY, _API_SECRET
+
+    room = f"e2ee-{int(time.time() * 1000)}-{os.urandom(2).hex()}"
+    op_key = key if operator_key == "same" else operator_key
+
+    robot_cfg = PortalConfig(room, Role.ROBOT)
+    operator_cfg = PortalConfig(room, Role.OPERATOR)
+    for cfg in (robot_cfg, operator_cfg):
+        cfg.add_video("cam", codec=VideoCodec.PNG)
+        cfg.add_state_typed([("j", DType.F32)])
+        cfg.add_action_typed([("j", DType.F32)])
+
+    if key is not None:
+        robot_cfg.set_e2ee_key(key)
+    if op_key is not None:
+        operator_cfg.set_e2ee_key(op_key)
+
+    def _token(identity: str) -> str:
+        grants = api.VideoGrants(
+            room_join=True, room=room, can_publish=True, can_subscribe=True
+        )
+        return (
+            api.AccessToken(API_KEY, API_SECRET)
+            .with_identity(identity)
+            .with_grants(grants)
+            .with_ttl(datetime.timedelta(hours=1))
+            .to_jwt()
+        )
+
+    return robot_cfg, operator_cfg, URL, _token("robot"), _token("operator")
+
+
+# ---------------------------------------------------------------------------
+# Matching key: data must flow end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_e2ee_matching_key_observations_arrive():
+    """Robot and operator share the same key. State + frame should pair
+    into at least one observation on the operator side."""
+    robot_cfg, operator_cfg, url, robot_tok, op_tok = _e2ee_pair(KEY_A)
+
+    robot = Portal(robot_cfg)
+    operator = Portal(operator_cfg)
+    obs: list[Observation] = []
+    operator.on_observation(lambda o: obs.append(o))
+
+    try:
+        await robot.connect(url, robot_tok)
+        await asyncio.sleep(0.2)
+        await operator.connect(url, op_tok)
+        await asyncio.sleep(0.3)
+
+        ts = int(time.time() * 1_000_000)
+        robot.send_video_frame("cam", _rgb_frame(seed=1), timestamp_us=ts)
+        robot.send_state({"j": 0.5}, timestamp_us=ts)
+        await asyncio.sleep(SETTLE_S)
+
+        assert len(obs) >= 1, (
+            "expected at least one observation with matching E2EE key; "
+            f"got {len(obs)}"
+        )
+        assert "cam" in obs[-1].frames
+        assert abs(obs[-1].state["j"] - 0.5) < 1e-3
+    finally:
+        await operator.disconnect()
+        await robot.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Mismatched keys: data must NOT form valid observations
+# ---------------------------------------------------------------------------
+
+
+async def test_e2ee_mismatched_keys_no_observations():
+    """Robot uses KEY_A, operator uses KEY_B. Packets arrive at the
+    operator but decrypt as garbage; no valid observations should form."""
+    robot_cfg, operator_cfg, url, robot_tok, op_tok = _e2ee_pair(
+        KEY_A, operator_key=KEY_B
+    )
+
+    robot = Portal(robot_cfg)
+    operator = Portal(operator_cfg)
+    obs: list[Observation] = []
+    operator.on_observation(lambda o: obs.append(o))
+
+    try:
+        await robot.connect(url, robot_tok)
+        await asyncio.sleep(0.2)
+        await operator.connect(url, op_tok)
+        await asyncio.sleep(0.3)
+
+        ts = int(time.time() * 1_000_000)
+        for _ in range(5):
+            robot.send_video_frame("cam", _rgb_frame(), timestamp_us=ts)
+            robot.send_state({"j": 0.5}, timestamp_us=ts)
+            ts += 33_333
+
+        await asyncio.sleep(SETTLE_S)
+
+        assert len(obs) == 0, (
+            f"expected no observations with mismatched E2EE keys; got {len(obs)}"
+        )
+    finally:
+        await operator.disconnect()
+        await robot.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# One side unencrypted: data must NOT form valid observations
+# ---------------------------------------------------------------------------
+
+
+async def test_e2ee_only_robot_encrypted_no_observations():
+    """Robot sets a key, operator does not. Robot's outbound packets are
+    E2EE-encrypted; the operator has no key to decrypt them. No valid
+    observations should arrive."""
+    robot_cfg, operator_cfg, url, robot_tok, op_tok = _e2ee_pair(
+        KEY_A, operator_key=None
+    )
+
+    robot = Portal(robot_cfg)
+    operator = Portal(operator_cfg)
+    obs: list[Observation] = []
+    operator.on_observation(lambda o: obs.append(o))
+
+    try:
+        await robot.connect(url, robot_tok)
+        await asyncio.sleep(0.2)
+        await operator.connect(url, op_tok)
+        await asyncio.sleep(0.3)
+
+        ts = int(time.time() * 1_000_000)
+        for _ in range(5):
+            robot.send_video_frame("cam", _rgb_frame(), timestamp_us=ts)
+            robot.send_state({"j": 0.5}, timestamp_us=ts)
+            ts += 33_333
+
+        await asyncio.sleep(SETTLE_S)
+
+        assert len(obs) == 0, (
+            f"expected no observations when only robot is encrypted; got {len(obs)}"
+        )
+    finally:
+        await operator.disconnect()
+        await robot.disconnect()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ members = ["packages/*"]
 
 [dependency-groups]
 dev = [
+    "livekit-api>=1.1.0",
     "pytest>=8",
     "pytest-asyncio>=0.23",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -852,7 +852,6 @@ wheels = [
 
 [[package]]
 name = "lerobot-robot-livekit"
-version = "0.1.0"
 source = { editable = "packages/lerobot-robot-livekit" }
 dependencies = [
     { name = "lerobot" },
@@ -869,7 +868,6 @@ requires-dist = [
 
 [[package]]
 name = "lerobot-teleoperator-livekit"
-version = "0.1.0"
 source = { editable = "packages/lerobot-teleoperator-livekit" }
 dependencies = [
     { name = "lerobot" },
@@ -902,7 +900,6 @@ wheels = [
 
 [[package]]
 name = "livekit-portal"
-version = "0.1.0"
 source = { editable = "packages/livekit-portal" }
 dependencies = [
     { name = "numpy" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -941,6 +941,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "livekit-api" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -954,6 +955,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "livekit-api", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
 ]


### PR DESCRIPTION
## Summary

- Adds `PortalConfig.set_e2ee_key(key: bytes)` (Python), `set_e2ee_key(key: Vec<u8>)` (Rust core + FFI)
- When set, Portal builds an AES-GCM `E2eeOptions` with a shared `KeyProvider` and passes it to `RoomOptions.encryption` at connect time — covers all media tracks and data channels
- Both peers must call `set_e2ee_key` with the same key before `connect()`
- Adds `docs/e2ee.md` (key generation, distribution, coverage table, mismatch behavior) and links it from `docs/portal-api.md`

## Usage

```python
import os
cfg = PortalConfig("session-1", Role.ROBOT)
cfg.set_e2ee_key(os.environ["PORTAL_E2EE_KEY"].encode())
portal = Portal(cfg)
await portal.connect(url, token)
```

## Test plan

Tested against a local LiveKit server (`livekit-server --dev`) with `tests/integration/test_e2ee.py`:

- [x] **Matching key on both sides** — state + PNG frame pair into observations normally (`test_e2ee_matching_key_observations_arrive`)
- [x] **Mismatched keys** — robot uses KEY_A, operator uses KEY_B; encrypted packets arrive but decrypt as garbage, Portal's deserializer rejects them, zero observations form (`test_e2ee_mismatched_keys_no_observations`)
- [x] **One side unencrypted** — robot sets a key, operator does not; no valid observations arrive (`test_e2ee_only_robot_encrypted_no_observations`)

All 3 tests pass in ~6s on localhost.

Also caught and fixed during testing: `set_e2ee_key` was passing `list(key)` to the FFI but UniFFI maps `Vec<u8>` to `bytes` — fixed to `bytes(key)`.