### PR TITLE
feat(lerobot-robot-livekit): add action_features config field

### DIFF
--- a/docs/lerobot.md
+++ b/docs/lerobot.md
@@ -164,6 +164,37 @@ LiveKitRobotConfig(
 
 The dict follows lerobot's own `observation_features` convention: scalar types for motors, shape tuples for cameras. The robot side must declare and send the same keys via its `send_feedback` call.
 
+### Declaring action keys explicitly
+
+When your action keys differ from the observation keys and can't be expressed as `"{motor}.pos"` names, set `action_features` on the config. It is the explicit action schema used when no local `Teleoperator` is passed.
+
+```python
+LiveKitRobotConfig(
+    ...,
+    observation_features={
+        "shoulder.pos": float,
+        "elbow.pos": float,
+        "slider.pos": float,
+    },
+    action_features={
+        "shoulder.pos": float,
+        "elbow.pos": float,
+        # slider is read-only — not commanded
+    },
+)
+```
+
+You can also use `action_features` without `observation_features`. In that case, state is assumed to mirror the action schema (the default lerobot convention):
+
+```python
+LiveKitRobotConfig(
+    ...,
+    action_features={"gripper.pos": float, "wrist.vel": float},
+)
+```
+
+`action_features` is ignored when a local `Teleoperator` is passed — the teleop's `action_features` always take precedence.
+
 ### CLI mode
 
 If you instantiate via `--robot.type=livekit`, supply `motors` on the config:
@@ -203,6 +234,7 @@ Operator-only (`LiveKitRobotConfig`):
 | `camera_height` | `480` | Camera shape advertised in `observation_features` (metadata only — Portal accepts any resolution at runtime). |
 | `camera_width` | `640` | See above. |
 | `observation_features` | `None` | Full state schema when the robot reports state beyond the action keys (e.g. `{"shoulder.pos": float, "slider.pos": float}`). When set, replaces the default "state mirrors action" assumption. Follows lerobot's `observation_features` convention: scalar types for motors, shape tuples for cameras. |
+| `action_features` | `None` | Explicit action schema when action keys differ from observation keys and can't be derived from `motors` (e.g. `{"gripper.pos": float, "wrist.vel": float}`). Ignored when a local `Teleoperator` is passed. |
 
 See [tuning.md](tuning.md) for the math behind `fps`, `slack`, and `tolerance`.
 
@@ -238,4 +270,4 @@ The loop also handles Portal's callback dispatch, so if you ever want to registe
 | High `states_dropped` | Encoder is throttling or a camera stopped publishing. Compare `portal.metrics().transport.frames_received` (operator) with `frames_sent` (robot). |
 | `WrongRole` `PortalError` | You're calling `send_action` on the robot side or `send_state`/`send_video_frame` on the operator side. Role is fixed at `PortalConfig` construction. |
 | `InvalidFrameDimensions` | Frame width or height is odd. Portal requires even dimensions for I420 chroma subsampling. |
-| `ValueError: ... cannot infer schema` | Constructor got neither a local instance nor `motors`/`camera_names` on the config. Pass one or the other. |
+| `ValueError: ... cannot infer schema` | Constructor got neither a local instance nor `motors`/`action_features`/`camera_names` on the config. Pass one or the other. |

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -70,6 +70,13 @@ class LiveKitRobotConfig(RobotConfig):
     # replaces the default "state mirrors action" assumption entirely.
     observation_features: dict | None = None
 
+    # Explicit action schema when action keys differ from observation keys and
+    # cannot be derived from config.motors (e.g. {"gripper.pos": float,
+    # "wrist.vel": float}). Follows the same scalar-type convention as
+    # observation_features. Ignored when a local Teleoperator is passed — the
+    # teleop's action_features take precedence.
+    action_features: dict | None = None
+
 
 class LiveKitRobot(Robot):
     """lerobot Robot that receives synced observations from a remote physical
@@ -118,7 +125,10 @@ class LiveKitRobot(Robot):
             self._obs_features = {k: float for k in self._state_keys}
             for name, shape in self._cameras.items():
                 self._obs_features[name] = shape
-        self._act_features: dict = {k: float for k in self._action_keys}
+        if config.action_features and teleop is None:
+            self._act_features: dict = dict(config.action_features)
+        else:
+            self._act_features: dict = {k: float for k in self._action_keys}
 
         self._portal: Portal | None = None
         self._portal_cfg: PortalConfig | None = None
@@ -300,6 +310,8 @@ class LiveKitRobot(Robot):
                         " schema"
                     )
                 return obs_state_keys, sorted(act_features.keys()), cameras
+            if config.action_features:
+                return obs_state_keys, sorted(config.action_features.keys()), cameras
             if config.motors:
                 return obs_state_keys, sorted(f"{m}.pos" for m in config.motors), cameras
             return obs_state_keys, obs_state_keys, cameras
@@ -315,13 +327,18 @@ class LiveKitRobot(Robot):
             # lerobot convention: observation mirrors action for telemetry.
             return list(action_keys), action_keys, cameras
 
+        if config.action_features:
+            action_keys = sorted(config.action_features.keys())
+            return list(action_keys), action_keys, cameras
+
         if config.motors or config.camera_names:
             state_keys = sorted(f"{m}.pos" for m in config.motors)
             return state_keys, list(state_keys), cameras
 
         raise ValueError(
             "LiveKitRobot needs either a local Teleoperator instance or"
-            " config.motors / config.camera_names to derive its schema"
+            " config.motors / config.action_features / config.camera_names to"
+            " derive its schema"
         )
 
     # -- background loop plumbing --------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `action_features: dict | None = None` to `LiveKitRobotConfig`
- Wires it into `_resolve_schema` as the explicit action schema when no local `Teleoperator` is passed — higher priority than `config.motors`, lower than a live teleop instance
- Works with or without `observation_features`: standalone (state mirrors action) or alongside it (disjoint obs/action schemas)
- Documents the new field in the config reference table and with a dedicated "Declaring action keys explicitly" section

## Test plan

- [ ] No teleop, `action_features` only: action keys match provided dict; state keys mirror action
- [ ] No teleop, `observation_features` + `action_features`: state keys from obs, action keys from action_features
- [ ] No teleop, `observation_features` only (no `action_features`, no `motors`): state and action keys both come from obs (existing behavior unchanged)
- [ ] Teleop passed alongside `action_features`: teleop wins, `action_features` is ignored