### PR TITLE
Upgrade to 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,9 +196,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
@@ -300,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -327,26 +316,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "camino"
@@ -383,13 +352,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -441,16 +408,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -537,12 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378f0974ae2468eaf63aa036dbe9c926b0dc7ea64c156f2ea618bc2f75b934f0"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -759,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -775,18 +726,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "device-info"
 version = "0.1.1"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "core-foundation",
  "jni",
@@ -870,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1312,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1575,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1605,18 +1547,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1624,16 +1557,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1743,20 +1666,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1766,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -1783,6 +1696,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -1802,9 +1716,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1824,8 +1738,8 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.33"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+version = "0.3.34"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "cxx",
  "glib",
@@ -1857,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8600ca3dbe044f07955b443ff606c50f45295b863289bbe7d0844d50cf11e4"
+checksum = "4d1e908a416d6e9f725743b84a36feea40c4c131e805fbc26d61f9f451f36080"
 
 [[package]]
 name = "linktime-proc-macro"
@@ -1881,8 +1795,8 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "livekit"
-version = "0.7.40"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+version = "0.7.42"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "base64 0.22.1",
  "bmrng",
@@ -1908,8 +1822,8 @@ dependencies = [
 
 [[package]]
 name = "livekit-api"
-version = "0.4.22"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+version = "0.4.24"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1940,14 +1854,15 @@ dependencies = [
 
 [[package]]
 name = "livekit-datatrack"
-version = "0.1.5"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+version = "0.1.7"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "anyhow",
  "bytes",
  "from_variants",
  "futures-core",
  "futures-util",
+ "indexmap",
  "livekit-protocol",
  "livekit-runtime",
  "log",
@@ -1992,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "livekit-protocol"
 version = "0.7.7"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "pbjson",
  "pbjson-types",
@@ -2003,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "livekit-runtime"
 version = "0.4.0"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -2081,9 +1996,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2122,12 +2037,6 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2338,9 +2247,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "os_info"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
@@ -2400,17 +2309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "pbjson"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,18 +2343,6 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -2559,12 +2445,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2950,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "rtrb"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
+checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
 name = "rustc-hash"
@@ -2984,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -3011,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3190,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3278,9 +3158,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3489,25 +3369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3534,9 +3395,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3678,20 +3539,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3975,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3988,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3998,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4008,9 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4021,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4064,9 +3925,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4084,8 +3945,8 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.31"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+version = "0.3.32"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "cc",
  "cxx",
@@ -4098,8 +3959,8 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys-build"
-version = "0.3.16"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+version = "0.3.18"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "anyhow",
  "fs2",
@@ -4441,9 +4302,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4574,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "yuv-sys"
 version = "0.3.14"
-source = "git+https://github.com/livekit/rust-sdks.git#497527d4169a62ac38d3bc7f7651395465806f84"
+source = "git+https://github.com/livekit/rust-sdks.git#1848e77a32ca2f302a58323a7a21858165d81aad"
 dependencies = [
  "bindgen",
  "cc",
@@ -4604,9 +4465,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -4628,6 +4489,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4668,18 +4543,10 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
  "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
 ]
 
 [[package]]
@@ -4687,35 +4554,6 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["livekit-portal", "livekit-portal-ffi"]
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 version = "0.1.0"
 

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -29,11 +29,9 @@ uniffi::setup_scaffolding!();
 /// Initialize `env_logger` when the cdylib is loaded to allow outputting logs via `RUST_LOG`.
 #[ctor::ctor(unsafe)]
 fn init_logging() {
-    let _ = env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("info"),
-    )
-    .format_timestamp_millis()
-    .try_init();
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp_millis()
+        .try_init();
 }
 
 // ---------------------------------------------------------------------------
@@ -576,15 +574,11 @@ impl PortalConfig {
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {
-        self.inner
-            .lock()
-            .add_state_typed(schema.into_iter().map(|f| (f.name, f.dtype.into())));
+        self.inner.lock().add_state_typed(schema.into_iter().map(|f| (f.name, f.dtype.into())));
     }
 
     pub fn add_action_typed(&self, schema: Vec<FieldSpec>) {
-        self.inner
-            .lock()
-            .add_action_typed(schema.into_iter().map(|f| (f.name, f.dtype.into())));
+        self.inner.lock().add_action_typed(schema.into_iter().map(|f| (f.name, f.dtype.into())));
     }
 
     /// Declare a named action chunk: a fixed-horizon batch of typed
@@ -724,11 +718,8 @@ impl Portal {
                 quality: s.quality,
             })
             .collect();
-        let action_chunks: Vec<ChunkSpec> = cfg
-            .action_chunks()
-            .iter()
-            .map(chunkspec_from_core)
-            .collect();
+        let action_chunks: Vec<ChunkSpec> =
+            cfg.action_chunks().iter().map(chunkspec_from_core).collect();
 
         let inner = core::Portal::new(cfg);
 
@@ -760,9 +751,7 @@ impl Portal {
             // Cross with raw f64 maps. Python wraps to typed on receipt.
             let raw: Vec<HashMap<String, f64>> = dropped
                 .into_iter()
-                .map(|m| {
-                    m.into_iter().map(|(k, v)| (k, v.as_f64())).collect()
-                })
+                .map(|m| m.into_iter().map(|(k, v)| (k, v.as_f64())).collect())
                 .collect();
             cb.on_drop(raw);
         });
@@ -850,9 +839,7 @@ impl Portal {
         in_reply_to_ts_us: Option<u64>,
     ) -> PortalResult<()> {
         let typed = f64_to_typed(&values, self.inner.action_schema());
-        self.inner
-            .send_action(&typed, timestamp_us, in_reply_to_ts_us)
-            .map_err(Into::into)
+        self.inner.send_action(&typed, timestamp_us, in_reply_to_ts_us).map_err(Into::into)
     }
 
     /// Publish an action chunk on the named declaration. `data` is
