### PR TITLE
feat(config-file): YAML loader for PortalConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +51,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +72,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "askama"
@@ -816,6 +846,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1205,16 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e736dfe3881c53a7dce0685eb18202d0d9fe6911782f9870946eb9ee89d778"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1805,6 +1863,8 @@ dependencies = [
  "livekit",
  "log",
  "parking_lot",
+ "serde",
+ "serde-saphyr",
  "thiserror 2.0.18",
  "tokio",
  "yuv-sys",
@@ -1929,6 +1989,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3030,6 +3096,25 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc7fe48e34d02a97bc8e6253b8b91e5a47fe2c47eaacb5149cefbb69922eaf0"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -277,6 +277,11 @@ uv run robot.py                 # terminal 1
 uv run teleoperator.py          # terminal 2
 ```
 
+The same directory ships `robot_yaml.py` / `teleoperator_yaml.py`, which
+load the wire contract from a shared [`portal.yaml`](examples/python/basic/portal.yaml)
+instead of declaring it in code. See [Config from YAML](docs/config-file.md)
+for the schema reference.
+
 **[`examples/python/inference/`](examples/python/inference)**
 
 VLA-style remote inference. The robot streams obs to a remote "policy"
@@ -336,6 +341,7 @@ this. A direct socket is enough.
 | [Quickstart](docs/quickstart.md) | Install, tokens, first run with `Robot` and `Operator` |
 | [Portal API](docs/portal-api.md) | The primary surface. `Robot`, `Operator`, callbacks, send methods, multi-controller |
 | [Concepts](docs/concepts.md) | Roles, the observation model, multi-controller, frame format |
+| [Config from YAML](docs/config-file.md) | Build `RobotConfig` / `OperatorConfig` from a shareable YAML file |
 | [Tuning](docs/tuning.md) | `fps`, `slack`, `tolerance`, asymmetric rates, reliability |
 | [RPC](docs/rpc.md) | Imperative commands (`home`, `calibrate`, ...) on top of LiveKit RPC |
 | [Synchronization deep dive](docs/synchronization.md) | The full match algorithm, cursor bookkeeping, complexity |

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1,0 +1,157 @@
+# Config from YAML
+
+`PortalConfig`, `RobotConfig`, and `OperatorConfig` can be built from a YAML
+file. The YAML describes the **shareable wire contract** — schemas, video
+tracks, sync knobs. Identity (`session`, `role`, E2EE key) is supplied at
+load time so the same file is reusable across the robot side and the
+operator side and contains no secrets.
+
+```python
+from livekit.portal import RobotConfig
+
+cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
+robot = Robot(cfg)
+```
+
+The Rust core does the parsing and validation. Bad codec names, unknown
+dtypes, duplicate track names, zero horizons, and unknown top-level keys
+all raise `ConfigFileError` with a message pointing at the offending
+field. The same file produces an equivalent `PortalConfig` whether you
+load it from Python, the FFI, or the Rust crate directly — there's only
+one parser.
+
+## Quick example
+
+```yaml
+version: 1
+fps: 30
+
+videos:
+  - { name: cam1, codec: h264 }
+
+state:
+  - { name: j1, dtype: f32 }
+  - { name: j2, dtype: f32 }
+  - { name: gripper, dtype: bool }
+
+action:
+  - { name: j1, dtype: f32 }
+  - { name: j2, dtype: f32 }
+  - { name: gripper, dtype: bool }
+```
+
+```python
+from livekit.portal import OperatorConfig, RobotConfig
+
+robot_cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
+op_cfg = OperatorConfig.from_yaml_file("portal.yaml", "session-1")
+```
+
+A runnable end-to-end version lives at
+[`examples/python/basic/`](../examples/python/basic) — `portal.yaml` plus
+`robot_yaml.py` / `teleoperator_yaml.py`.
+
+## Schema reference
+
+### Top level
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `version` | int | required | Major version of the file format. Currently `1`. Unknown majors are rejected. |
+| `fps` | int | `30` | Observation rate. Drives `search_range = tolerance / fps`. |
+| `slack` | int | `5` | Pipeline headroom in tick intervals. |
+| `tolerance` | float | `1.5` | State/frame match window in tick intervals. See [tuning](tuning.md). |
+| `state_reliable` | bool | `true` | Reliable transport for state packets. |
+| `action_reliable` | bool | `true` | Reliable transport for action packets. |
+| `reuse_stale_frames` | bool | `false` | Reuse the most recent frame on a track when the current state has no in-range match. |
+| `ping_ms` | int | `1000` | RTT ping cadence in ms. `0` disables active pinging on this side. |
+| `action_subscription` | bool | `false` | Operator-side opt-in for receiving executed actions (HITL recording). No-op on the robot side. |
+| `videos` | list | `[]` | Declared video tracks. See below. |
+| `state` | list | `[]` | Declared state schema. List of `{name, dtype}`. |
+| `action` | list | `[]` | Declared action schema. List of `{name, dtype}`. |
+| `action_chunks` | list | `[]` | Declared action chunks. See below. |
+
+### `videos`
+
+```yaml
+videos:
+  - { name: front, codec: h264 }
+  - { name: wrist, codec: mjpeg, quality: 90 }
+  - { name: depth, codec: png }
+  - { name: raw, codec: raw }
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Track name. Unique across all `videos` entries. |
+| `codec` | string | One of `h264`, `mjpeg`, `png`, `raw`. Case-insensitive. `h264` rides the WebRTC media path; the others ride per-frame byte streams. |
+| `quality` | int (optional) | `1..=100` for `mjpeg`. Defaults to `90`. Ignored for `raw`, `png`, `h264`. |
+
+### `state` and `action`
+
+```yaml
+state:
+  - { name: joint_pos, dtype: f32 }
+  - { name: gripper, dtype: bool }
+  - { name: mode, dtype: i8 }
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Field name. |
+| `dtype` | string | One of `f64`, `f32`, `i32`, `i16`, `i8`, `u32`, `u16`, `u8`, `bool`. Case-insensitive. |
+
+Order is significant. Both peers must declare the same fields in the
+same order, or the schema fingerprint differs and packets are dropped.
+
+### `action_chunks`
+
+```yaml
+action_chunks:
+  - name: vla
+    horizon: 16
+    fields:
+      - { name: joint_pos, dtype: f32 }
+      - { name: gripper, dtype: bool }
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Chunk name. Unique per Portal. |
+| `horizon` | int | Number of timesteps per published chunk. Must be `> 0`. |
+| `fields` | list | Per-field schema, same shape as `state` / `action`. |
+
+## What's not in the file
+
+Three things are deliberately omitted and must be supplied at load time
+or set on the loaded config:
+
+- **`session`** — passed as the second positional arg to
+  `from_yaml_str` / `from_yaml_file`.
+- **`role`** — passed as the third arg to `PortalConfig.from_yaml_*`.
+  `RobotConfig` and `OperatorConfig` pin it for you.
+- **`shared_key`** (E2EE) — call `cfg.set_e2ee_key(key)` after loading.
+  Keep keys out of config repos.
+
+## Errors
+
+`ConfigFileError` is raised on:
+
+- YAML parse failures (malformed, unknown top-level keys, missing
+  `version`, wrong types).
+- Unknown major version.
+- Validation failures: duplicate track names, duplicate chunk names,
+  zero horizon, out-of-range MJPEG quality, `fps` / `slack` /
+  `tolerance` set to zero or negative.
+
+Catch it like any other exception:
+
+```python
+from livekit.portal import ConfigFileError, RobotConfig
+
+try:
+    cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
+except ConfigFileError as e:
+    print(f"bad config: {e}")
+    raise
+```

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1,24 +1,45 @@
 # Config from YAML
 
-`PortalConfig`, `RobotConfig`, and `OperatorConfig` can be built from a YAML
-file. The YAML describes the **shareable wire contract** — schemas, video
-tracks, sync knobs. Identity (`session`, `role`, E2EE key) is supplied at
-load time so the same file is reusable across the robot side and the
-operator side and contains no secrets.
+`PortalConfig`, `RobotConfig`, and `OperatorConfig` can be built from a
+YAML file. The file describes the **shareable wire contract** —
+schemas, video tracks, sync knobs. Identity (`session`, `role`, E2EE
+key) is supplied at load time, so the same file is reusable across the
+robot and operator processes and never holds a secret.
 
 ```python
 from livekit.portal import RobotConfig
 
 cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
-robot = Robot(cfg)
 ```
 
-The Rust core does the parsing and validation. Bad codec names, unknown
-dtypes, duplicate track names, zero horizons, and unknown top-level keys
-all raise `ConfigFileError` with a message pointing at the offending
-field. The same file produces an equivalent `PortalConfig` whether you
-load it from Python, the FFI, or the Rust crate directly — there's only
-one parser.
+The Rust core does the parsing and validation. Bad codec names,
+unknown dtypes, duplicate track names, zero horizons, and unknown
+top-level keys all raise `ConfigFileError` with a message pointing at
+the offending field. The same file produces an equivalent
+`PortalConfig` whether you load it from Python, the FFI, or the Rust
+crate — there is exactly one parser.
+
+A runnable end-to-end version lives at
+[`examples/python/basic/`](../examples/python/basic) — `portal.yaml`
+plus `robot_yaml.py` / `teleoperator_yaml.py`.
+
+## Loading API
+
+Every `*Config` class exposes the same two entry points.
+
+```python
+PortalConfig.from_yaml_str(yaml: str, session: str, role: Role) -> PortalConfig
+PortalConfig.from_yaml_file(path: str | os.PathLike, session: str, role: Role) -> PortalConfig
+
+RobotConfig.from_yaml_str(yaml: str, session: str) -> RobotConfig
+RobotConfig.from_yaml_file(path: str | os.PathLike, session: str) -> RobotConfig
+
+OperatorConfig.from_yaml_str(yaml: str, session: str) -> OperatorConfig
+OperatorConfig.from_yaml_file(path: str | os.PathLike, session: str) -> OperatorConfig
+```
+
+`RobotConfig` / `OperatorConfig` pin the role for you. Use them
+unless you have a reason to drive the unified `PortalConfig` directly.
 
 ## Quick example
 
