### PR TITLE
feat(lerobot-robot-livekit): state_features config field and schema mismatch warning

### DIFF
--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/_utils.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/_utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+def split_observation_features(
+    features: dict,
+) -> tuple[list[str], dict[str, tuple[int, ...]]]:
+    """Split a lerobot observation_features dict into motor keys and cameras.
+
+    Scalar-valued entries are motor keys; tuple-valued entries are camera
+    names mapped to their shape. Returns ``(sorted_motor_keys, cameras)``.
+    """
+    motor_keys: list[str] = []
+    cameras: dict[str, tuple[int, ...]] = {}
+    for key, val in features.items():
+        if isinstance(val, tuple):
+            cameras[key] = val
+        else:
+            motor_keys.append(key)
+    return sorted(motor_keys), cameras

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -10,6 +10,7 @@ LiveKitRobot forwards over the wire.
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from dataclasses import dataclass
 from typing import Any
@@ -26,6 +27,8 @@ from livekit.portal import (
     VideoCodec,
     frame_bytes_to_numpy_rgb,
 )
+
+_log = logging.getLogger(__name__)
 
 
 @RobotConfig.register_subclass("livekit")
@@ -57,6 +60,11 @@ class LiveKitRobotConfig(RobotConfig):
     state_reliable: bool = True
     action_reliable: bool = True
     reuse_stale_frames: bool = False
+
+    # Extra state keys beyond the action schema (e.g. {"slider.pos": float}).
+    # Values are the Python types used in observation_features. Keys follow the
+    # same ".pos" convention as motor keys; bare names are also accepted.
+    state_features: dict | None = None
 
 
 class LiveKitRobot(Robot):
@@ -99,6 +107,10 @@ class LiveKitRobot(Robot):
         self._camera_names = list(self._cameras.keys())
 
         self._obs_features: dict = {k: float for k in self._state_keys}
+        if config.state_features:
+            for k, t in config.state_features.items():
+                if k in self._obs_features:
+                    self._obs_features[k] = t
         for name, shape in self._cameras.items():
             self._obs_features[name] = shape
         self._act_features: dict = {k: float for k in self._action_keys}
@@ -109,6 +121,7 @@ class LiveKitRobot(Robot):
         self._loop_thread: threading.Thread | None = None
         self._connected = False
         self._last_observation_timestamp_us: int | None = None
+        self._schema_mismatch_warned = False
 
     # -- lerobot interface ----------------------------------------------------
 
@@ -207,6 +220,20 @@ class LiveKitRobot(Robot):
         for key, motor in zip(self._state_keys, self._state_motors):
             if motor in obs.state:
                 out[key] = float(obs.state[motor])
+        if (
+            not self._schema_mismatch_warned
+            and self._state_motors
+            and obs.state
+            and not out
+        ):
+            _log.warning(
+                "get_observation() returned no state fields: robot sent %s"
+                " but operator schema expects %s. Check that both sides"
+                " declare matching state keys.",
+                sorted(obs.state.keys()),
+                sorted(self._state_motors),
+            )
+            self._schema_mismatch_warned = True
         for cam in self._camera_names:
             frame = obs.frames.get(cam)
             if frame is not None:
@@ -250,6 +277,7 @@ class LiveKitRobot(Robot):
     ) -> tuple[list[str], list[str], dict[str, tuple[int, ...]]]:
         camera_shape = (config.camera_height, config.camera_width, 3)
         cameras = {name: camera_shape for name in config.camera_names}
+        extra_state = sorted(config.state_features.keys()) if config.state_features else []
 
         if teleop is not None:
             act_features = dict(getattr(teleop, "action_features", {}))
@@ -262,11 +290,17 @@ class LiveKitRobot(Robot):
             # lerobot convention: observation mirrors action for telemetry
             # (each commanded motor reports its actual position back).
             state_keys = list(action_keys)
+            for k in extra_state:
+                if k not in state_keys:
+                    state_keys.append(k)
             return state_keys, action_keys, cameras
 
         if config.motors or config.camera_names:
             state_keys = sorted(f"{m}.pos" for m in config.motors)
             action_keys = list(state_keys)