@@ -887,10 +874,7 @@ impl Portal {
     }
 
     pub fn get_state(&self) -> Option<State> {
-        self.inner.get_state().map(|s| State {
-            values: s.raw_values,
-            timestamp_us: s.timestamp_us,
-        })
+        self.inner.get_state().map(|s| State { values: s.raw_values, timestamp_us: s.timestamp_us })
     }
 
     pub fn get_video_frame(&self, track_name: String) -> Option<VideoFrame> {

--- a/livekit-portal/src/codec.rs
+++ b/livekit-portal/src/codec.rs
@@ -78,9 +78,7 @@ pub struct DecodedFrame {
 pub enum CodecError {
     #[error("invalid frame dimensions: {width}x{height}")]
     InvalidDimensions { width: u32, height: u32 },
-    #[error(
-        "wrong RGB buffer size for {width}x{height}: expected {expected} bytes, got {got}"
-    )]
+    #[error("wrong RGB buffer size for {width}x{height}: expected {expected} bytes, got {got}")]
     WrongRgbSize { width: u32, height: u32, expected: usize, got: usize },
     #[error("encode failed: {0}")]
     EncodeFailed(String),
@@ -110,12 +108,7 @@ fn check_rgb(rgb: &[u8], width: u32, height: u32) -> CodecResult<()> {
         .and_then(|n| n.checked_mul(3))
         .ok_or(CodecError::InvalidDimensions { width, height })?;
     if rgb.len() != expected {
-        return Err(CodecError::WrongRgbSize {
-            width,
-            height,
-            expected,
-            got: rgb.len(),
-        });
+        return Err(CodecError::WrongRgbSize { width, height, expected, got: rgb.len() });
     }
     Ok(())
 }
@@ -130,9 +123,7 @@ fn check_rgb(rgb: &[u8], width: u32, height: u32) -> CodecResult<()> {
 ///   * Mjpeg = raw / 8 (≈ q90 ratio on natural images; loose, but avoids
 ///     the common case of `Vec` doubling-from-zero during encode)
 pub fn estimated_encoded_size(width: u32, height: u32, codec: Codec) -> usize {
-    let raw = (width as usize)
-        .saturating_mul(height as usize)
-        .saturating_mul(3);
+    let raw = (width as usize).saturating_mul(height as usize).saturating_mul(3);
     match codec {
         Codec::Raw => raw,
         Codec::Png => raw,
@@ -230,11 +221,7 @@ pub fn decode_frame(
     match codec {
         Codec::Raw => {
             check_rgb(&bytes, declared_width, declared_height)?;
-            Ok(DecodedFrame {
-                rgb: bytes,
-                width: declared_width,
-                height: declared_height,
-            })
+            Ok(DecodedFrame { rgb: bytes, width: declared_width, height: declared_height })
         }
         Codec::Png => decode_with_image_crate(
             &bytes,
@@ -262,10 +249,7 @@ fn decode_with_image_crate(
 ) -> CodecResult<DecodedFrame> {
     let cursor = Cursor::new(bytes);
     let reader = image::ImageReader::with_format(cursor, format);
-    let decoded = reader
-        .decode()
-        .map_err(|e| CodecError::DecodeFailed(e.to_string()))?
-        .into_rgb8();
+    let decoded = reader.decode().map_err(|e| CodecError::DecodeFailed(e.to_string()))?.into_rgb8();
     let (w, h) = decoded.dimensions();
     if (declared_width != 0 || declared_height != 0)
         && (w != declared_width || h != declared_height)

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -114,11 +114,7 @@ impl ChunkSpec {
         horizon: u32,
         fields: impl IntoIterator<Item = impl Into<FieldSpec>>,
     ) -> Self {
-        Self {
-            name: name.into(),
-            horizon,
-            fields: fields.into_iter().map(Into::into).collect(),
-        }
+        Self { name: name.into(), horizon, fields: fields.into_iter().map(Into::into).collect() }
     }
 }
 

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -158,8 +158,8 @@ impl PortalConfig {
         session: impl Into<String>,
         role: Role,
     ) -> Result<Self, ConfigFileError> {
-        let parsed: ConfigFileV1 = serde_saphyr::from_str(yaml)
-            .map_err(|e| ConfigFileError::Parse(e.to_string()))?;
+        let parsed: ConfigFileV1 =
+            serde_saphyr::from_str(yaml).map_err(|e| ConfigFileError::Parse(e.to_string()))?;
 
         if parsed.version != SUPPORTED_VERSION {
             return Err(ConfigFileError::UnsupportedVersion {
@@ -241,10 +241,7 @@ fn validate(p: &ConfigFileV1) -> Result<(), ConfigFileError> {
     let mut seen_video = std::collections::HashSet::new();
     for v in &p.videos {
         if !seen_video.insert(v.name.as_str()) {
-            return Err(ConfigFileError::Invalid(format!(
-                "duplicate video track '{}'",
-                v.name
-            )));
+            return Err(ConfigFileError::Invalid(format!("duplicate video track '{}'", v.name)));
         }
         if v.codec == Codec::Mjpeg {
             let q = v.quality.unwrap_or(DEFAULT_MJPEG_QUALITY);
@@ -293,10 +290,7 @@ fn validate(p: &ConfigFileV1) -> Result<(), ConfigFileError> {
     let mut seen_chunk = std::collections::HashSet::new();
     for c in &p.action_chunks {
         if !seen_chunk.insert(c.name.as_str()) {
-            return Err(ConfigFileError::Invalid(format!(
-                "duplicate action chunk '{}'",
-                c.name
-            )));
+            return Err(ConfigFileError::Invalid(format!("duplicate action chunk '{}'", c.name)));
         }
         if c.horizon == 0 {
             return Err(ConfigFileError::Invalid(format!(
@@ -411,10 +405,7 @@ videos:
   - { name: d, codec: h265 }
 "#;
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
-        assert_eq!(
-            cfg.video_track_names().collect::<Vec<_>>(),
-            ["a", "b", "c", "d"]
-        );
+        assert_eq!(cfg.video_track_names().collect::<Vec<_>>(), ["a", "b", "c", "d"]);
         // No byte-stream tracks: every codec here rides the WebRTC path.
         assert_eq!(cfg.frame_video_tracks().len(), 0);
         assert_eq!(cfg.video_tracks()[1].codec, Codec::Vp9);

--- a/livekit-portal/src/data.rs
+++ b/livekit-portal/src/data.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet};
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
-use livekit::prelude::*;
 use livekit::StreamByteOptions;
+use livekit::prelude::*;
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -14,14 +14,13 @@ use crate::error::{PortalError, PortalResult};
 #[cfg(test)]
 use crate::dtype::DType;
 use crate::metrics::{DataStream, MetricsRegistry};
-use crate::rtt::{RttService, RTT_TOPIC};
+use crate::rtt::{RTT_TOPIC, RttService};
 use crate::serialization::{
-    action_fingerprint, chunk_fingerprint, deserialize_action, deserialize_chunk,
+    DecodeError, action_fingerprint, chunk_fingerprint, deserialize_action, deserialize_chunk,
     deserialize_values, schema_fingerprint, serialize_action, serialize_chunk, serialize_values,
-    DecodeError,
 };
 use crate::sync_buffer::{SyncBuffer, SyncOutput};
-use crate::types::{to_value_maps, Action, ActionChunk, Role, State, TypedValue};
+use crate::types::{Action, ActionChunk, Role, State, TypedValue, to_value_maps};
 use crate::video::now_us;
 
 /// Reserved Portal topics. State and action travel as data packets;
@@ -148,16 +147,10 @@ impl DataPublisher {
             let mut last = self.last_values.lock();
             apply_carry_forward(&self.schema, &mut last, map);
             let out = match self.stream {
-                DataStream::State => {
-                    serialize_values(self.fingerprint, ts, &last, &self.schema)
+                DataStream::State => serialize_values(self.fingerprint, ts, &last, &self.schema),
+                DataStream::Action => {
+                    serialize_action(self.fingerprint, ts, in_reply_to_ts_us, &last, &self.schema)
                 }
-                DataStream::Action => serialize_action(
-                    self.fingerprint,
-                    ts,
-                    in_reply_to_ts_us,
-                    &last,
-                    &self.schema,
-                ),
                 DataStream::Chunk => unreachable!(
                     "DataPublisher only handles scalar state/action; chunks go through ChunkPublisher"
                 ),
@@ -257,11 +250,7 @@ impl DataPublisher {
 /// Update `last` in place with values from `map` for each declared field,
 /// leaving other slots untouched (carry-forward). Typed values are
 /// lossless-widened to `f64` on the way in.
-fn apply_carry_forward(
-    schema: &[FieldSpec],
-    last: &mut [f64],
-    map: &HashMap<String, TypedValue>,
-) {
+fn apply_carry_forward(schema: &[FieldSpec], last: &mut [f64], map: &HashMap<String, TypedValue>) {
     for (i, field) in schema.iter().enumerate() {
         if let Some(v) = map.get(&field.name) {
             last[i] = v.as_f64();
@@ -446,8 +435,7 @@ impl ChunkPublisher {
     ) -> PortalResult<()> {
         self.warn_unknown_keys(data);
         let ts = timestamp_us.unwrap_or_else(now_us);
-        let out =
-            serialize_chunk(self.fingerprint, ts, in_reply_to_ts_us, &self.spec, data);
+        let out = serialize_chunk(self.fingerprint, ts, in_reply_to_ts_us, &self.spec, data);
         if !out.saturated_indices.is_empty() {
             self.warn_saturated(&out.saturated_indices);
         }
@@ -552,13 +540,8 @@ pub(crate) fn dispatch_chunk_payload(
             let now = now_us();
             metrics.record_received(DataStream::Chunk, send_ts, now);
             metrics.record_e2e(in_reply_to_ts_us, now);
-            let data: HashMap<String, Vec<f64>> = slot
-                .spec
-                .fields
-                .iter()
-                .map(|f| f.name.clone())
-                .zip(columns)
-                .collect();
+            let data: HashMap<String, Vec<f64>> =
+                slot.spec.fields.iter().map(|f| f.name.clone()).zip(columns).collect();
             slot.deliver(ActionChunk {
                 name: slot.spec.name.clone(),
                 horizon: slot.spec.horizon,
@@ -593,11 +576,7 @@ pub(crate) fn build_action(
     Action { values: typed, raw_values: raw, timestamp_us, in_reply_to_ts_us, sender }
 }
 
-fn build_state(
-    timestamp_us: u64,
-    schema: &[FieldSpec],
-    values: &[f64],
-) -> State {
+fn build_state(timestamp_us: u64, schema: &[FieldSpec], values: &[f64]) -> State {
     let (typed, raw) = to_value_maps(schema, values);
     State { values: typed, raw_values: raw, timestamp_us }
 }
@@ -698,12 +677,10 @@ mod tests {
         apply_carry_forward(&schema, &mut last, &m);
         assert_eq!(last, vec![1.0, 2.5, 0.0], "j1 carries forward; j2 updates; j3 still at seed");
 
-        let m: HashMap<String, TypedValue> = [
-            ("j1".to_string(), TypedValue::F64(-1.0)),
-            ("j3".to_string(), TypedValue::F64(7.0)),
-        ]
-        .into_iter()
-        .collect();
+        let m: HashMap<String, TypedValue> =
+            [("j1".to_string(), TypedValue::F64(-1.0)), ("j3".to_string(), TypedValue::F64(7.0))]
+                .into_iter()
+                .collect();
         apply_carry_forward(&schema, &mut last, &m);
         assert_eq!(last, vec![-1.0, 2.5, 7.0], "j2 carries forward when omitted; others update");
     }
@@ -728,10 +705,8 @@ mod tests {
             Ok(())
         }
 
-        let schema = vec![
-            FieldSpec::new("gripper", DType::Bool),
-            FieldSpec::new("mode", DType::I8),
-        ];
+        let schema =
+            vec![FieldSpec::new("gripper", DType::Bool), FieldSpec::new("mode", DType::I8)];
 
         // Correct variants pass.
         let m: HashMap<String, TypedValue> = [

--- a/livekit-portal/src/error.rs
+++ b/livekit-portal/src/error.rs
@@ -19,7 +19,9 @@ pub enum PortalError {
     #[error("no peer in the room")]
     NoPeer,
 
-    #[error("room has multiple remote participants and no peer has been identified yet; pass destination explicitly")]
+    #[error(
+        "room has multiple remote participants and no peer has been identified yet; pass destination explicitly"
+    )]
     AmbiguousPeer,
 
     #[error("unknown video track: {name}")]
@@ -43,7 +45,9 @@ pub enum PortalError {
     #[error("operation not available for role {0:?}")]
     WrongRole(Role),
 
-    #[error("field '{field}' declared as {expected:?} but sent as {got}; use the matching TypedValue variant or redeclare the dtype")]
+    #[error(
+        "field '{field}' declared as {expected:?} but sent as {got}; use the matching TypedValue variant or redeclare the dtype"
+    )]
     DtypeMismatch { field: String, expected: DType, got: &'static str },
 
     #[error("{0}")]

--- a/livekit-portal/src/frame_video.rs
+++ b/livekit-portal/src/frame_video.rs
@@ -51,24 +51,24 @@
 //! quality knob.
 
 use std::collections::HashMap;
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use bytes::Bytes;
-use livekit::prelude::*;
 use livekit::StreamByteOptions;
+use livekit::prelude::*;
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use crate::codec::{decode_frame, encode_frame_into, estimated_encoded_size, Codec};
+use crate::codec::{Codec, decode_frame, encode_frame_into, estimated_encoded_size};
 use crate::config::FrameVideoSpec;
 use crate::error::{PortalError, PortalResult};
 use crate::metrics::TrackMetrics;
 use crate::portal::ObservationSink;
 use crate::sync_buffer::SyncBuffer;
 use crate::types::VideoFrameData;
-use crate::video::{now_us, VideoTrackSlots};
+use crate::video::{VideoTrackSlots, now_us};
 
 /// Reserved Portal topic for frame-video byte streams. A single topic
 /// multiplexes all frame-video tracks; the per-frame header carries the
@@ -161,8 +161,7 @@ pub(crate) fn build_frame_payload(
         )));
     }
     let header_len = HEADER_FIXED_LEN + name_bytes.len();
-    let mut buf =
-        Vec::with_capacity(header_len + estimated_encoded_size(width, height, codec));
+    let mut buf = Vec::with_capacity(header_len + estimated_encoded_size(width, height, codec));
     buf.push(WIRE_VERSION);
     buf.push(codec_id(codec));
     buf.extend_from_slice(&(width as u16).to_le_bytes());
@@ -377,10 +376,9 @@ pub(crate) fn dispatch_frame_payload(
         Err(e) => {
             // Re-borrow the name from the header buffer for the log; the
             // buffer is `payload`, still alive because we sliced from it.
-            let track_name = std::str::from_utf8(
-                &payload[HEADER_FIXED_LEN..HEADER_FIXED_LEN + track_name_len],
-            )
-            .unwrap_or("<invalid utf-8>");
+            let track_name =
+                std::str::from_utf8(&payload[HEADER_FIXED_LEN..HEADER_FIXED_LEN + track_name_len])
+                    .unwrap_or("<invalid utf-8>");
             log::warn!("[decode-failed] frame_video '{}': decode failed: {e}", track_name);
             return;
         }

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -20,15 +20,13 @@ pub use config::{
     VideoTrackSpec,
 };
 pub use config_file::ConfigFileError;
-pub use frame_video::BYTE_STREAM_CHUNK_SIZE;
 pub use dtype::DType;
 pub use error::{PortalError, PortalResult};
+pub use frame_video::BYTE_STREAM_CHUNK_SIZE;
 pub use metrics::{
     BufferMetrics, PolicyMetrics, PortalMetrics, RttMetrics, SyncMetrics, TransportMetrics,
 };
-pub use portal::{
-    Portal, ACTIVE_OPERATOR_ATTR_KEY, ROLE_ATTR_KEY, SET_ACTIVE_OPERATOR_RPC,
-};
+pub use portal::{ACTIVE_OPERATOR_ATTR_KEY, Portal, ROLE_ATTR_KEY, SET_ACTIVE_OPERATOR_RPC};
 pub use rpc::{RpcError, RpcHandler, RpcInvocationData};
 pub use types::{
     Action, ActionChunk, Observation, Role, State, SyncConfig, TypedValue, VideoFrameData,

--- a/livekit-portal/src/metrics.rs
+++ b/livekit-portal/src/metrics.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use parking_lot::Mutex;
 
@@ -141,10 +141,8 @@ pub(crate) struct MetricsRegistry {
 
 impl MetricsRegistry {
     pub fn new(video_tracks: &[String]) -> Self {
-        let per_track: HashMap<String, Arc<TrackMetrics>> = video_tracks
-            .iter()
-            .map(|n| (n.clone(), Arc::new(TrackMetrics::new())))
-            .collect();
+        let per_track: HashMap<String, Arc<TrackMetrics>> =
+            video_tracks.iter().map(|n| (n.clone(), Arc::new(TrackMetrics::new()))).collect();
         Self {
             track_order: video_tracks.to_vec(),
             per_track,
@@ -244,11 +242,7 @@ impl MetricsRegistry {
         self.rtt_last.store(rtt_us.max(1), Ordering::Relaxed);
     }
 
-    pub fn snapshot(
-        &self,
-        video_fill: HashMap<String, usize>,
-        state_fill: usize,
-    ) -> PortalMetrics {
+    pub fn snapshot(&self, video_fill: HashMap<String, usize>, state_fill: usize) -> PortalMetrics {
         let n = self.track_order.len();
         let mut frames_sent = HashMap::with_capacity(n);
         let mut frames_received = HashMap::with_capacity(n);
@@ -263,10 +257,8 @@ impl MetricsRegistry {
                 frames_received.insert(name.clone(), t.frames_received.load(Ordering::Relaxed));
                 frame_jitter_us.insert(name.clone(), t.jitter.lock().jitter_us);
                 evictions.insert(name.clone(), t.evictions.load(Ordering::Relaxed));
-                frames_dropped_publisher_full.insert(
-                    name.clone(),
-                    t.frames_dropped_publisher_full.load(Ordering::Relaxed),
-                );
+                frames_dropped_publisher_full
+                    .insert(name.clone(), t.frames_dropped_publisher_full.load(Ordering::Relaxed));
                 bytes_sent.insert(name.clone(), t.bytes_sent.load(Ordering::Relaxed));
                 bytes_received.insert(name.clone(), t.bytes_received.load(Ordering::Relaxed));
             }
@@ -296,9 +288,7 @@ impl MetricsRegistry {
         PortalMetrics {
             sync: SyncMetrics {
                 observations_emitted: self.observations_emitted.load(Ordering::Relaxed),
-                stale_observations_emitted: self
-                    .stale_observations_emitted
-                    .load(Ordering::Relaxed),
+                stale_observations_emitted: self.stale_observations_emitted.load(Ordering::Relaxed),
                 states_dropped: self.states_dropped.load(Ordering::Relaxed),
                 match_delta_us_p50: match_p50,
                 match_delta_us_p95: match_p95,

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,12 +11,12 @@ use tokio::task::JoinHandle;
 
 use crate::config::{ChunkSpec, FieldSpec, PortalConfig};
 use crate::data::{
-    dispatch_chunk_payload, handle_data_received, ActionSlot, ChunkPublisher, ChunkSlot,
-    DataPublisher, StateSlot, ACTION_CHUNK_TOPIC, ACTION_TOPIC, STATE_TOPIC,
+    ACTION_CHUNK_TOPIC, ACTION_TOPIC, ActionSlot, ChunkPublisher, ChunkSlot, DataPublisher,
+    STATE_TOPIC, StateSlot, dispatch_chunk_payload, handle_data_received,
 };
 use crate::error::{PortalError, PortalResult};
 use crate::frame_video::{
-    dispatch_frame_payload, FrameVideoPublisher, FrameVideoTrackEntry, FRAME_VIDEO_TOPIC,
+    FRAME_VIDEO_TOPIC, FrameVideoPublisher, FrameVideoTrackEntry, dispatch_frame_payload,
 };
 use crate::metrics::{DataStream, MetricsRegistry, PortalMetrics};
 use crate::rpc::{RpcError, RpcHandler, RpcInvocationData};
@@ -360,11 +360,7 @@ impl Portal {
         Self {
             config,
             lifecycle: tokio::sync::Mutex::new(()),
-            conn: Mutex::new(ConnectionState {
-                room: None,
-                event_task: None,
-                rtt: None,
-            }),
+            conn: Mutex::new(ConnectionState { room: None, event_task: None, rtt: None }),
             video_receivers: Arc::new(Mutex::new(HashMap::new())),
             video_publishers: Mutex::new(HashMap::new()),
             frame_video_publishers: Mutex::new(HashMap::new()),
@@ -396,10 +392,15 @@ impl Portal {
         let mut options = RoomOptions::default();
         options.auto_subscribe = true;
         if let Some(key) = &self.config.shared_key {
-            use livekit::e2ee::{key_provider::{KeyProvider, KeyProviderOptions}, EncryptionType};
             use livekit::E2eeOptions;
-            let key_provider = KeyProvider::with_shared_key(KeyProviderOptions::default(), key.clone());
-            options.encryption = Some(E2eeOptions { key_provider, encryption_type: EncryptionType::Gcm });
+            use livekit::e2ee::{
+                EncryptionType,
+                key_provider::{KeyProvider, KeyProviderOptions},
+            };
+            let key_provider =
+                KeyProvider::with_shared_key(KeyProviderOptions::default(), key.clone());
+            options.encryption =
+                Some(E2eeOptions { key_provider, encryption_type: EncryptionType::Gcm });
         }
 
         log::info!("[{}] connecting as {:?} to {}", self.config.session, self.config.role, url);
@@ -426,9 +427,9 @@ impl Portal {
             let handler: RpcHandler = Arc::new(move |data: RpcInvocationData| {
                 let lp_slot = lp_slot.clone();
                 let controller = controller.clone();
-                Box::pin(async move {
-                    set_active_operator_rpc_impl(&lp_slot, &controller, data).await
-                })
+                Box::pin(
+                    async move { set_active_operator_rpc_impl(&lp_slot, &controller, data).await },
+                )
             });
             self.register_rpc_method(SET_ACTIVE_OPERATOR_RPC, handler);
         }
@@ -549,7 +550,6 @@ impl Portal {
         Ok(())
     }
 
-
     pub fn send_video_frame(
         &self,
         track_name: &str,
@@ -576,11 +576,7 @@ impl Portal {
         // `send_action_chunk`.
         if self.config.role != Role::Robot
             && (self.config.video_tracks.iter().any(|s| s.name == track_name)
-                || self
-                    .config
-                    .frame_video_tracks
-                    .iter()
-                    .any(|s| s.name == track_name))
+                || self.config.frame_video_tracks.iter().any(|s| s.name == track_name))
         {
             return Err(PortalError::WrongRole(self.config.role));
         }
@@ -596,11 +592,8 @@ impl Portal {
         values: &HashMap<String, TypedValue>,
         timestamp_us: Option<u64>,
     ) -> PortalResult<()> {
-        let publisher = self
-            .state_publisher
-            .lock()
-            .clone()
-            .ok_or(PortalError::WrongRole(Role::Operator))?;
+        let publisher =
+            self.state_publisher.lock().clone().ok_or(PortalError::WrongRole(Role::Operator))?;
         // State has no echo path; drop the wire-values vector that
         // `send_map` returns for action callers.
         publisher.send_map(values, timestamp_us, None).map(|_| ())
@@ -642,9 +635,8 @@ impl Portal {
         if self.config.action_subscription && self.is_self_active() {
             // We only echo when self is the active operator, which means
             // we are connected and have a local identity. Unwrap is safe.
-            let local_id = self
-                .local_identity()
-                .expect("local_identity is Some when self == active_operator");
+            let local_id =
+                self.local_identity().expect("local_identity is Some when self == active_operator");
             let action = crate::data::build_action(
                 send_ts,
                 in_reply_to_ts_us,
@@ -746,10 +738,7 @@ impl Portal {
     /// This Portal's own LiveKit identity once connected. Reads from the
     /// stored `LocalParticipant`. `None` before `connect()` succeeds.
     pub fn local_identity(&self) -> Option<String> {
-        self.local_participant
-            .lock()
-            .as_ref()
-            .map(|lp| lp.identity().as_str().to_string())
+        self.local_participant.lock().as_ref().map(|lp| lp.identity().as_str().to_string())
     }
 
     /// Identity of the operator the robot is currently listening to, or
@@ -780,20 +769,14 @@ impl Portal {
     pub async fn set_active_operator(&self, identity: Option<String>) -> PortalResult<()> {
         match self.config.role {
             Role::Robot => {
-                let lp = self
-                    .local_participant
-                    .lock()
-                    .clone()
-                    .ok_or(PortalError::NotConnected)?;
+                let lp = self.local_participant.lock().clone().ok_or(PortalError::NotConnected)?;
                 let prev = self.controller.active_operator.lock().clone();
                 let mut attrs = HashMap::new();
                 attrs.insert(
                     ACTIVE_OPERATOR_ATTR_KEY.to_string(),
                     identity.clone().unwrap_or_default(),
                 );
-                lp.set_attributes(attrs)
-                    .await
-                    .map_err(|e| PortalError::Room(e.to_string()))?;
+                lp.set_attributes(attrs).await.map_err(|e| PortalError::Room(e.to_string()))?;
                 *self.controller.active_operator.lock() = identity.clone();
                 if prev != identity {
                     self.controller.fire_active_changed(identity.as_deref());
@@ -816,8 +799,7 @@ impl Portal {
                 // surface NoPeer quickly when there really is no robot.
                 let robot = self.resolve_robot_identity().await?;
                 let payload = identity.unwrap_or_default();
-                self.perform_rpc(Some(&robot), SET_ACTIVE_OPERATOR_RPC, payload, None)
-                    .await?;
+                self.perform_rpc(Some(&robot), SET_ACTIVE_OPERATOR_RPC, payload, None).await?;
                 Ok(())
             }
         }
@@ -900,11 +882,7 @@ impl Portal {
             Some(id) => id.to_string(),
             None => self.resolve_peer()?,
         };
-        let lp = self
-            .local_participant
-            .lock()
-            .clone()
-            .ok_or(PortalError::NotConnected)?;
+        let lp = self.local_participant.lock().clone().ok_or(PortalError::NotConnected)?;
 
         let mut data = PerformRpcData {
             destination_identity: destination,
@@ -1199,10 +1177,8 @@ impl Portal {
 
         for spec in &self.config.video_tracks {
             let track_name = &spec.name;
-            let track_metrics = self
-                .metrics
-                .track(track_name)
-                .expect("track metrics registered at construction");
+            let track_metrics =
+                self.metrics.track(track_name).expect("track metrics registered at construction");
             let publisher = VideoPublisher::new(
                 track_name,
                 track_metrics,
@@ -1224,12 +1200,9 @@ impl Portal {
         // — they emit one byte stream per frame instead. So no async setup
         // here, just spawn the per-track drainer task.
         for spec in &self.config.frame_video_tracks {
-            let track_metrics = self
-                .metrics
-                .track(&spec.name)
-                .expect("track metrics registered at construction");
-            let publisher =
-                FrameVideoPublisher::new(spec.clone(), lp.clone(), track_metrics);
+            let track_metrics =
+                self.metrics.track(&spec.name).expect("track metrics registered at construction");
+            let publisher = FrameVideoPublisher::new(spec.clone(), lp.clone(), track_metrics);
             log::info!(
                 "[{}] ready to publish frame-video track '{}' via byte stream (codec={:?}, quality={})",
                 self.config.session,
@@ -1237,9 +1210,7 @@ impl Portal {
                 spec.codec,
                 spec.quality
             );
-            self.frame_video_publishers
-                .lock()
-                .insert(spec.name.clone(), Arc::new(publisher));
+            self.frame_video_publishers.lock().insert(spec.name.clone(), Arc::new(publisher));
         }
 
         if !self.config.state_schema.is_empty() {
@@ -1305,14 +1276,8 @@ impl Portal {
                     spec.horizon,
                     spec.fields.len()
                 );
-                let publisher = ChunkPublisher::new(
-                    spec.clone(),
-                    lp.clone(),
-                    self.metrics.clone(),
-                );
-                self.chunk_publishers
-                    .lock()
-                    .insert(spec.name.clone(), Arc::new(publisher));
+                let publisher = ChunkPublisher::new(spec.clone(), lp.clone(), self.metrics.clone());
+                self.chunk_publishers.lock().insert(spec.name.clone(), Arc::new(publisher));
             }
         }
     }
@@ -1342,8 +1307,7 @@ impl Portal {
 /// when registering metrics and sync-buffer slots, since the consumer-facing
 /// API doesn't distinguish WebRTC and frame-video tracks.
 fn combined_track_names(config: &PortalConfig) -> Vec<String> {
-    let mut names: Vec<String> =
-        config.video_tracks.iter().map(|s| s.name.clone()).collect();
+    let mut names: Vec<String> = config.video_tracks.iter().map(|s| s.name.clone()).collect();
     names.extend(config.frame_video_tracks.iter().map(|s| s.name.clone()));
     names
 }
@@ -1447,25 +1411,14 @@ async fn set_active_operator_rpc_impl(
     controller: &ControllerState,
     data: RpcInvocationData,
 ) -> Result<String, RpcError> {
-    let identity = if data.payload.is_empty() {
-        None
-    } else {
-        Some(data.payload.clone())
-    };
+    let identity = if data.payload.is_empty() { None } else { Some(data.payload.clone()) };
     let lp = lp_slot.lock().clone();
     let Some(lp) = lp else {
-        return Err(RpcError::new(
-            RPC_NOT_CONNECTED,
-            "robot not connected",
-            None,
-        ));
+        return Err(RpcError::new(RPC_NOT_CONNECTED, "robot not connected", None));
     };
     let prev = controller.active_operator.lock().clone();
     let mut attrs = HashMap::new();
-    attrs.insert(
-        ACTIVE_OPERATOR_ATTR_KEY.to_string(),
-        identity.clone().unwrap_or_default(),
-    );
+    attrs.insert(ACTIVE_OPERATOR_ATTR_KEY.to_string(), identity.clone().unwrap_or_default());
     if let Err(e) = lp.set_attributes(attrs).await {
         return Err(RpcError::new(
             RPC_SET_ATTRIBUTES_FAILED,
@@ -1489,10 +1442,7 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
             if let RemoteTrack::Video(video_track) = track {
                 let track_name = publication.name();
                 if ctx.config.video_tracks.iter().any(|s| s.name == track_name) {
-                    log::info!(
-                        "[{}] subscribed to video track '{track_name}'",
-                        ctx.config.session
-                    );
+                    log::info!("[{}] subscribed to video track '{track_name}'", ctx.config.session);
                     if let Some(sync_buffer) = &ctx.sync_buffer {
                         let slots = ctx
                             .video_tracks
@@ -1529,7 +1479,9 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
             // an empty sender — those records don't carry a sender field.
             let gate_sender: String = match (ctx.config.role, topic.as_str()) {
                 (Role::Robot, ACTION_TOPIC) => {
-                    let Some(p) = &participant else { return; };
+                    let Some(p) = &participant else {
+                        return;
+                    };
                     let sender_id = p.identity().as_str().to_string();
                     let active = ctx.controller.active_operator.lock().clone();
                     if active.as_deref() != Some(sender_id.as_str()) {
@@ -1541,7 +1493,9 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                     if !ctx.config.action_subscription {
                         return;
                     }
-                    let Some(p) = &participant else { return; };
+                    let Some(p) = &participant else {
+                        return;
+                    };
                     let sender_id = p.identity().as_str().to_string();
                     let active = ctx.controller.active_operator.lock().clone();
                     if active.as_deref() != Some(sender_id.as_str()) {
@@ -1580,19 +1534,16 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
             // it owns; other applications using byte streams on unrelated
             // topics are left untouched.
             match (ctx.config.role, topic.as_str()) {
-                (Role::Robot, ACTION_CHUNK_TOPIC)
-                | (Role::Operator, ACTION_CHUNK_TOPIC) => {
+                (Role::Robot, ACTION_CHUNK_TOPIC) | (Role::Operator, ACTION_CHUNK_TOPIC) => {
                     // Robot always consumes chunks. Operators only consume
                     // when subscription is on (HITL recording, shadow eval).
                     // Bail out early on operators with subscription off so
                     // we never spawn the read task.
-                    if matches!(ctx.config.role, Role::Operator)
-                        && !ctx.config.action_subscription
+                    if matches!(ctx.config.role, Role::Operator) && !ctx.config.action_subscription
                     {
                         return;
                     }
-                    let Some(reader) =
-                        reader.take_if(|info| info.topic == ACTION_CHUNK_TOPIC)
+                    let Some(reader) = reader.take_if(|info| info.topic == ACTION_CHUNK_TOPIC)
                     else {
                         return;
                     };
@@ -1636,8 +1587,7 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
                     if ctx.frame_video_entries.is_empty() {
                         return;
                     }
-                    let Some(reader) =
-                        reader.take_if(|info| info.topic == FRAME_VIDEO_TOPIC)
+                    let Some(reader) = reader.take_if(|info| info.topic == FRAME_VIDEO_TOPIC)
                     else {
                         return;
                     };
@@ -1699,11 +1649,7 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
             // claims explicitly via `set_active_operator`.
             let identity = participant.identity();
             let id_str = identity.as_str().to_string();
-            log::info!(
-                "[{}] participant '{}' disconnected",
-                ctx.config.session,
-                id_str
-            );
+            log::info!("[{}] participant '{}' disconnected", ctx.config.session, id_str);
             if ctx.controller.operators.lock().remove(&id_str) {
                 ctx.controller.fire_op_left(&id_str);
             }

--- a/livekit-portal/src/rtt.rs
+++ b/livekit-portal/src/rtt.rs
@@ -54,10 +54,8 @@ impl RttService {
             let tx_ping = tx.clone();
             let metrics_ping = metrics.clone();
             Some(tokio::spawn(async move {
-                let mut interval =
-                    tokio::time::interval(Duration::from_millis(ping_interval_ms));
-                interval
-                    .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                let mut interval = tokio::time::interval(Duration::from_millis(ping_interval_ms));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                 loop {
                     interval.tick().await;
                     let ts = now_us();

--- a/livekit-portal/src/serialization.rs
+++ b/livekit-portal/src/serialization.rs
@@ -356,12 +356,8 @@ mod tests {
 
     #[test]
     fn mixed_dtype_roundtrip() {
-        let s = schema(&[
-            ("f", DType::F32),
-            ("i", DType::I8),
-            ("b", DType::Bool),
-            ("u", DType::U16),
-        ]);
+        let s =
+            schema(&[("f", DType::F32), ("i", DType::I8), ("b", DType::Bool), ("u", DType::U16)]);
         let fp = schema_fingerprint(&s);
         let values = vec![1.5, 127.0, 1.0, 65535.0];
         let out = serialize_values(fp, 42, &values, &s);
@@ -430,20 +426,11 @@ mod tests {
         // Two peers build their schemas separately; if the field names,
         // order, and dtypes agree, the u32 fingerprint must match —
         // otherwise the receive path drops every packet.
-        let peer_robot = schema(&[
-            ("j1", DType::F32),
-            ("gripper", DType::Bool),
-            ("mode", DType::I8),
-        ]);
-        let peer_operator = schema(&[
-            ("j1", DType::F32),
-            ("gripper", DType::Bool),
-            ("mode", DType::I8),
-        ]);
-        assert_eq!(
-            schema_fingerprint(&peer_robot),
-            schema_fingerprint(&peer_operator),
-        );
+        let peer_robot =
+            schema(&[("j1", DType::F32), ("gripper", DType::Bool), ("mode", DType::I8)]);
+        let peer_operator =
+            schema(&[("j1", DType::F32), ("gripper", DType::Bool), ("mode", DType::I8)]);
+        assert_eq!(schema_fingerprint(&peer_robot), schema_fingerprint(&peer_operator),);
     }
 
     #[test]
@@ -516,11 +503,7 @@ mod tests {
     // --- Chunk wire ------------------------------------------------------
 
     fn chunk_spec(name: &str, horizon: u32, fields: &[(&str, DType)]) -> ChunkSpec {
-        ChunkSpec::new(
-            name,
-            horizon,
-            fields.iter().map(|(n, d)| FieldSpec::new(*n, *d)),
-        )
+        ChunkSpec::new(name, horizon, fields.iter().map(|(n, d)| FieldSpec::new(*n, *d)))
     }
 
     #[test]

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -233,11 +233,7 @@ impl SyncBuffer {
             Some(_) => evicted > 0,
         };
 
-        if should_run {
-            self.try_sync()
-        } else {
-            SyncOutput::empty()
-        }
+        if should_run { self.try_sync() } else { SyncOutput::empty() }
     }
 
     pub fn push_state(&mut self, timestamp_us: u64, values: Vec<f64>) -> SyncOutput {
@@ -411,9 +407,7 @@ impl SyncBuffer {
                     if !frame_buf.is_empty() {
                         let c = self.cursors[track_i];
                         let cand = &frame_buf[c];
-                        if cand.timestamp_us <= state_ts
-                            && state_ts - cand.timestamp_us >= range
-                        {
+                        if cand.timestamp_us <= state_ts && state_ts - cand.timestamp_us >= range {
                             self.matched_scratch[track_i] = Some(MatchSlot {
                                 frame: cand.clone(),
                                 drain_to: Some(c),
@@ -423,11 +417,8 @@ impl SyncBuffer {
                         }
                     }
                     if let Some(stale) = self.last_emitted_frames[track_i].clone() {
-                        self.matched_scratch[track_i] = Some(MatchSlot {
-                            frame: stale,
-                            drain_to: None,
-                            stale: true,
-                        });
+                        self.matched_scratch[track_i] =
+                            Some(MatchSlot { frame: stale, drain_to: None, stale: true });
                         continue;
                     }
                 }
@@ -793,7 +784,11 @@ mod tests {
         // Only the second state remains. A frame matching it fires the obs.
         let out = push_f(&mut buf, "cam1", 2_005);
         assert_eq!(out.observations.len(), 1);
-        assert_eq!(out.observations[0].state["j1"], TypedValue::F64(2.0), "evicted state should not leak through");
+        assert_eq!(
+            out.observations[0].state["j1"],
+            TypedValue::F64(2.0),
+            "evicted state should not leak through"
+        );
         assert_eq!(out.observations[0].timestamp_us, 2_000);
     }
 
@@ -983,8 +978,7 @@ mod tests {
         assert_eq!(out.observations.len(), 1);
         assert_eq!(out.observations[0].state["j1"], TypedValue::F64(2.0));
         assert_eq!(
-            out.observations[0].frames["cam1"].timestamp_us,
-            1_000,
+            out.observations[0].frames["cam1"].timestamp_us, 1_000,
             "stale reuse uses the last emitted frame"
         );
     }
@@ -1010,8 +1004,7 @@ mod tests {
         assert_eq!(out.drops.len(), 0, "reuse replaces the horizon drop");
         assert_eq!(out.observations.len(), 1);
         assert_eq!(
-            out.observations[0].frames["cam1"].timestamp_us,
-            0,
+            out.observations[0].frames["cam1"].timestamp_us, 0,
             "stale reuse, not the unmatched buffered frame"
         );
         // The buffered frame must still be available for a later state.
@@ -1032,11 +1025,7 @@ mod tests {
 
         assert!(buf.push_state(1_000, vec![1.0]).is_empty());
         let out = push_f(&mut buf, "cam1", 100_000);
-        assert_eq!(
-            out.drops.len(),
-            1,
-            "no last-emitted frame yet — reuse can't save the state"
-        );
+        assert_eq!(out.drops.len(), 1, "no last-emitted frame yet — reuse can't save the state");
         assert_eq!(out.observations.len(), 0);
     }
 
@@ -1145,8 +1134,7 @@ mod tests {
         assert_eq!(out.drops.len(), 0);
         assert_eq!(out.observations.len(), 1);
         assert_eq!(
-            out.observations[0].frames["cam1"].timestamp_us,
-            200,
+            out.observations[0].frames["cam1"].timestamp_us, 200,
             "stale reuse should advance to the newest below-horizon frame"
         );
         // Buffer drained; last-emitted advanced.
@@ -1189,16 +1177,12 @@ mod tests {
             assert_eq!(out.observations.len(), 1);
             assert_eq!(out.drops.len(), 0);
             assert_eq!(
-                out.observations[0].frames["cam1"].timestamp_us,
-                frame_ts,
+                out.observations[0].frames["cam1"].timestamp_us, frame_ts,
                 "round #{i}: stale match should be the newest below-horizon frame"
             );
             // Buffer drains so it never pins at cap.
             assert_eq!(buf.video_buffers[0].len(), 0);
-            assert_eq!(
-                buf.last_emitted_frames[0].as_ref().unwrap().timestamp_us,
-                frame_ts
-            );
+            assert_eq!(buf.last_emitted_frames[0].as_ref().unwrap().timestamp_us, frame_ts);
         }
     }
 
@@ -1214,15 +1198,27 @@ mod tests {
         let mut buf = SyncBuffer::new(&tracks, schema, reuse_config(), metrics.clone());
 
         // Fresh emission #1.
-        let _ = buf.push_frame("cam1", Arc::new(VideoFrameData {
-            width: 2, height: 2, data: bytes::Bytes::from(vec![0u8; 12]), timestamp_us: 1_000,
-        }));
+        let _ = buf.push_frame(
+            "cam1",
+            Arc::new(VideoFrameData {
+                width: 2,
+                height: 2,
+                data: bytes::Bytes::from(vec![0u8; 12]),
+                timestamp_us: 1_000,
+            }),
+        );
         let _ = buf.push_state(1_050, vec![1.0]);
 
         // Fresh emission #2.
-        let _ = buf.push_frame("cam1", Arc::new(VideoFrameData {
-            width: 2, height: 2, data: bytes::Bytes::from(vec![0u8; 12]), timestamp_us: 2_000,
-        }));
+        let _ = buf.push_frame(
+            "cam1",
+            Arc::new(VideoFrameData {
+                width: 2,
+                height: 2,
+                data: bytes::Bytes::from(vec![0u8; 12]),
+                timestamp_us: 2_000,
+            }),
+        );
         let _ = buf.push_state(2_050, vec![2.0]);
 
         let snap = metrics.snapshot(HashMap::new(), 0);

--- a/livekit-portal/src/types.rs
+++ b/livekit-portal/src/types.rs
@@ -101,7 +101,13 @@ impl TypedValue {
             TypedValue::U32(v) => v as f64,
             TypedValue::U16(v) => v as f64,
             TypedValue::U8(v) => v as f64,
-            TypedValue::Bool(v) => if v { 1.0 } else { 0.0 },
+            TypedValue::Bool(v) => {
+                if v {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
         }
     }
 }
@@ -256,29 +262,47 @@ pub(crate) fn to_value_maps(
 //     m.insert("shoulder".into(), 0.5f32.into());
 
 impl From<f64> for TypedValue {
-    fn from(v: f64) -> Self { TypedValue::F64(v) }
+    fn from(v: f64) -> Self {
+        TypedValue::F64(v)
+    }
 }
 impl From<f32> for TypedValue {
-    fn from(v: f32) -> Self { TypedValue::F32(v) }
+    fn from(v: f32) -> Self {
+        TypedValue::F32(v)
+    }
 }
 impl From<i32> for TypedValue {
-    fn from(v: i32) -> Self { TypedValue::I32(v) }
+    fn from(v: i32) -> Self {
+        TypedValue::I32(v)
+    }
 }
 impl From<i16> for TypedValue {
-    fn from(v: i16) -> Self { TypedValue::I16(v) }
+    fn from(v: i16) -> Self {
+        TypedValue::I16(v)
+    }
 }
 impl From<i8> for TypedValue {
-    fn from(v: i8) -> Self { TypedValue::I8(v) }
+    fn from(v: i8) -> Self {
+        TypedValue::I8(v)
+    }
 }
 impl From<u32> for TypedValue {
-    fn from(v: u32) -> Self { TypedValue::U32(v) }
+    fn from(v: u32) -> Self {
+        TypedValue::U32(v)
+    }
 }
 impl From<u16> for TypedValue {
-    fn from(v: u16) -> Self { TypedValue::U16(v) }
+    fn from(v: u16) -> Self {
+        TypedValue::U16(v)
+    }
 }
 impl From<u8> for TypedValue {
-    fn from(v: u8) -> Self { TypedValue::U8(v) }
+    fn from(v: u8) -> Self {
+        TypedValue::U8(v)
+    }
 }
 impl From<bool> for TypedValue {
-    fn from(v: bool) -> Self { TypedValue::Bool(v) }
+    fn from(v: bool) -> Self {
+        TypedValue::Bool(v)
+    }
 }

--- a/livekit-portal/src/video.rs
+++ b/livekit-portal/src/video.rs
@@ -1,4 +1,4 @@
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -88,8 +88,7 @@ impl VideoPublisher {
         //     just don't want a tight cap forcing frame drops on high-motion
         //     bursts. Configurable per track via `add_video`'s
         //     `max_bitrate_kbps`.
-        let max_bitrate_kbps =
-            self.max_bitrate_kbps.unwrap_or(DEFAULT_H264_MAX_BITRATE_KBPS);
+        let max_bitrate_kbps = self.max_bitrate_kbps.unwrap_or(DEFAULT_H264_MAX_BITRATE_KBPS);
         let options = TrackPublishOptions {
             video_codec: webrtc_video_codec(self.codec),
             simulcast: false,
@@ -179,13 +178,10 @@ impl VideoReceiver {
                 // Portal-published tracks set this automatically; subscribed
                 // tracks from other publishers must do the same. See the
                 // "Sender requirement" note in README.md.
-                let timestamp_us = frame
-                    .frame_metadata
-                    .and_then(|m| m.user_timestamp)
-                    .expect(
-                        "video frame missing user_timestamp — \
+                let timestamp_us = frame.frame_metadata.and_then(|m| m.user_timestamp).expect(
+                    "video frame missing user_timestamp — \
                          sender must enable PacketTrailerFeatures.user_timestamp",
-                    );
+                );
                 let frame_data = convert_frame(&frame, timestamp_us);
                 let frame_arc = Arc::new(frame_data);
 


### PR DESCRIPTION
The output of `cargo fix` did not indicate any code changes are necessary, however, this should still be tested end-to-end to verify nothing has broken. Changes in diff are due solely to rerunning `cargo fmt` for the new edition.