@@ -47,11 +68,61 @@ robot_cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
 op_cfg = OperatorConfig.from_yaml_file("portal.yaml", "session-1")
 ```
 
-A runnable end-to-end version lives at
-[`examples/python/basic/`](../examples/python/basic) — `portal.yaml` plus
-`robot_yaml.py` / `teleoperator_yaml.py`.
+## Kitchen-sink example
 
-## Schema reference
+Every field the loader understands, set explicitly. Treat this as the
+"all knobs at once" reference. None of these fields are required
+except `version`.
+
+```yaml
+version: 1
+
+# Sync and pacing
+fps: 30                      # observation rate
+slack: 5                     # pipeline headroom (tick intervals)
+tolerance: 1.5               # state/frame match window (tick intervals)
+
+# Transport reliability
+state_reliable: true         # SCTP reliable for state packets
+action_reliable: true        # SCTP reliable for action packets
+
+# Sync behavior
+reuse_stale_frames: false    # freeze frames during loss instead of dropping state
+
+# Heartbeat
+ping_ms: 1000                # RTT ping cadence; 0 disables active pinging on this side
+
+# Operator-only opt-in
+action_subscription: false   # operator receives executed actions (HITL recording)
+
+# Video tracks
+videos:
+  - { name: front, codec: h264 }
+  - { name: wrist, codec: mjpeg, quality: 90 }
+  - { name: depth, codec: png }
+  - { name: raw_test, codec: raw }
+
+# Wire schemas (state from robot, action from operator)
+state:
+  - { name: joint_pos, dtype: f32 }
+  - { name: gripper, dtype: bool }
+  - { name: mode, dtype: i8 }
+
+action:
+  - { name: joint_pos, dtype: f32 }
+  - { name: gripper, dtype: bool }
+  - { name: mode, dtype: i8 }
+
+# VLA-style fixed-horizon batched action
+action_chunks:
+  - name: vla
+    horizon: 16
+    fields:
+      - { name: joint_pos, dtype: f32 }
+      - { name: gripper, dtype: bool }
+```
+
+## Per-section reference
 
 ### Top level
 
@@ -63,37 +134,62 @@ A runnable end-to-end version lives at
 | `tolerance` | float | `1.5` | State/frame match window in tick intervals. See [tuning](tuning.md). |
 | `state_reliable` | bool | `true` | Reliable transport for state packets. |
 | `action_reliable` | bool | `true` | Reliable transport for action packets. |
-| `reuse_stale_frames` | bool | `false` | Reuse the most recent frame on a track when the current state has no in-range match. |
-| `ping_ms` | int | `1000` | RTT ping cadence in ms. `0` disables active pinging on this side. |
+| `reuse_stale_frames` | bool | `false` | Reuse the most recent frame on a track when the current state has no in-range match. See [tuning](tuning.md). |
+| `ping_ms` | int | `1000` | RTT ping cadence in ms. `0` disables active pinging on this side; the pong path stays active so the peer can still measure. |
 | `action_subscription` | bool | `false` | Operator-side opt-in for receiving executed actions (HITL recording). No-op on the robot side. |
 | `videos` | list | `[]` | Declared video tracks. See below. |
 | `state` | list | `[]` | Declared state schema. List of `{name, dtype}`. |
 | `action` | list | `[]` | Declared action schema. List of `{name, dtype}`. |
 | `action_chunks` | list | `[]` | Declared action chunks. See below. |
 
+Anything else at the top level is a hard error. The loader uses
+`deny_unknown_fields`, so a misspelled `tolarance: 1.5` raises rather
+than being silently ignored.
+
 ### `videos`
 
 ```yaml
 videos:
-  - { name: front, codec: h264 }
-  - { name: wrist, codec: mjpeg, quality: 90 }
-  - { name: depth, codec: png }
-  - { name: raw, codec: raw }
+  - { name: front,    codec: h264 }                   # WebRTC media path
+  - { name: wrist,    codec: mjpeg, quality: 90 }     # byte-stream, lossy
+  - { name: depth,    codec: png }                    # byte-stream, lossless
+  - { name: raw_cam,  codec: raw }                    # byte-stream, uncompressed RGB
 ```
 
 | Field | Type | Description |
 |---|---|---|
 | `name` | string | Track name. Unique across all `videos` entries. |
-| `codec` | string | One of `h264`, `mjpeg`, `png`, `raw`. Case-insensitive. `h264` rides the WebRTC media path; the others ride per-frame byte streams. |
+| `codec` | string | One of `h264`, `mjpeg`, `png`, `raw`. Case-insensitive (`H264` works too). |
 | `quality` | int (optional) | `1..=100` for `mjpeg`. Defaults to `90`. Ignored for `raw`, `png`, `h264`. |
+
+Codec choice picks both the encoding and the wire transport:
+
+- **`h264`** — WebRTC media path. Real-time RTP/SRTP, lossy, best-effort
+  delivery. libwebrtc picks the operating bitrate. Lowest end-to-end
+  latency at scale.
+- **`mjpeg`** — per-frame byte-stream, lossy. ~10-20x compression at
+  q=90. Sub-millisecond decode. Each frame is independent.
+- **`png`** — per-frame byte-stream, lossless. ~2-3x compression on
+  natural images.
+- **`raw`** — per-frame byte-stream, uncompressed RGB24. Largest
+  payload, zero encode cost. Caller passes dimensions in the framing
+  header.
+
+See [frame video](frame-video.md) for codec selection guidance and
+latency math.
 
 ### `state` and `action`
 
 ```yaml
 state:
   - { name: joint_pos, dtype: f32 }
-  - { name: gripper, dtype: bool }
-  - { name: mode, dtype: i8 }
+  - { name: gripper,   dtype: bool }
+  - { name: mode,      dtype: i8 }
+
+action:
+  - { name: joint_pos, dtype: f32 }
+  - { name: gripper,   dtype: bool }
+  - { name: mode,      dtype: i8 }
 ```
 
 | Field | Type | Description |
@@ -101,10 +197,20 @@ state:
 | `name` | string | Field name. |
 | `dtype` | string | One of `f64`, `f32`, `i32`, `i16`, `i8`, `u32`, `u16`, `u8`, `bool`. Case-insensitive. |
 
-Order is significant. Both peers must declare the same fields in the
-same order, or the schema fingerprint differs and packets are dropped.
+**Order is significant.** Both peers must declare the same fields in
+the same order, with the same dtypes. The schema fingerprint is
+computed from this list — any disagreement (rename, reorder, dtype
+flip) drops packets at the receiver with a warning.
+
+Numbers cast to and from the declared dtype at the wire boundary, with
+saturation on integer overflow (e.g., `mode: 500` → `i8::MAX = 127`,
+flagged as saturated).
 
 ### `action_chunks`
+
+A chunk is a fixed-horizon batch of typed per-field values published
+as one packet. Use this for VLA-style policies that emit a horizon of
+future actions per inference step.
 
 ```yaml
 action_chunks:
@@ -112,7 +218,13 @@ action_chunks:
     horizon: 16
     fields:
       - { name: joint_pos, dtype: f32 }