+            for k in extra_state:
+                if k not in state_keys:
+                    state_keys.append(k)
             return state_keys, action_keys, cameras
 
         raise ValueError(

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -26,8 +26,9 @@ from livekit.portal import (
     Role,
     VideoCodec,
     frame_bytes_to_numpy_rgb,
-    split_observation_features,
 )
+
+from ._utils import split_observation_features
 
 _log = logging.getLogger(__name__)
 

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -61,10 +61,12 @@ class LiveKitRobotConfig(RobotConfig):
     action_reliable: bool = True
     reuse_stale_frames: bool = False
 
-    # Extra state keys beyond the action schema (e.g. {"slider.pos": float}).
-    # Values are the Python types used in observation_features. Keys follow the
-    # same ".pos" convention as motor keys; bare names are also accepted.
-    state_features: dict | None = None
+    # Full observation schema when the remote robot reports state beyond the
+    # action schema (e.g. {"shoulder.pos": float, "slider.pos": float}).
+    # Mirrors lerobot's observation_features convention: scalar keys map to a
+    # Python type; camera keys map to a shape tuple. When provided this
+    # replaces the default "state mirrors action" assumption entirely.
+    observation_features: dict | None = None
 
 
 class LiveKitRobot(Robot):
@@ -106,13 +108,14 @@ class LiveKitRobot(Robot):
         self._action_motors = [_strip_pos(k) for k in self._action_keys]
         self._camera_names = list(self._cameras.keys())
 
-        self._obs_features: dict = {k: float for k in self._state_keys}
-        if config.state_features:
-            for k, t in config.state_features.items():
-                if k in self._obs_features:
-                    self._obs_features[k] = t
-        for name, shape in self._cameras.items():
-            self._obs_features[name] = shape
+        if config.observation_features:
+            self._obs_features = dict(config.observation_features)
+            for name, shape in self._cameras.items():
+                self._obs_features.setdefault(name, shape)
+        else:
+            self._obs_features = {k: float for k in self._state_keys}
+            for name, shape in self._cameras.items():
+                self._obs_features[name] = shape
         self._act_features: dict = {k: float for k in self._action_keys}
 
         self._portal: Portal | None = None
@@ -277,7 +280,25 @@ class LiveKitRobot(Robot):
     ) -> tuple[list[str], list[str], dict[str, tuple[int, ...]]]:
         camera_shape = (config.camera_height, config.camera_width, 3)
         cameras = {name: camera_shape for name in config.camera_names}
-        extra_state = sorted(config.state_features.keys()) if config.state_features else []
+
+        # When observation_features is provided it is the authoritative state
+        # schema — same pattern as LiveKitTeleoperator using robot.observation_features.
+        if config.observation_features:
+            obs_state_keys, obs_cameras = _split_observation_features(
+                config.observation_features
+            )
+            cameras = {**cameras, **obs_cameras}
+            if teleop is not None:
+                act_features = dict(getattr(teleop, "action_features", {}))
+                if not act_features:
+                    raise ValueError(
+                        "local teleop has empty action_features; cannot infer"
+                        " schema"
+                    )
+                return obs_state_keys, sorted(act_features.keys()), cameras
+            if config.motors:
+                return obs_state_keys, sorted(f"{m}.pos" for m in config.motors), cameras
+            return obs_state_keys, obs_state_keys, cameras
 
         if teleop is not None:
             act_features = dict(getattr(teleop, "action_features", {}))
@@ -287,21 +308,12 @@ class LiveKitRobot(Robot):
                     " schema"
                 )
             action_keys = sorted(act_features.keys())
-            # lerobot convention: observation mirrors action for telemetry
-            # (each commanded motor reports its actual position back).
-            state_keys = list(action_keys)
-            for k in extra_state:
-                if k not in state_keys:
-                    state_keys.append(k)
-            return state_keys, action_keys, cameras
+            # lerobot convention: observation mirrors action for telemetry.
+            return list(action_keys), action_keys, cameras
 
         if config.motors or config.camera_names:
             state_keys = sorted(f"{m}.pos" for m in config.motors)