-      - { name: gripper, dtype: bool }
+      - { name: gripper,   dtype: bool }
+  - name: pose_targets
+    horizon: 4
+    fields:
+      - { name: x,   dtype: f32 }
+      - { name: y,   dtype: f32 }
+      - { name: yaw, dtype: f32 }
 ```
 
 | Field | Type | Description |
@@ -121,30 +233,77 @@ action_chunks:
 | `horizon` | int | Number of timesteps per published chunk. Must be `> 0`. |
 | `fields` | list | Per-field schema, same shape as `state` / `action`. |
 
-## What's not in the file
+Multiple chunks are allowed. Each is dispatched to its own callback by
+schema fingerprint, so chunk names are unique per Portal but
+cross-Portal collisions are impossible by construction.
 
-Three things are deliberately omitted and must be supplied at load time
-or set on the loaded config:
+The chunk's payload travels as a LiveKit byte stream (not a data
+packet), so it isn't bounded by the 15 KB packet limit.
+
+## What's *not* in the file
+
+Three things are deliberately omitted and must be supplied at load
+time or set on the loaded config:
 
 - **`session`** — passed as the second positional arg to
   `from_yaml_str` / `from_yaml_file`.
 - **`role`** — passed as the third arg to `PortalConfig.from_yaml_*`.
   `RobotConfig` and `OperatorConfig` pin it for you.
-- **`shared_key`** (E2EE) — call `cfg.set_e2ee_key(key)` after loading.
-  Keep keys out of config repos.
+- **`shared_key`** (E2EE) — call `cfg.set_e2ee_key(key)` after
+  loading. Keep keys out of config repos.
+
+The split is intentional. A YAML file describes a wire contract and is
+meant to be checked in, shared, or templated. Identity and secrets
+belong in your environment, your token-mint pipeline, or your secrets
+manager.
+
+```python
+import os
+from livekit.portal import RobotConfig
+
+cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
+cfg.set_e2ee_key(os.environ["PORTAL_E2EE_KEY"].encode())
+```
+
+## YAML ↔ programmatic equivalence
+
+The loader produces the same `PortalConfig` you would build by hand.
+This table maps each YAML field to the setter or builder call it
+ends up making.
+
+| YAML field | Equivalent code |
+|---|---|
+| `fps` | `cfg.set_fps(...)` |
+| `slack` | `cfg.set_slack(...)` |
+| `tolerance` | `cfg.set_tolerance(...)` |
+| `state_reliable` | `cfg.set_state_reliable(...)` |
+| `action_reliable` | `cfg.set_action_reliable(...)` |
+| `reuse_stale_frames` | `cfg.set_reuse_stale_frames(...)` |
+| `ping_ms` | `cfg.set_ping_ms(...)` |
+| `action_subscription` | `cfg.set_action_subscription(...)` |
+| `videos[]` | `cfg.add_video(name, codec, quality)` |
+| `state[]` | `cfg.add_state_typed([...])` |
+| `action[]` | `cfg.add_action_typed([...])` |
+| `action_chunks[]` | `cfg.add_action_chunk(name, horizon, fields)` |
+
+Two configs built from the same YAML and from the matching code path
+are observably identical: same schema fingerprints, same registered
+tracks, same sync config.
 
 ## Errors
 
-`ConfigFileError` is raised on:
+`ConfigFileError` is raised in four situations:
 
-- YAML parse failures (malformed, unknown top-level keys, missing
-  `version`, wrong types).
-- Unknown major version.
-- Validation failures: duplicate track names, duplicate chunk names,
-  zero horizon, out-of-range MJPEG quality, `fps` / `slack` /
-  `tolerance` set to zero or negative.
-
-Catch it like any other exception:
+1. **`Parse`** — YAML parse failures, including unknown top-level
+   keys, missing `version`, wrong types for known keys, and bad
+   codec/dtype strings. The message contains the position the parser
+   was at when it gave up.
+2. **`UnsupportedVersion { got, supported }`** — the file declares a
+   `version` the build doesn't know how to read.
+3. **`Invalid`** — pre-flight validation failures. Duplicate track
+   names, duplicate chunk names, `horizon: 0`, MJPEG quality outside
+   `1..=100`, `fps` / `slack` / `tolerance` set to zero or negative.
+4. **`Io`** — `from_yaml_file` only. The file couldn't be opened.
 
 ```python
 from livekit.portal import ConfigFileError, RobotConfig
@@ -155,3 +314,113 @@ except ConfigFileError as e:
     print(f"bad config: {e}")
     raise
 ```
+
+In Python, `ConfigFileError` is a `flat_error` (UniFFI), so each
+variant is a subclass you can catch individually if you want to:
+
+```python
+try:
+    cfg = RobotConfig.from_yaml_str(yaml, "demo")
+except ConfigFileError.UnsupportedVersion as e:
+    # Bumped the file format; downgrade or upgrade the SDK.
+    ...
+except ConfigFileError.Invalid as e:
+    # Schema bug. Surface to the human.
+    ...
+except ConfigFileError as e:
+    # Catch-all (parse, io).
+    ...
+```
+
+## Validation walk-through
+
+A handful of common mistakes and what the loader does with them.
+
+```yaml
+# tolarance is a typo of tolerance.
+version: 1
+tolarance: 1.5
+```
+
+→ `ConfigFileError.Parse(...)`: unknown field `tolarance`. The
+parser uses `deny_unknown_fields` everywhere, so misspellings never
+silently no-op.
+
+```yaml
+version: 1
+videos:
+  - { name: cam, codec: h264 }
+  - { name: cam, codec: mjpeg, quality: 80 }
+```
+
+→ `ConfigFileError.Invalid("duplicate video track 'cam'")`. Track
+names must be unique across all `videos` entries regardless of
+codec.
+
+```yaml
+version: 1
+videos:
+  - { name: cam, codec: vp8 }
+```
+
+→ `ConfigFileError.Parse(...)`: unknown codec `vp8`. The codec set
+is closed: `h264`, `raw`, `png`, `mjpeg`.
+
+```yaml
+version: 1
+state:
+  - { name: x, dtype: float64 }
+```
+
+→ `ConfigFileError.Parse(...)`: unknown dtype `float64`. The Portal
+dtype names are short: `f64`, `f32`, `i32`, `i16`, `i8`, `u32`,
+`u16`, `u8`, `bool`.
+
+```yaml
+version: 1
+videos:
+  - { name: cam, codec: mjpeg, quality: 0 }
+```
+
+→ `ConfigFileError.Invalid("video 'cam': mjpeg quality must be in
+1..=100, got 0")`. Quality range is enforced for MJPEG only;
+omitting `quality` falls back to `90`.
+
+```yaml
+version: 1
+action_chunks:
+  - { name: vla, horizon: 0, fields: [{ name: x, dtype: f32 }] }
+```
+
+→ `ConfigFileError.Invalid("action chunk 'vla' horizon must be > 0")`.
+
+```yaml
+version: 99
+```
+
+→ `ConfigFileError.UnsupportedVersion { got: 99, supported: 1 }`.
+Bumping the file format is a deliberate, named operation; the
+loader will not silently misparse a future format.
+
+## Sharing and templating
+
+Portal configs are deliberately small enough to live next to your
+code or to be templated by your deployment pipeline. A few patterns
+people land on:
+
+- **Single file in the repo.** Both robot and operator load the same
+  `portal.yaml` from the same path. Add `LIVEKIT_*` to `.env.example`
+  and let session naming flow through the room name.
+- **Per-robot file plus a template.** One `portal_so101.yaml`,
+  `portal_widowx.yaml`, etc. Pick the file at boot. Useful when the
+  hardware genuinely changes the wire shape.
+- **Generated at deploy time.** Render the YAML from a templating
+  layer (Jinja, Helm chart, etc.) so production schemas are derived
+  rather than hand-edited.
+- **Versioned alongside the code.** Bump `version` (and the SDK) in
+  lockstep. The loader rejects unknown majors, so a stale operator
+  trying to read a newer file fails loudly instead of silently
+  drifting.
+
+Whatever you pick, the contract is the same: identity and secrets
+stay out of the file, everything else is fair game.

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -401,6 +401,23 @@ op.metrics() / op.reset_metrics()
 await op.connect(url, token) / await op.disconnect()
 ```
 
+## Loading a config from YAML
+
+`RobotConfig`, `OperatorConfig`, and `PortalConfig` each have
+`from_yaml_str` / `from_yaml_file` classmethods that build the config
+from a shareable YAML file. The file describes the wire contract only
+— schemas, video tracks, sync knobs — and `session`, `role`, and the
+E2EE key are supplied at the call site. The same file is reusable
+across the robot and operator processes.
+
+```python
+from livekit.portal import RobotConfig
+
+cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
+```
+
+See [Config from YAML](config-file.md) for the schema reference.
+
 ## End-to-end encryption
 
 Call `cfg.set_e2ee_key(key: bytes)` before `connect`. Both peers must use the
@@ -436,6 +453,8 @@ exposes; runtime behavior is identical. New code should usually pick
 ## Reference
 
 - [Concepts](concepts.md). Roles, observation model, frame format.
+- [Config from YAML](config-file.md). Build configs from a shareable
+  file instead of declaring them in code.
 - [Frame video](frame-video.md). Codec choice, latency math, wire format
   for byte-stream-based per-frame video.
 - [Tuning](tuning.md). `fps`, `slack`, `tolerance`, asymmetric rates.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -245,5 +245,7 @@ and CLI mode: [lerobot integration](lerobot.md).
 - [Portal API](portal-api.md). The full surface. All callbacks, send
   methods, role semantics.
 - [Concepts](concepts.md). Roles, the observation model, frame format.
+- [Config from YAML](config-file.md). Build the same configs from a
+  shareable file so the wire contract lives in one place.
 - [Tuning](tuning.md). `fps`, `slack`, `tolerance`, asymmetric rates,
   reliability.

--- a/examples/python/basic/portal.yaml
+++ b/examples/python/basic/portal.yaml
@@ -1,0 +1,30 @@
+# Example portal config matching the basic/ robot.py + teleoperator.py
+# scripts. Loaded via `RobotConfig.from_yaml_file(...)` and
+# `OperatorConfig.from_yaml_file(...)` in robot_yaml.py / teleoperator_yaml.py.
+#
+# The file describes the shareable wire contract only: schemas, video
+# tracks, sync knobs. Identity (session, role, E2EE key) is supplied at
+# load time so the same file is reusable across robot and operator.
+
+version: 1
+
+fps: 30
+
+videos:
+  - { name: cam1, codec: h264 }
+
+# Mixed-dtype state and action schema. Both peers must declare the same
+# fields in the same order; a fingerprint mismatch drops the packets.
+state:
+  - { name: j1, dtype: f32 }
+  - { name: j2, dtype: f32 }
+  - { name: j3, dtype: f32 }
+  - { name: gripper, dtype: bool }
+  - { name: mode, dtype: i8 }
+
+action:
+  - { name: j1, dtype: f32 }
+  - { name: j2, dtype: f32 }
+  - { name: j3, dtype: f32 }
+  - { name: gripper, dtype: bool }
+  - { name: mode, dtype: i8 }

--- a/examples/python/basic/robot_yaml.py
+++ b/examples/python/basic/robot_yaml.py
@@ -1,0 +1,107 @@
+"""Same as `robot.py`, but loads the wire contract from `portal.yaml`.
+
+The schema (state / action fields, video tracks, fps) lives in the YAML
+so robot and operator share one file. Only role, session, and runtime
+behavior live in code.
+
+Usage:
+    cp .env.example .env   # fill in API_KEY / API_SECRET
+    uv run robot_yaml.py
+"""
+from __future__ import annotations
+
+import asyncio
+import math
+import pathlib
+import time
+
+from livekit.portal import Action, Robot, RobotConfig, RpcInvocationData
+from _common import _dump_metrics, env_float, env_int, load_env, mint_token, periodic_metrics, required_env
+from robot import _make_frame  # reuse the shared test-pattern generator
+
+IDENTITY = "robot"
+TRACK_NAME = "cam1"
+CONFIG_PATH = pathlib.Path(__file__).parent / "portal.yaml"
+
+
+async def main() -> None:
+    load_env()
+    url = required_env("LIVEKIT_URL")
+    room = required_env("LIVEKIT_ROOM")
+    token = mint_token(IDENTITY, room)
+    width = env_int("PORTAL_FRAME_WIDTH", 320)
+    height = env_int("PORTAL_FRAME_HEIGHT", 240)
+    duration = env_float("PORTAL_DURATION_SECONDS", 30.0)
+
+    # The whole declarative surface comes from YAML. `session` (the room
+    # name) is supplied here; everything else is in the file.
+    cfg = RobotConfig.from_yaml_file(CONFIG_PATH, room)
+    fps = env_int("PORTAL_FPS", 30)  # matches the YAML default
+
+    robot_portal = Robot(cfg)
+
+    actions_received = 0
+
+    def on_action(action: Action) -> None:
+        nonlocal actions_received
+        actions_received += 1
+        if actions_received % max(1, fps) == 0:
+            print(
+                f"[robot] action #{actions_received}: ts={action.timestamp_us} "
+                f"values={action.values} from={robot_portal.active_operator()}"
+            )
+
+    robot_portal.on_action(on_action)
+
+    def say(data: RpcInvocationData) -> str:
+        print(f"[robot] operator says: {data.payload}")
+        return "ok"
+
+    robot_portal.register_rpc_method("say", say)
+
+    print(f"[robot] connecting to {url} as '{IDENTITY}' in room '{room}' ...")
+    print(f"[robot] config loaded from {CONFIG_PATH}")
+    await robot_portal.connect(url, token)
+    print(f"[robot] connected; streaming at {fps} fps for {duration:.0f}s")
+
+    metrics_task = asyncio.create_task(periodic_metrics(robot_portal, "[robot]", interval=2.0))
+
+    try:
+        n_frames = int(duration * fps)
+        interval = 1.0 / fps
+        start = time.monotonic()
+        next_tick = start
+        for i in range(n_frames):
+            phase = i / fps
+            frame = _make_frame(width, height, phase)
+            ts_us = int(time.time() * 1_000_000)
+            robot_portal.send_video_frame(TRACK_NAME, frame, timestamp_us=ts_us)
+            robot_portal.send_state(
+                {
+                    "j1": math.sin(phase),
+                    "j2": math.cos(phase),
+                    "j3": 0.1 * phase,
+                    "gripper": int(phase) % 2 == 0,
+                    "mode": int(phase) % 3,
+                },
+                timestamp_us=ts_us,
+            )
+            next_tick += interval
+            sleep_for = next_tick - time.monotonic()
+            if sleep_for > 0:
+                await asyncio.sleep(sleep_for)
+
+        _dump_metrics("[robot]", robot_portal.metrics())
+    finally:
+        metrics_task.cancel()
+        try:
+            await metrics_task
+        except asyncio.CancelledError:
+            pass
+        print("[robot] disconnecting...")
+        await robot_portal.disconnect()
+        robot_portal.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/basic/teleoperator_yaml.py
+++ b/examples/python/basic/teleoperator_yaml.py
@@ -1,0 +1,107 @@
+"""Same as `teleoperator.py`, but loads the wire contract from
+`portal.yaml` — the same file the robot uses.
+
+Usage:
+    cp .env.example .env  # fill in API_KEY / API_SECRET
+    uv run teleoperator_yaml.py
+"""
+from __future__ import annotations
+
+import asyncio
+import math
+import pathlib
+import time
+
+from livekit.portal import Observation, Operator, OperatorConfig
+from _common import _dump_metrics, env_float, env_int, load_env, mint_token, periodic_metrics, required_env
+
+IDENTITY = "teleoperator"
+TRACK_NAME = "cam1"
+CONFIG_PATH = pathlib.Path(__file__).parent / "portal.yaml"
+
+
+async def main() -> None:
+    load_env()
+    url = required_env("LIVEKIT_URL")
+    room = required_env("LIVEKIT_ROOM")
+    token = mint_token(IDENTITY, room)
+    fps = env_int("PORTAL_FPS", 30)
+    duration = env_float("PORTAL_DURATION_SECONDS", 30.0)
+
+    cfg = OperatorConfig.from_yaml_file(CONFIG_PATH, room)
+
+    op = Operator(cfg)
+
+    observations = 0
+    drops = 0
+    last_log = time.monotonic()
+
+    def on_observation(obs: Observation) -> None:
+        nonlocal observations, last_log
+        observations += 1
+        now = time.monotonic()
+        if now - last_log >= 1.0:
+            frame = obs.frames.get(TRACK_NAME)
+            frame_desc = f"{frame.width}x{frame.height}" if frame else "none"
+            print(
+                f"[operator] obs #{observations}: ts={obs.timestamp_us} "
+                f"state={obs.state} frame={frame_desc}"
+            )
+            last_log = now
+
+    def on_drop(dropped: list[dict]) -> None:
+        nonlocal drops
+        drops += len(dropped)
+        print(f"[operator] {len(dropped)} state(s) dropped (total {drops})")
+
+    op.on_observation(on_observation)
+    op.on_drop(on_drop)
+
+    print(f"[operator] connecting to {url} as '{IDENTITY}' in room '{room}' ...")
+    print(f"[operator] config loaded from {CONFIG_PATH}")
+    await op.connect(url, token)
+    print(f"[operator] connected; echoing actions at {fps} fps for {duration:.0f}s")
+
+    await op.set_active_operator(op.local_identity())
+    print(f"[operator] claimed control as '{op.local_identity()}'")
+
+    metrics_task = asyncio.create_task(periodic_metrics(op, "[operator]", interval=2.0))
+
+    try:
+        interval = 1.0 / fps
+        n_ticks = int(duration * fps)
+        start = time.monotonic()
+        next_tick = start
+        for i in range(n_ticks):
+            phase = i / fps
+            ts_us = int(time.time() * 1_000_000)
+            op.send_action(
+                {
+                    "j1": 0.5 * math.sin(phase * 2),
+                    "j2": 0.5 * math.cos(phase * 2),
+                    "j3": 0.0,
+                    "gripper": int(phase) % 2 == 0,
+                    "mode": i % 4,
+                },
+                timestamp_us=ts_us,
+            )
+            next_tick += interval
+            sleep_for = next_tick - time.monotonic()
+            if sleep_for > 0:
+                await asyncio.sleep(sleep_for)
+
+        print(f"[operator] observations={observations} drops={drops}")
+        _dump_metrics("[operator]", op.metrics())
+    finally:
+        metrics_task.cancel()
+        try:
+            await metrics_task
+        except asyncio.CancelledError:
+            pass
+        print("[operator] disconnecting...")
+        await op.disconnect()
+        op.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -385,6 +385,36 @@ impl From<core::PortalError> for PortalError {
 
 pub type PortalResult<T> = Result<T, PortalError>;
 
+/// Errors raised by `PortalConfig::from_yaml_str`. Mirrors
+/// `livekit_portal::ConfigFileError` and is exposed as its own UniFFI
+/// error type so bindings can catch YAML problems separately from
+/// runtime portal failures.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi(flat_error)]
+pub enum ConfigFileError {
+    #[error("yaml parse error: {0}")]
+    Parse(String),
+    #[error("io error: {0}")]
+    Io(String),
+    #[error("unsupported config-file version {got}; this build supports version {supported}")]
+    UnsupportedVersion { got: u32, supported: u32 },
+    #[error("invalid config: {0}")]
+    Invalid(String),
+}
+
+impl From<core::ConfigFileError> for ConfigFileError {
+    fn from(e: core::ConfigFileError) -> Self {
+        match e {
+            core::ConfigFileError::Parse(s) => ConfigFileError::Parse(s),
+            core::ConfigFileError::Io(e) => ConfigFileError::Io(e.to_string()),
+            core::ConfigFileError::UnsupportedVersion { got, supported } => {
+                ConfigFileError::UnsupportedVersion { got, supported }
+            }
+            core::ConfigFileError::Invalid(s) => ConfigFileError::Invalid(s),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // RPC types
 // ---------------------------------------------------------------------------
@@ -482,6 +512,21 @@ impl PortalConfig {
         Arc::new(Self { inner: Mutex::new(core::PortalConfig::new(session, role.into())) })
     }
 
+    /// Build a `PortalConfig` from a YAML string. The file describes the
+    /// shareable wire contract (schemas, video tracks, sync knobs);
+    /// `session` and `role` are supplied here because they're per-process
+    /// identity. The shared E2EE key, when used, must be applied with
+    /// `set_e2ee_key` after loading.
+    #[uniffi::constructor]
+    pub fn from_yaml_str(
+        yaml: String,
+        session: String,
+        role: Role,
+    ) -> Result<Arc<Self>, ConfigFileError> {
+        let cfg = core::PortalConfig::from_yaml_str(&yaml, session, role.into())?;
+        Ok(Arc::new(Self { inner: Mutex::new(cfg) }))
+    }
+
     /// Declare a video track. `codec` picks both the encoding and the wire
     /// transport: `H264` rides the WebRTC media path; `Mjpeg`, `Png`, and
     /// `Raw` ride a reliable per-frame byte-stream channel and the
@@ -554,6 +599,53 @@ impl PortalConfig {
     /// No-op on the Robot side — the robot always processes actions.
     pub fn set_action_subscription(&self, enable: bool) {
         self.inner.lock().set_action_subscription(enable);
+    }
+
+    /// Declared WebRTC video track names (H264).
+    pub fn video_tracks(&self) -> Vec<String> {
+        self.inner.lock().video_tracks().to_vec()
+    }
+
+    /// Declared byte-stream video tracks (Raw / Png / Mjpeg) with codec
+    /// and per-codec quality.
+    pub fn frame_video_tracks(&self) -> Vec<FrameVideoSpec> {
+        self.inner
+            .lock()
+            .frame_video_tracks()
+            .iter()
+            .map(|s| FrameVideoSpec {
+                name: s.name.clone(),
+                codec: s.codec.into(),
+                quality: s.quality,
+            })
+            .collect()
+    }
+
+    /// Declared state schema, in declaration order.
+    pub fn state_schema(&self) -> Vec<FieldSpec> {
+        self.inner
+            .lock()
+            .state_schema()
+            .iter()
+            .map(|f| FieldSpec { name: f.name.clone(), dtype: f.dtype.into() })
+            .collect()
+    }
+
+    /// Declared action schema, in declaration order.
+    pub fn action_schema(&self) -> Vec<FieldSpec> {
+        self.inner
+            .lock()
+            .action_schema()
+            .iter()
+            .map(|f| FieldSpec { name: f.name.clone(), dtype: f.dtype.into() })
+            .collect()
+    }
+
+    /// Declared action chunks. Used by bindings that load a config from
+    /// YAML and need to mirror chunk schemas into their own typed-state
+    /// tracking after construction.
+    pub fn action_chunks(&self) -> Vec<ChunkSpec> {
+        self.inner.lock().action_chunks().iter().map(chunkspec_from_core).collect()
     }
 }
 

--- a/livekit-portal/Cargo.toml
+++ b/livekit-portal/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = []
+# YAML config file loader. Pulls in serde + serde-saphyr. Off by default so
+# users who only build configs programmatically don't pay the dep cost.
+config-file = ["dep:serde", "dep:serde-saphyr"]
+
 [dependencies]
 # `rustls-tls-native-roots`: livekit's default feature set doesn't enable any
 # TLS backend (its comment: "By default ws TLS is not enabled"). Without this
@@ -21,3 +27,8 @@ log = "0.4"
 # every supported format and would bloat link time and binary size; we only
 # need PNG and JPEG.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+# `serde-saphyr` is pinned exactly: pre-1.0 and may break across patch
+# releases. Bump deliberately. `serde` follows semver and floats so the
+# workspace's transitive deps don't conflict.
+serde = { version = "1", features = ["derive"], optional = true }
+serde-saphyr = { version = "=0.0.26", optional = true }

--- a/livekit-portal/Cargo.toml
+++ b/livekit-portal/Cargo.toml
@@ -4,12 +4,6 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
-[features]
-default = []
-# YAML config file loader. Pulls in serde + serde-saphyr. Off by default so
-# users who only build configs programmatically don't pay the dep cost.
-config-file = ["dep:serde", "dep:serde-saphyr"]
-
 [dependencies]
 # `rustls-tls-native-roots`: livekit's default feature set doesn't enable any
 # TLS backend (its comment: "By default ws TLS is not enabled"). Without this
@@ -29,6 +23,7 @@ log = "0.4"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 # `serde-saphyr` is pinned exactly: pre-1.0 and may break across patch
 # releases. Bump deliberately. `serde` follows semver and floats so the
-# workspace's transitive deps don't conflict.
-serde = { version = "1", features = ["derive"], optional = true }
-serde-saphyr = { version = "=0.0.26", optional = true }
+# workspace's transitive deps don't conflict. Both are required: YAML
+# config-file loading is part of the public surface, not opt-in.
+serde = { version = "1", features = ["derive"] }
+serde-saphyr = "=0.0.26"

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -1,9 +1,9 @@
 //! YAML config-file loader for `PortalConfig`.
 //!
-//! Gated behind the `config-file` Cargo feature. Lets users describe the
-//! wire contract (schemas, video tracks, sync knobs) once in a YAML file
-//! and load it as a `PortalConfig` at runtime, supplying `session` and
-//! `role` as kwargs since those are per-process identity, not shareable.
+//! Lets users describe the wire contract (schemas, video tracks, sync
+//! knobs) once in a YAML file and load it as a `PortalConfig` at runtime,
+//! supplying `session` and `role` at the call site since those are
+//! per-process identity, not shareable.
 //!
 //! The file format is versioned: every document must declare `version: 1`
 //! at the top level. Unknown majors are rejected so additive changes can

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -1,0 +1,486 @@
+//! YAML config-file loader for `PortalConfig`.
+//!
+//! Gated behind the `config-file` Cargo feature. Lets users describe the
+//! wire contract (schemas, video tracks, sync knobs) once in a YAML file
+//! and load it as a `PortalConfig` at runtime, supplying `session` and
+//! `role` as kwargs since those are per-process identity, not shareable.
+//!
+//! The file format is versioned: every document must declare `version: 1`
+//! at the top level. Unknown majors are rejected so additive changes can
+//! land without silently misparsing older files.
+//!
+//! Identity-only fields (`session`, `role`, `shared_key`) are deliberately
+//! NOT in the file. They're supplied at load time. This keeps a single
+//! `arm.yaml` usable by both the robot and the operator side, and keeps
+//! E2EE keys out of config repos.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::codec::Codec;
+use crate::config::{DEFAULT_MJPEG_QUALITY, PortalConfig};
+use crate::dtype::DType;
+use crate::types::Role;
+
+/// Errors raised by `PortalConfig::from_yaml_*`.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigFileError {
+    #[error("yaml parse error: {0}")]
+    Parse(String),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("unsupported config-file version {got}; this build supports version {supported}")]
+    UnsupportedVersion { got: u32, supported: u32 },
+
+    #[error("invalid config: {0}")]
+    Invalid(String),
+}
+
+/// The single supported major version. Bump when an incompatible change
+/// lands.
+const SUPPORTED_VERSION: u32 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfigFileV1 {
+    version: u32,
+
+    #[serde(default)]
+    fps: Option<u32>,
+    #[serde(default)]
+    slack: Option<u32>,
+    #[serde(default)]
+    tolerance: Option<f32>,
+    #[serde(default)]
+    state_reliable: Option<bool>,
+    #[serde(default)]
+    action_reliable: Option<bool>,
+    #[serde(default)]
+    reuse_stale_frames: Option<bool>,
+    #[serde(default)]
+    ping_ms: Option<u64>,
+    #[serde(default)]
+    action_subscription: Option<bool>,
+
+    #[serde(default)]
+    videos: Vec<VideoEntry>,
+    #[serde(default)]
+    state: Vec<FieldEntry>,
+    #[serde(default)]
+    action: Vec<FieldEntry>,
+    #[serde(default)]
+    action_chunks: Vec<ChunkEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VideoEntry {
+    name: String,
+    #[serde(deserialize_with = "deserialize_codec")]
+    codec: Codec,
+    #[serde(default)]
+    quality: Option<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FieldEntry {
+    name: String,
+    #[serde(deserialize_with = "deserialize_dtype")]
+    dtype: DType,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChunkEntry {
+    name: String,
+    horizon: u32,
+    fields: Vec<FieldEntry>,
+}
+
+fn deserialize_codec<'de, D>(d: D) -> Result<Codec, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(d)?;
+    match s.to_ascii_lowercase().as_str() {
+        "h264" => Ok(Codec::H264),
+        "raw" => Ok(Codec::Raw),
+        "png" => Ok(Codec::Png),
+        "mjpeg" => Ok(Codec::Mjpeg),
+        other => Err(serde::de::Error::custom(format!(
+            "unknown codec '{other}' (expected one of h264, raw, png, mjpeg)"
+        ))),
+    }
+}
+
+fn deserialize_dtype<'de, D>(d: D) -> Result<DType, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(d)?;
+    match s.to_ascii_lowercase().as_str() {
+        "f64" => Ok(DType::F64),
+        "f32" => Ok(DType::F32),
+        "i32" => Ok(DType::I32),
+        "i16" => Ok(DType::I16),
+        "i8" => Ok(DType::I8),
+        "u32" => Ok(DType::U32),
+        "u16" => Ok(DType::U16),
+        "u8" => Ok(DType::U8),
+        "bool" => Ok(DType::Bool),
+        other => Err(serde::de::Error::custom(format!(
+            "unknown dtype '{other}' (expected one of f64, f32, i32, i16, i8, u32, u16, u8, bool)"
+        ))),
+    }
+}
+
+impl PortalConfig {
+    /// Load a `PortalConfig` from a YAML string. `session` and `role` are
+    /// supplied here because they're per-process identity, not part of the
+    /// shareable wire contract. The shared E2EE key, when used, must be
+    /// applied with `set_e2ee_key` after loading.
+    pub fn from_yaml_str(
+        yaml: &str,
+        session: impl Into<String>,
+        role: Role,
+    ) -> Result<Self, ConfigFileError> {
+        let parsed: ConfigFileV1 = serde_saphyr::from_str(yaml)
+            .map_err(|e| ConfigFileError::Parse(e.to_string()))?;
+
+        if parsed.version != SUPPORTED_VERSION {
+            return Err(ConfigFileError::UnsupportedVersion {
+                got: parsed.version,
+                supported: SUPPORTED_VERSION,
+            });
+        }
+
+        validate(&parsed)?;
+
+        let mut cfg = PortalConfig::new(session, role);
+
+        for v in &parsed.videos {
+            let quality = v.quality.unwrap_or(match v.codec {
+                Codec::Mjpeg => DEFAULT_MJPEG_QUALITY,
+                _ => 0,
+            });
+            cfg.add_video(&v.name, v.codec, quality);
+        }
+
+        if !parsed.state.is_empty() {
+            cfg.add_state_typed(parsed.state.iter().map(|f| (f.name.clone(), f.dtype)));
+        }
+        if !parsed.action.is_empty() {
+            cfg.add_action_typed(parsed.action.iter().map(|f| (f.name.clone(), f.dtype)));
+        }
+        for chunk in &parsed.action_chunks {
+            cfg.add_action_chunk(
+                &chunk.name,
+                chunk.horizon,
+                chunk.fields.iter().map(|f| (f.name.clone(), f.dtype)),
+            );
+        }
+
+        if let Some(v) = parsed.fps {
+            cfg.set_fps(v);
+        }
+        if let Some(v) = parsed.slack {
+            cfg.set_slack(v);
+        }
+        if let Some(v) = parsed.tolerance {
+            cfg.set_tolerance(v);
+        }
+        if let Some(v) = parsed.state_reliable {
+            cfg.set_state_reliable(v);
+        }
+        if let Some(v) = parsed.action_reliable {
+            cfg.set_action_reliable(v);
+        }
+        if let Some(v) = parsed.reuse_stale_frames {
+            cfg.set_reuse_stale_frames(v);
+        }
+        if let Some(v) = parsed.ping_ms {
+            cfg.set_ping_ms(v);
+        }
+        if let Some(v) = parsed.action_subscription {
+            cfg.set_action_subscription(v);
+        }
+
+        Ok(cfg)
+    }
+
+    /// Load a `PortalConfig` from a YAML file on disk. See `from_yaml_str`
+    /// for the field semantics.
+    pub fn from_yaml_file(
+        path: impl AsRef<Path>,
+        session: impl Into<String>,
+        role: Role,
+    ) -> Result<Self, ConfigFileError> {
+        let text = std::fs::read_to_string(path)?;
+        Self::from_yaml_str(&text, session, role)
+    }
+}
+
+/// Pre-flight validation: catches everything `PortalConfig`'s setters
+/// would assert on, and returns a typed error rather than letting the
+/// loader panic mid-build.
+fn validate(p: &ConfigFileV1) -> Result<(), ConfigFileError> {
+    let mut seen_video = std::collections::HashSet::new();
+    for v in &p.videos {
+        if !seen_video.insert(v.name.as_str()) {
+            return Err(ConfigFileError::Invalid(format!(
+                "duplicate video track '{}'",
+                v.name
+            )));
+        }
+        if v.codec == Codec::Mjpeg {
+            let q = v.quality.unwrap_or(DEFAULT_MJPEG_QUALITY);
+            if !(1..=100).contains(&q) {
+                return Err(ConfigFileError::Invalid(format!(
+                    "video '{}': mjpeg quality must be in 1..=100, got {q}",
+                    v.name
+                )));
+            }
+        }
+    }
+
+    if let Some(fps) = p.fps {
+        if fps == 0 {
+            return Err(ConfigFileError::Invalid("fps must be > 0".into()));
+        }
+    }
+    if let Some(slack) = p.slack {
+        if slack == 0 {
+            return Err(ConfigFileError::Invalid("slack must be > 0".into()));
+        }
+    }
+    if let Some(tol) = p.tolerance {
+        if !(tol > 0.0) {
+            return Err(ConfigFileError::Invalid("tolerance must be > 0".into()));
+        }
+    }
+
+    let mut seen_chunk = std::collections::HashSet::new();
+    for c in &p.action_chunks {
+        if !seen_chunk.insert(c.name.as_str()) {
+            return Err(ConfigFileError::Invalid(format!(
+                "duplicate action chunk '{}'",
+                c.name
+            )));
+        }
+        if c.horizon == 0 {
+            return Err(ConfigFileError::Invalid(format!(
+                "action chunk '{}' horizon must be > 0",
+                c.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn yaml_full() -> &'static str {
+        r#"
+version: 1
+fps: 60
+slack: 8
+tolerance: 1.0
+state_reliable: false
+action_reliable: false
+reuse_stale_frames: true
+ping_ms: 500
+action_subscription: true
+videos:
+  - { name: front, codec: h264 }
+  - { name: wrist, codec: mjpeg, quality: 80 }
+  - { name: depth, codec: png }
+state:
+  - { name: joint_pos, dtype: f32 }
+  - { name: gripper, dtype: bool }
+action:
+  - { name: joint_pos, dtype: f32 }
+action_chunks:
+  - name: vla
+    horizon: 16
+    fields:
+      - { name: joint_pos, dtype: f32 }
+"#
+    }
+
+    #[test]
+    fn full_config_round_trip() {
+        let cfg = PortalConfig::from_yaml_str(yaml_full(), "demo", Role::Robot).unwrap();
+        assert_eq!(cfg.video_tracks(), &["front".to_string()]);
+        assert_eq!(cfg.frame_video_tracks().len(), 2);
+        assert_eq!(cfg.frame_video_tracks()[0].name, "wrist");
+        assert_eq!(cfg.frame_video_tracks()[0].codec, Codec::Mjpeg);
+        assert_eq!(cfg.frame_video_tracks()[0].quality, 80);
+        assert_eq!(cfg.frame_video_tracks()[1].codec, Codec::Png);
+
+        let state: Vec<&str> = cfg.state_fields().collect();
+        assert_eq!(state, vec!["joint_pos", "gripper"]);
+        assert_eq!(cfg.state_schema()[1].dtype, DType::Bool);
+
+        let action: Vec<&str> = cfg.action_fields().collect();
+        assert_eq!(action, vec!["joint_pos"]);
+
+        assert_eq!(cfg.action_chunks().len(), 1);
+        assert_eq!(cfg.action_chunks()[0].horizon, 16);
+
+        assert!(cfg.action_subscription());
+    }
+
+    #[test]
+    fn defaults_apply_when_fields_omitted() {
+        let yaml = "version: 1\n";
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        // Same defaults as `PortalConfig::new`.
+        assert_eq!(cfg.video_tracks().len(), 0);
+        assert_eq!(cfg.frame_video_tracks().len(), 0);
+        assert_eq!(cfg.state_schema().len(), 0);
+        assert_eq!(cfg.action_schema().len(), 0);
+        assert_eq!(cfg.action_chunks().len(), 0);
+        assert!(!cfg.action_subscription());
+    }
+
+    #[test]
+    fn mjpeg_quality_defaults_to_90() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: mjpeg }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        assert_eq!(cfg.frame_video_tracks()[0].quality, DEFAULT_MJPEG_QUALITY);
+    }
+
+    #[test]
+    fn unknown_version_rejected() {
+        let yaml = "version: 2\n";
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::UnsupportedVersion { got: 2, supported: 1 }));
+    }
+
+    #[test]
+    fn missing_version_rejected() {
+        let yaml = "fps: 30\n";
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Parse(_)));
+    }
+
+    #[test]
+    fn unknown_field_rejected() {
+        let yaml = "version: 1\nbogus_field: 7\n";
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Parse(_)));
+    }
+
+    #[test]
+    fn duplicate_video_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: h264 }
+  - { name: cam, codec: mjpeg, quality: 80 }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        match err {
+            ConfigFileError::Invalid(msg) => assert!(msg.contains("duplicate video")),
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_chunk_rejected() {
+        let yaml = r#"
+version: 1
+action_chunks:
+  - { name: vla, horizon: 4, fields: [{ name: x, dtype: f32 }] }
+  - { name: vla, horizon: 4, fields: [{ name: x, dtype: f32 }] }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Invalid(_)));
+    }
+
+    #[test]
+    fn zero_horizon_rejected() {
+        let yaml = r#"
+version: 1
+action_chunks:
+  - { name: vla, horizon: 0, fields: [{ name: x, dtype: f32 }] }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Invalid(_)));
+    }
+
+    #[test]
+    fn bad_dtype_rejected() {
+        let yaml = r#"
+version: 1
+state:
+  - { name: x, dtype: float64 }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Parse(_)));
+    }
+
+    #[test]
+    fn bad_codec_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: vp8 }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Parse(_)));
+    }
+
+    #[test]
+    fn out_of_range_mjpeg_quality_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: mjpeg, quality: 0 }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Invalid(_)));
+    }
+
+    #[test]
+    fn dtype_and_codec_strings_are_case_insensitive() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: H264 }
+state:
+  - { name: x, dtype: F32 }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        assert_eq!(cfg.video_tracks(), &["cam".to_string()]);
+        assert_eq!(cfg.state_schema()[0].dtype, DType::F32);
+    }
+
+    #[test]
+    fn fps_zero_rejected() {
+        let yaml = "version: 1\nfps: 0\n";
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Invalid(_)));
+    }
+
+    #[test]
+    fn role_is_supplied_at_load_time() {
+        // Same YAML loaded twice with different roles produces two configs
+        // that disagree only on role.
+        let robot = PortalConfig::from_yaml_str(yaml_full(), "demo", Role::Robot).unwrap();
+        let operator = PortalConfig::from_yaml_str(yaml_full(), "demo", Role::Operator).unwrap();
+        assert_eq!(robot.state_schema(), operator.state_schema());
+        assert_eq!(robot.action_schema(), operator.action_schema());
+    }
+}

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -258,7 +258,10 @@ fn validate(p: &ConfigFileV1) -> Result<(), ConfigFileError> {
         }
     }
     if let Some(tol) = p.tolerance {
-        if !(tol > 0.0) {
+        // Equivalent to `!(tol > 0.0)` but explicit about NaN. Mirrors
+        // `PortalConfig::set_tolerance`'s assertion: NaN, zero, and
+        // negative all reject; positive (including +inf) passes.
+        if tol.is_nan() || tol <= 0.0 {
             return Err(ConfigFileError::Invalid("tolerance must be > 0".into()));
         }
     }

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod codec;
 pub mod config;
+#[cfg(feature = "config-file")]
+pub mod config_file;
 mod data;
 pub mod dtype;
 pub mod error;
@@ -15,6 +17,8 @@ mod video;
 
 pub use codec::Codec;
 pub use config::{ChunkSpec, FieldSpec, FrameVideoSpec, PortalConfig};
+#[cfg(feature = "config-file")]
+pub use config_file::ConfigFileError;
 pub use frame_video::BYTE_STREAM_CHUNK_SIZE;
 pub use dtype::DType;
 pub use error::{PortalError, PortalResult};

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod codec;
 pub mod config;
-#[cfg(feature = "config-file")]
 pub mod config_file;
 mod data;
 pub mod dtype;
@@ -17,7 +16,6 @@ mod video;
 
 pub use codec::Codec;
 pub use config::{ChunkSpec, FieldSpec, FrameVideoSpec, PortalConfig};
-#[cfg(feature = "config-file")]
 pub use config_file::ConfigFileError;
 pub use frame_video::BYTE_STREAM_CHUNK_SIZE;
 pub use dtype::DType;

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import numbers
+import os
 import threading
 import traceback
 from dataclasses import dataclass, field
@@ -54,6 +55,7 @@ BufferMetrics = _ffi.BufferMetrics
 RttMetrics = _ffi.RttMetrics
 PolicyMetrics = _ffi.PolicyMetrics
 PortalError = _ffi.PortalError
+ConfigFileError = _ffi.ConfigFileError
 RpcInvocationData = _ffi.RpcInvocationData
 RpcError = _ffi.RpcError
 
@@ -635,6 +637,64 @@ class PortalConfig:
         self._action_schema: List[FieldSpec] = []
         self._action_chunks: List[ChunkSpec] = []
 
+    @classmethod
+    def from_yaml_str(
+        cls,
+        yaml: str,
+        session: str,
+        role: Role,
+    ) -> "PortalConfig":
+        """Build a `PortalConfig` from a YAML string.
+
+        The YAML describes the shareable wire contract — schemas, video
+        tracks, sync knobs. `session` and `role` are supplied at the call
+        site since they're per-process identity, so the same file is
+        reusable across robot and operator processes. The shared E2EE
+        key, when used, must be applied with `set_e2ee_key` after loading.
+
+        Raises `ConfigFileError` for parse errors, unknown versions, and
+        invalid configs (duplicate tracks, bad dtypes, out-of-range
+        values).
+        """
+        inner = _ffi.PortalConfig.from_yaml_str(yaml, session, role)
+        return cls._from_inner(inner, session, role)
+
+    @classmethod
+    def from_yaml_file(
+        cls,
+        path: Union[str, os.PathLike],
+        session: str,
+        role: Role,
+    ) -> "PortalConfig":
+        """Convenience wrapper around `from_yaml_str` that reads `path`
+        from disk first.
+        """
+        with open(path, "r", encoding="utf-8") as f:
+            return cls.from_yaml_str(f.read(), session, role)
+
+    @classmethod
+    def _from_inner(
+        cls,
+        inner: _ffi.PortalConfig,
+        session: str,
+        role: Role,
+    ) -> "PortalConfig":
+        # Bypass __init__ — `inner` is already a fully built FFI config.
+        # Mirror the schemas back into Python-side state by reading the
+        # FFI accessors so downstream consumers (`Portal.__init__`,
+        # introspection properties) see the same shape they would on a
+        # programmatic build.
+        instance = cls.__new__(cls)
+        instance._inner = inner
+        instance._session = session
+        instance._role = role
+        instance._video_tracks = list(inner.video_tracks())
+        instance._frame_video_tracks = list(inner.frame_video_tracks())
+        instance._state_schema = list(inner.state_schema())
+        instance._action_schema = list(inner.action_schema())
+        instance._action_chunks = list(inner.action_chunks())
+        return instance
+
     @property
     def session(self) -> str:
         return self._session
@@ -1156,6 +1216,12 @@ class _RoleConfigBase:
     def __init__(self, session: str, role: Role) -> None:
         self._inner = PortalConfig(session, role)
 
+    @classmethod
+    def _from_portal_config(cls, inner: PortalConfig) -> "_RoleConfigBase":
+        instance = cls.__new__(cls)
+        instance._inner = inner
+        return instance
+
     @property
     def session(self) -> str:
         return self._inner.session
@@ -1246,6 +1312,23 @@ class RobotConfig(_RoleConfigBase):
     def __init__(self, session: str) -> None:
         super().__init__(session, Role.ROBOT)
 
+    @classmethod
+    def from_yaml_str(cls, yaml: str, session: str) -> "RobotConfig":
+        """Build a `RobotConfig` from a YAML string. See
+        `PortalConfig.from_yaml_str` for the schema and semantics.
+        """
+        inner = PortalConfig.from_yaml_str(yaml, session, Role.ROBOT)
+        return cls._from_portal_config(inner)  # type: ignore[return-value]
+
+    @classmethod
+    def from_yaml_file(
+        cls,
+        path: Union[str, os.PathLike],
+        session: str,
+    ) -> "RobotConfig":
+        inner = PortalConfig.from_yaml_file(path, session, Role.ROBOT)
+        return cls._from_portal_config(inner)  # type: ignore[return-value]
+
 
 class OperatorConfig(_RoleConfigBase):
     """Operator-side session config. Same declarative surface as
@@ -1260,6 +1343,23 @@ class OperatorConfig(_RoleConfigBase):
 
     def __init__(self, session: str) -> None:
         super().__init__(session, Role.OPERATOR)
+
+    @classmethod
+    def from_yaml_str(cls, yaml: str, session: str) -> "OperatorConfig":
+        """Build an `OperatorConfig` from a YAML string. See
+        `PortalConfig.from_yaml_str` for the schema and semantics.
+        """
+        inner = PortalConfig.from_yaml_str(yaml, session, Role.OPERATOR)
+        return cls._from_portal_config(inner)  # type: ignore[return-value]
+
+    @classmethod
+    def from_yaml_file(
+        cls,
+        path: Union[str, os.PathLike],
+        session: str,
+    ) -> "OperatorConfig":
+        inner = PortalConfig.from_yaml_file(path, session, Role.OPERATOR)
+        return cls._from_portal_config(inner)  # type: ignore[return-value]
 
 
 class Robot:
@@ -1581,6 +1681,7 @@ __all__ = [
     "RttMetrics",
     "PolicyMetrics",
     "PortalError",
+    "ConfigFileError",
     "RpcInvocationData",
     "RpcError",
     "frame_bytes_to_numpy_rgb",

--- a/python/packages/livekit-portal/tests/test_config_yaml.py
+++ b/python/packages/livekit-portal/tests/test_config_yaml.py
@@ -1,0 +1,179 @@
+"""Tests for YAML config-file loading on PortalConfig / RobotConfig /
+OperatorConfig.
+
+The Rust core has its own deeper unit tests against the loader. These
+tests exercise the FFI surface end-to-end: parse + validate happen in
+Rust, and the Python wrapper mirrors the Rust-built schemas back into
+its own state via the FFI accessors.
+"""
+import os
+import tempfile
+import textwrap
+
+import pytest
+
+from livekit.portal import (
+    ChunkSpec,
+    ConfigFileError,
+    DType,
+    FieldSpec,
+    OperatorConfig,
+    Portal,
+    PortalConfig,
+    RobotConfig,
+    Role,
+    VideoCodec,
+)
+
+
+YAML_FULL = textwrap.dedent(
+    """
+    version: 1
+    fps: 60
+    slack: 8
+    tolerance: 1.0
+    state_reliable: false
+    action_reliable: false
+    reuse_stale_frames: true
+    ping_ms: 500
+    action_subscription: true
+    videos:
+      - { name: front, codec: h264 }
+      - { name: wrist, codec: mjpeg, quality: 80 }
+      - { name: depth, codec: png }
+    state:
+      - { name: joint_pos, dtype: f32 }
+      - { name: gripper, dtype: bool }
+    action:
+      - { name: joint_pos, dtype: f32 }
+    action_chunks:
+      - name: vla
+        horizon: 16
+        fields:
+          - { name: joint_pos, dtype: f32 }
+    """
+)
+
+
+def test_from_yaml_str_mirrors_full_schema():
+    cfg = PortalConfig.from_yaml_str(YAML_FULL, "demo", Role.ROBOT)
+    assert cfg.session == "demo"
+    assert cfg.role == Role.ROBOT
+
+    # H264 videos go on the WebRTC list, frame-video codecs on their own list.
+    assert cfg.video_tracks == ["front"]
+    assert [t.name for t in cfg.frame_video_tracks] == ["wrist", "depth"]
+    assert cfg.frame_video_tracks[0].codec == VideoCodec.MJPEG
+    assert cfg.frame_video_tracks[0].quality == 80
+    assert cfg.frame_video_tracks[1].codec == VideoCodec.PNG
+
+    assert cfg.state_schema == [
+        FieldSpec(name="joint_pos", dtype=DType.F32),
+        FieldSpec(name="gripper", dtype=DType.BOOL),
+    ]
+    assert cfg.action_schema == [FieldSpec(name="joint_pos", dtype=DType.F32)]
+
+    assert len(cfg.action_chunks) == 1
+    assert cfg.action_chunks[0].name == "vla"
+    assert cfg.action_chunks[0].horizon == 16
+
+
+def test_from_yaml_str_works_with_minimal_doc():
+    cfg = PortalConfig.from_yaml_str("version: 1\n", "demo", Role.OPERATOR)
+    assert cfg.session == "demo"
+    assert cfg.role == Role.OPERATOR
+    assert cfg.video_tracks == []
+    assert cfg.frame_video_tracks == []
+    assert cfg.state_schema == []
+    assert cfg.action_schema == []
+    assert cfg.action_chunks == []
+
+
+def test_from_yaml_str_role_is_supplied_at_load_time():
+    # Same YAML, two roles. The wire contract is identical; only role differs.
+    robot = PortalConfig.from_yaml_str(YAML_FULL, "demo", Role.ROBOT)
+    operator = PortalConfig.from_yaml_str(YAML_FULL, "demo", Role.OPERATOR)
+    assert robot.state_schema == operator.state_schema
+    assert robot.action_schema == operator.action_schema
+    assert robot.role == Role.ROBOT
+    assert operator.role == Role.OPERATOR
+
+
+def test_from_yaml_str_unknown_version_rejected():
+    with pytest.raises(ConfigFileError):
+        PortalConfig.from_yaml_str("version: 99\n", "demo", Role.ROBOT)
+
+
+def test_from_yaml_str_invalid_dtype_rejected():
+    with pytest.raises(ConfigFileError):
+        PortalConfig.from_yaml_str(
+            "version: 1\nstate:\n  - { name: x, dtype: float64 }\n",
+            "demo",
+            Role.ROBOT,
+        )
+
+
+def test_from_yaml_str_duplicate_video_rejected():
+    yaml = textwrap.dedent(
+        """
+        version: 1
+        videos:
+          - { name: cam, codec: h264 }
+          - { name: cam, codec: mjpeg, quality: 80 }
+        """
+    )
+    with pytest.raises(ConfigFileError):
+        PortalConfig.from_yaml_str(yaml, "demo", Role.ROBOT)
+
+
+def test_from_yaml_file_round_trip():
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        f.write(YAML_FULL)
+        path = f.name
+    try:
+        cfg = PortalConfig.from_yaml_file(path, "demo", Role.ROBOT)
+        assert cfg.video_tracks == ["front"]
+        assert len(cfg.frame_video_tracks) == 2
+        assert len(cfg.action_chunks) == 1
+    finally:
+        os.unlink(path)
+
+
+def test_yaml_built_config_drives_portal():
+    # The whole point: Portal construction works seamlessly with a
+    # YAML-built PortalConfig. Verifies the Python-side mirror is
+    # populated correctly (Portal reads chunk specs and field names
+    # from the config).
+    cfg = PortalConfig.from_yaml_str(YAML_FULL, "demo", Role.ROBOT)
+    portal = Portal(cfg)
+    assert portal._state_fields == ["joint_pos", "gripper"]
+    assert portal._action_fields == ["joint_pos"]
+    assert portal._video_tracks == ["front"]
+    assert "vla" in portal._chunk_schemas
+
+
+def test_robot_config_from_yaml_str():
+    cfg = RobotConfig.from_yaml_str(YAML_FULL, "demo")
+    assert cfg.role == Role.ROBOT
+    assert [f.name for f in cfg.state_schema] == ["joint_pos", "gripper"]
+
+
+def test_operator_config_from_yaml_str():
+    cfg = OperatorConfig.from_yaml_str(YAML_FULL, "demo")
+    assert cfg.role == Role.OPERATOR
+    assert len(cfg.action_chunks) == 1
+
+
+def test_robot_config_from_yaml_file():
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        f.write(YAML_FULL)
+        path = f.name
+    try:
+        cfg = RobotConfig.from_yaml_file(path, "demo")
+        assert cfg.role == Role.ROBOT
+    finally:
+        os.unlink(path)

--- a/python/packages/livekit-portal/tests/test_config_yaml.py
+++ b/python/packages/livekit-portal/tests/test_config_yaml.py
@@ -13,7 +13,6 @@ import textwrap
 import pytest
 
 from livekit.portal import (
-    ChunkSpec,
     ConfigFileError,
     DType,
     FieldSpec,


### PR DESCRIPTION
## Summary

Adds a YAML loader for `PortalConfig`, `RobotConfig`, and `OperatorConfig` so the wire contract (schemas, video tracks, sync knobs) can live in a shareable file instead of being declared in code.

```python
from livekit.portal import RobotConfig

cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
```

The Rust core does the parsing and validation. The same file is reusable across the robot and operator processes — `session`, `role`, and the E2EE key are deliberately supplied at the call site so configs are checkable into a repo and never hold a secret.

## What changed

- **Rust core (`livekit-portal`)**: new `config_file.rs` with `PortalConfig::from_yaml_str` / `from_yaml_file`. Pure-Rust YAML via `serde-saphyr` (panic-free parser, pinned at `=0.0.26`). Pre-flight validation surfaces duplicate tracks, bad codec/dtype names, out-of-range MJPEG quality, zero horizons, and unknown fields as typed `ConfigFileError` rather than letting the underlying setter assertions panic. Top-level `version: 1` field required; unknown majors are rejected so additive changes can land without silent misparses.
- **FFI (`livekit-portal-ffi`)**: exposes `from_yaml_str` as a fallible UniFFI constructor on `PortalConfig`, plus `ConfigFileError` as its own UniFFI error type. Adds five introspection accessors (`video_tracks`, `frame_video_tracks`, `state_schema`, `action_schema`, `action_chunks`) so bindings that build via YAML can mirror the resulting schemas back into their own state. The `config-file` Cargo feature was removed — the loader is part of the default surface.
- **Python (`livekit-portal`)**: `PortalConfig.from_yaml_str` / `from_yaml_file` classmethods, plus single-arg variants on `RobotConfig` / `OperatorConfig` that pin the role for you. Walks the FFI accessors after construction to populate Python-side mirror state, so YAML-built configs are interchangeable with programmatic ones (`Portal` construction, introspection properties, dispatcher state all work).
- **Examples**: `examples/python/basic/portal.yaml` plus `robot_yaml.py` / `teleoperator_yaml.py`. Identical wire shape to the existing `robot.py` / `teleoperator.py`, but loaded from disk.
- **Docs**: new `docs/config-file.md` covers the full surface — loading API, kitchen-sink example, per-section reference tables, what is deliberately *not* in the file, YAML-to-programmatic equivalence map, error taxonomy with both catch-all and catch-by-variant recipes, validation walk-through of six common mistakes, and sharing/templating patterns. Linked from README, quickstart, and portal-api.

## Schema (locked in for v1)

```yaml
version: 1                            # required
fps: 30                               # all sync/transport/behavior knobs optional
slack: 5
tolerance: 1.5
state_reliable: true
action_reliable: true
reuse_stale_frames: false
ping_ms: 1000
action_subscription: false

videos:
  - { name: front, codec: h264 }
  - { name: wrist, codec: mjpeg, quality: 90 }

state:
  - { name: joint_pos, dtype: f32 }
  - { name: gripper, dtype: bool }

action:
  - { name: joint_pos, dtype: f32 }
  - { name: gripper, dtype: bool }

action_chunks:
  - name: vla
    horizon: 16
    fields:
      - { name: joint_pos, dtype: f32 }
```

`#[serde(deny_unknown_fields)]` everywhere — typos surface as parse errors instead of silently no-op.

## Test plan

- [x] `cargo test -p livekit-portal --lib` (92 tests, 15 new in `config_file::tests`).
- [x] `cargo clippy -p livekit-portal` clean on `config_file.rs`.
- [x] `pytest tests/` in `python/packages/livekit-portal` (47 tests, 11 new in `test_config_yaml.py`).
- [x] `pyflakes` clean on changed Python files.
- [x] `bash scripts/build_ffi_python.sh debug` regenerates bindings cleanly; new FFI surface (`from_yaml_str`, accessors, `ConfigFileError`) appears in the generated module.
- [x] `python -c 'import ast; ast.parse(open("...py").read())'` on the new examples.
- [ ] Run `examples/python/basic/robot_yaml.py` + `teleoperator_yaml.py` end-to-end against a LiveKit Cloud room (requires creds, not run in CI).