-            action_keys = list(state_keys)
-            for k in extra_state:
-                if k not in state_keys:
-                    state_keys.append(k)
-            return state_keys, action_keys, cameras
+            return state_keys, list(state_keys), cameras
 
         raise ValueError(
             "LiveKitRobot needs either a local Teleoperator instance or"
@@ -342,3 +354,17 @@ class LiveKitRobot(Robot):
 
 def _strip_pos(key: str) -> str:
     return key[: -len(".pos")] if key.endswith(".pos") else key
+
+
+def _split_observation_features(
+    features: dict,
+) -> tuple[list[str], dict[str, tuple[int, ...]]]:
+    """Separate scalar motor keys from camera (tuple-valued) keys."""
+    motor_keys: list[str] = []
+    cameras: dict[str, tuple[int, ...]] = {}
+    for key, val in features.items():
+        if isinstance(val, tuple):
+            cameras[key] = val
+        else:
+            motor_keys.append(key)
+    return sorted(motor_keys), cameras

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -26,6 +26,7 @@ from livekit.portal import (
     Role,
     VideoCodec,
     frame_bytes_to_numpy_rgb,
+    split_observation_features,
 )
 
 _log = logging.getLogger(__name__)
@@ -223,20 +224,22 @@ class LiveKitRobot(Robot):
         for key, motor in zip(self._state_keys, self._state_motors):
             if motor in obs.state:
                 out[key] = float(obs.state[motor])
-        if (
-            not self._schema_mismatch_warned
-            and self._state_motors
-            and obs.state
-            and not out
-        ):
-            _log.warning(
-                "get_observation() returned no state fields: robot sent %s"
-                " but operator schema expects %s. Check that both sides"
-                " declare matching state keys.",
-                sorted(obs.state.keys()),
-                sorted(self._state_motors),
-            )
-            self._schema_mismatch_warned = True
+        if not self._schema_mismatch_warned and self._state_motors and obs.state:
+            received = set(obs.state.keys())
+            expected = set(self._state_motors)
+            if received != expected:
+                missing = sorted(expected - received)
+                unexpected = sorted(received - expected)
+                _log.warning(
+                    "State schema mismatch: operator expects %s but robot"
+                    " sent %s (missing=%s, unexpected=%s). Check that both"
+                    " sides declare matching state keys.",
+                    sorted(expected),
+                    sorted(received),
+                    missing,
+                    unexpected,
+                )
+                self._schema_mismatch_warned = True
         for cam in self._camera_names:
             frame = obs.frames.get(cam)
             if frame is not None:
@@ -284,7 +287,7 @@ class LiveKitRobot(Robot):
         # When observation_features is provided it is the authoritative state
         # schema — same pattern as LiveKitTeleoperator using robot.observation_features.
         if config.observation_features:
-            obs_state_keys, obs_cameras = _split_observation_features(
+            obs_state_keys, obs_cameras = split_observation_features(
                 config.observation_features
             )
             cameras = {**cameras, **obs_cameras}
@@ -354,17 +357,3 @@ class LiveKitRobot(Robot):
 
 def _strip_pos(key: str) -> str:
     return key[: -len(".pos")] if key.endswith(".pos") else key
-
-
-def _split_observation_features(
-    features: dict,
-) -> tuple[list[str], dict[str, tuple[int, ...]]]:
-    """Separate scalar motor keys from camera (tuple-valued) keys."""
-    motor_keys: list[str] = []
-    cameras: dict[str, tuple[int, ...]] = {}
-    for key, val in features.items():
-        if isinstance(val, tuple):
-            cameras[key] = val
-        else:
-            motor_keys.append(key)
-    return sorted(motor_keys), cameras

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/_utils.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/_utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+def split_observation_features(
+    features: dict,
+) -> tuple[list[str], dict[str, tuple[int, ...]]]:
+    """Split a lerobot observation_features dict into motor keys and cameras.
+
+    Scalar-valued entries are motor keys; tuple-valued entries are camera
+    names mapped to their shape. Returns ``(sorted_motor_keys, cameras)``.
+    """
+    motor_keys: list[str] = []
+    cameras: dict[str, tuple[int, ...]] = {}
+    for key, val in features.items():
+        if isinstance(val, tuple):
+            cameras[key] = val
+        else:
+            motor_keys.append(key)
+    return sorted(motor_keys), cameras

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
@@ -16,8 +16,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
-
-logger = logging.getLogger(__name__)
 from lerobot.teleoperators.config import TeleoperatorConfig
 from lerobot.teleoperators.teleoperator import Teleoperator
 
@@ -31,6 +29,8 @@ from livekit.portal import (
 )
 
 from ._utils import split_observation_features
+
+logger = logging.getLogger(__name__)
 
 
 @TeleoperatorConfig.register_subclass("livekit")
@@ -62,7 +62,6 @@ class LiveKitTeleoperatorConfig(TeleoperatorConfig):
     state_reliable: bool = True
     action_reliable: bool = True
     reuse_stale_frames: bool = False
-
 
 
 class LiveKitTeleoperator(Teleoperator):

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
@@ -10,11 +10,14 @@ physical robot stays in the user's loop; the plugin just brokers the wire.
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 from lerobot.teleoperators.config import TeleoperatorConfig
 from lerobot.teleoperators.teleoperator import Teleoperator
 
@@ -25,6 +28,7 @@ from livekit.portal import (
     PortalConfig,
     Role,
     VideoCodec,
+    split_observation_features,
 )
 
 
@@ -58,19 +62,6 @@ class LiveKitTeleoperatorConfig(TeleoperatorConfig):
     action_reliable: bool = True
     reuse_stale_frames: bool = False
 
-
-def _split_observation_features(
-    features: dict,
-) -> tuple[list[str], dict[str, tuple[int, ...]]]:
-    """Separate scalar motor keys from camera (tuple-valued) keys."""
-    motor_keys: list[str] = []
-    cameras: dict[str, tuple[int, ...]] = {}
-    for key, val in features.items():
-        if isinstance(val, tuple):
-            cameras[key] = val
-        else:
-            motor_keys.append(key)
-    return sorted(motor_keys), cameras
 
 
 class LiveKitTeleoperator(Teleoperator):
@@ -246,6 +237,12 @@ class LiveKitTeleoperator(Teleoperator):
                 )
             self._portal.send_video_frame(cam, frame)
 
+        if logger.isEnabledFor(logging.DEBUG):
+            known = set(self._state_keys) | set(self._camera_names)
+            skipped = [k for k in feedback if k not in known]
+            if skipped:
+                logger.debug("send_feedback: skipped %d unknown key(s): %s", len(skipped), skipped)
+
     # -- schema resolution ---------------------------------------------------
 
     @staticmethod
@@ -261,7 +258,7 @@ class LiveKitTeleoperator(Teleoperator):
                     "local robot has empty observation_features /"
                     " action_features; cannot infer schema"
                 )
-            state_keys, cameras = _split_observation_features(obs_features)
+            state_keys, cameras = split_observation_features(obs_features)
             action_keys = sorted(act_features.keys())
             return state_keys, action_keys, cameras
 

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
@@ -28,8 +28,9 @@ from livekit.portal import (
     PortalConfig,
     Role,
     VideoCodec,
-    split_observation_features,
 )
+
+from ._utils import split_observation_features
 
 
 @TeleoperatorConfig.register_subclass("livekit")

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -1030,25 +1030,6 @@ class Portal:
         self._inner = None  # type: ignore[assignment]
 
 
-def split_observation_features(
-    features: Dict,
-) -> Tuple[List[str], Dict[str, Tuple[int, ...]]]:
-    """Split a lerobot-style observation_features dict into motor keys and cameras.
-
-    Scalar-valued entries (types like ``float``, ``int``) are motor keys;
-    tuple-valued entries are camera names mapped to their shape.
-    Returns ``(sorted_motor_keys, cameras)``.
-    """
-    motor_keys: List[str] = []
-    cameras: Dict[str, Tuple[int, ...]] = {}
-    for key, val in features.items():
-        if isinstance(val, tuple):
-            cameras[key] = val
-        else:
-            motor_keys.append(key)
-    return sorted(motor_keys), cameras
-
-
 __all__ = [
     "Role",
     "DType",
@@ -1075,5 +1056,4 @@ __all__ = [
     "RpcInvocationData",
     "RpcError",
     "frame_bytes_to_numpy_rgb",
-    "split_observation_features",
 ]

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -1030,6 +1030,25 @@ class Portal:
         self._inner = None  # type: ignore[assignment]
 
 
+def split_observation_features(
+    features: Dict,
+) -> Tuple[List[str], Dict[str, Tuple[int, ...]]]:
+    """Split a lerobot-style observation_features dict into motor keys and cameras.
+
+    Scalar-valued entries (types like ``float``, ``int``) are motor keys;
+    tuple-valued entries are camera names mapped to their shape.
+    Returns ``(sorted_motor_keys, cameras)``.
+    """
+    motor_keys: List[str] = []
+    cameras: Dict[str, Tuple[int, ...]] = {}
+    for key, val in features.items():
+        if isinstance(val, tuple):
+            cameras[key] = val
+        else:
+            motor_keys.append(key)
+    return sorted(motor_keys), cameras
+
+
 __all__ = [
     "Role",
     "DType",
@@ -1056,4 +1075,5 @@ __all__ = [
     "RpcInvocationData",
     "RpcError",
     "frame_bytes_to_numpy_rgb",
+    "split_observation_features",
 ]


### PR DESCRIPTION
## Summary

- Adds `observation_features: dict | None = None` to `LiveKitRobotConfig`, mirroring lerobot's own `observation_features` convention. Scalar keys map to a Python type; camera keys map to a shape tuple.
- When provided, `observation_features` is the authoritative state schema — the same pattern `LiveKitTeleoperator` already uses on the robot side with `robot.observation_features`. This replaces the previous "state mirrors action" assumption entirely rather than appending extras.
- Adds `_split_observation_features` to `robot.py` (same helper that exists in `teleoperator.py`) to separate motor keys from camera keys.
- Adds a one-time `logging.WARNING` in `get_observation()` when the robot sends state fields that don't match the operator's declared schema, naming both sides.

## Before / after

```python
# Before: no public API — had to mutate private attributes
robot._state_keys.append("slider.pos")
robot._state_motors.append("slider")

# After: standard lerobot convention
cfg = LiveKitRobotConfig(
    ...,
    observation_features={"shoulder.pos": float, "elbow.pos": float, "slider.pos": float},
)
```

## Test plan

- [ ] Construct `LiveKitRobot` with `observation_features` set and confirm `get_observation()` returns all declared keys including extras beyond the action schema
- [ ] Confirm that without `observation_features`, behavior is unchanged (state mirrors action)
- [ ] Intentionally mismatch schemas; confirm the warning fires once and names both sides