### PR TITLE
feat(video): configurable WebRTC max bitrate + VP8/VP9/AV1/H265 codecs

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -150,7 +150,8 @@ than being silently ignored.
 
 ```yaml
 videos:
-  - { name: front,    codec: h264 }                   # WebRTC media path
+  - { name: front,    codec: h264, max_bitrate_kbps: 8000 }  # WebRTC media path, capped at 8 Mbps
+  - { name: wide,     codec: vp9 }                    # WebRTC media path, default ceiling
   - { name: wrist,    codec: mjpeg, quality: 90 }     # byte-stream, lossy
   - { name: depth,    codec: png }                    # byte-stream, lossless
   - { name: raw_cam,  codec: raw }                    # byte-stream, uncompressed RGB
@@ -159,14 +160,17 @@ videos:
 | Field | Type | Description |
 |---|---|---|
 | `name` | string | Track name. Unique across all `videos` entries. |
-| `codec` | string | One of `h264`, `mjpeg`, `png`, `raw`. Case-insensitive (`H264` works too). |
-| `quality` | int (optional) | `1..=100` for `mjpeg`. Defaults to `90`. Ignored for `raw`, `png`, `h264`. |
+| `codec` | string | One of `h264`, `vp8`, `vp9`, `av1`, `h265`, `mjpeg`, `png`, `raw`. Case-insensitive (`H264` works too; `hevc` is an alias for `h265`). |
+| `quality` | int (optional) | `1..=100` for `mjpeg`. Defaults to `90`. Ignored for every other codec. |
+| `max_bitrate_kbps` | int (optional) | Encoder bitrate ceiling (kbps) for the WebRTC codecs. A cap, not a target. Defaults to `10000` (10 Mbps). Rejected on the byte-stream codecs. |
 
 Codec choice picks both the encoding and the wire transport:
 
-- **`h264`** — WebRTC media path. Real-time RTP/SRTP, lossy, best-effort
-  delivery. libwebrtc picks the operating bitrate. Lowest end-to-end
-  latency at scale.
+- **`h264` / `vp8` / `vp9` / `av1` / `h265`** — WebRTC media path. Real-time
+  RTP/SRTP, lossy, best-effort delivery. libwebrtc picks the operating
+  bitrate up to `max_bitrate_kbps`. Lowest end-to-end latency at scale. VP9
+  and AV1 compress better than H264 at higher CPU cost; AV1 and H265 support
+  is platform- and peer-dependent, so confirm both ends negotiate the codec.
 - **`mjpeg`** — per-frame byte-stream, lossy. ~10-20x compression at
   q=90. Sub-millisecond decode. Each frame is independent.
 - **`png`** — per-frame byte-stream, lossless. ~2-3x compression on
@@ -281,7 +285,7 @@ ends up making.
 | `reuse_stale_frames` | `cfg.set_reuse_stale_frames(...)` |
 | `ping_ms` | `cfg.set_ping_ms(...)` |
 | `action_subscription` | `cfg.set_action_subscription(...)` |
-| `videos[]` | `cfg.add_video(name, codec, quality)` |
+| `videos[]` | `cfg.add_video(name, codec, quality, max_bitrate_kbps)` |
 | `state[]` | `cfg.add_state_typed([...])` |
 | `action[]` | `cfg.add_action_typed([...])` |
 | `action_chunks[]` | `cfg.add_action_chunk(name, horizon, fields)` |
@@ -302,7 +306,8 @@ tracks, same sync config.
    `version` the build doesn't know how to read.
 3. **`Invalid`** — pre-flight validation failures. Duplicate track
    names, duplicate chunk names, `horizon: 0`, MJPEG quality outside
-   `1..=100`, `fps` / `slack` / `tolerance` set to zero or negative.
+   `1..=100`, `max_bitrate_kbps` on a byte-stream codec or set to zero,
+   `fps` / `slack` / `tolerance` set to zero or negative.
 4. **`Io`** — `from_yaml_file` only. The file couldn't be opened.
 
 ```python
@@ -360,11 +365,21 @@ codec.
 ```yaml
 version: 1
 videos:
-  - { name: cam, codec: vp8 }
+  - { name: cam, codec: theora }
 ```
 
-→ `ConfigFileError.Parse(...)`: unknown codec `vp8`. The codec set
-is closed: `h264`, `raw`, `png`, `mjpeg`.
+→ `ConfigFileError.Parse(...)`: unknown codec `theora`. The codec set
+is closed: `h264`, `vp8`, `vp9`, `av1`, `h265`, `raw`, `png`, `mjpeg`.
+
+```yaml
+version: 1
+videos:
+  - { name: cam, codec: mjpeg, quality: 80, max_bitrate_kbps: 4000 }
+```
+
+→ `ConfigFileError.Invalid("video 'cam': max_bitrate_kbps applies to
+the WebRTC codecs only, not Mjpeg")`. The bitrate ceiling is a WebRTC
+encoder knob; the byte-stream codecs reject it.
 
 ```yaml
 version: 1

--- a/docs/frame-video.md
+++ b/docs/frame-video.md
@@ -5,9 +5,11 @@ codec. Use this when the frames feeding your policy must arrive as the
 same RGB bytes the camera produced — no I420 conversion, no temporal
 codec, no quality drift.
 
-Selected by passing a non-`H264` codec to `add_video`. The default
-codec is `VideoCodec.H264` (WebRTC); the byte-stream codecs are `RAW`,
-`PNG`, and `MJPEG`.
+Selected by passing a byte-stream codec to `add_video`. The byte-stream
+codecs are `RAW`, `PNG`, and `MJPEG`; everything else (`H264`, `VP8`,
+`VP9`, `AV1`, `H265`) rides the WebRTC media path instead — see
+[portal-api.md](portal-api.md#webrtc-video-options) for the WebRTC codec
+and `max_bitrate_kbps` options.
 
 ## When to use it
 
@@ -134,9 +136,11 @@ It is the wrong call when:
 - Frame rate must be deterministic. WebRTC's encoder will drop frames
   silently to fit a bitrate target.
 
-Picking a non-H264 codec on the same `add_video` call routes the track
+Picking a byte-stream codec on the same `add_video` call routes the track
 through the byte-stream transport, trading adaptive bitrate for
-deterministic per-frame delivery and bit-exact RGB.
+deterministic per-frame delivery and bit-exact RGB. The other WebRTC
+codecs (`VP8`/`VP9`/`AV1`/`H265`) and the `max_bitrate_kbps` cap are
+documented in [portal-api.md](portal-api.md#webrtc-video-options).
 
 ## Configuration
 
@@ -145,11 +149,14 @@ PortalConfig.add_video(
     name: str,
     codec: VideoCodec = VideoCodec.H264,
     quality: int = 90,
+    max_bitrate_kbps: int | None = None,
 )
 ```
 
-- `codec` is one of `VideoCodec.H264` (WebRTC), `VideoCodec.RAW`,
-  `VideoCodec.PNG`, `VideoCodec.MJPEG` (byte-stream).
+- `codec` is one of the WebRTC codecs `VideoCodec.H264` / `VP8` / `VP9` /
+  `AV1` / `H265`, or a byte-stream codec `VideoCodec.RAW` / `PNG` / `MJPEG`.
+- `max_bitrate_kbps` caps the WebRTC encoder's peak rate (a ceiling, not a
+  target). Defaults to 10 Mbps. Rejected on the byte-stream codecs.
 - `quality` is `1..=100` for MJPEG, ignored for every other codec.
   Quality 90 is visually near-lossless on natural images and produces
   10-20× compression. Quality 70 trades visible artifacts for ~2× more

--- a/docs/portal-api.md
+++ b/docs/portal-api.md
@@ -323,12 +323,30 @@ type.
 uint8. Width and height must both be even. Full details in
 [concepts.md](concepts.md#video-frame-format).
 
+## WebRTC video options
+
+`add_video(name)` defaults to `VideoCodec.H264` on the WebRTC media path.
+The other WebRTC codecs are available on the same call — `VideoCodec.VP8`,
+`VideoCodec.VP9`, `VideoCodec.AV1`, `VideoCodec.H265`. VP9 and AV1 compress
+better than H264 at higher CPU cost; AV1 and H265 support is platform- and
+peer-dependent, so confirm both ends negotiate the codec.
+
+`max_bitrate_kbps` caps the encoder's peak rate for any WebRTC codec. It's a
+ceiling, not a target — libwebrtc still picks a lower operating bitrate from
+content. Omit it for the default 10 Mbps ceiling.
+
+```python
+from livekit.portal import VideoCodec
+
+cfg.add_video("front", max_bitrate_kbps=8000)              # H264, capped at 8 Mbps
+cfg.add_video("wide", codec=VideoCodec.VP9, max_bitrate_kbps=4000)
+```
+
 ## Frame video (lossless or codec-of-your-choice)
 
-`add_video(name)` defaults to `VideoCodec.H264`, the WebRTC media path
-(lossy). For policies that read the pixels — VLA inference, behavior
-cloning, any case where colorspace shift breaks the policy distribution
-— pass a non-H264 codec on the same call:
+For policies that read the pixels — VLA inference, behavior cloning, any
+case where colorspace shift breaks the policy distribution — pass a
+byte-stream codec on the same call:
 
 ```python
 from livekit.portal import VideoCodec

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -66,18 +66,28 @@ impl From<core::Role> for Role {
 
 /// Video codec. Selected per-track at config time via
 /// `PortalConfig::add_video`. Codec choice picks both the encoding and the
-/// wire transport: `H264` rides the WebRTC media path; the rest ride a
-/// reliable per-frame byte-stream channel. Mirrors `livekit_portal::Codec`.
+/// wire transport: the WebRTC codecs (`H264` / `Vp8` / `Vp9` / `Av1` /
+/// `H265`) ride the WebRTC media path; the rest ride a reliable per-frame
+/// byte-stream channel. Mirrors `livekit_portal::Codec`.
 ///
 /// **Foreign binding casing**: UniFFI emits enum variants in the host
 /// language's idiomatic case. Python code uses `VideoCodec.H264` /
-/// `VideoCodec.RAW` / `VideoCodec.PNG` / `VideoCodec.MJPEG` (UPPER), not
+/// `VideoCodec.VP8` / `VideoCodec.RAW` / `VideoCodec.MJPEG` (UPPER), not
 /// the Rust spelling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum VideoCodec {
     /// WebRTC H.264. Real-time RTP/SRTP transport, lossy, best-effort.
     /// `quality` is ignored — libwebrtc picks the operating bitrate.
     H264,
+    /// WebRTC VP8. Same media path and trade-offs as `H264`.
+    Vp8,
+    /// WebRTC VP9. Same media path as `H264`, better compression, higher CPU.
+    Vp9,
+    /// WebRTC AV1. Same media path as `H264`, best compression, highest CPU.
+    Av1,
+    /// WebRTC H.265 / HEVC. Same media path as `H264`. Support is platform-
+    /// and build-dependent in libwebrtc.
+    H265,
     /// Uncompressed RGB24. Largest payload, zero encode cost. Byte-stream
     /// transport.
     Raw,
@@ -94,6 +104,10 @@ impl From<VideoCodec> for core::Codec {
     fn from(c: VideoCodec) -> Self {
         match c {
             VideoCodec::H264 => core::Codec::H264,
+            VideoCodec::Vp8 => core::Codec::Vp8,
+            VideoCodec::Vp9 => core::Codec::Vp9,
+            VideoCodec::Av1 => core::Codec::Av1,
+            VideoCodec::H265 => core::Codec::H265,
             VideoCodec::Raw => core::Codec::Raw,
             VideoCodec::Png => core::Codec::Png,
             VideoCodec::Mjpeg => core::Codec::Mjpeg,
@@ -105,6 +119,10 @@ impl From<core::Codec> for VideoCodec {
     fn from(c: core::Codec) -> Self {
         match c {
             core::Codec::H264 => VideoCodec::H264,
+            core::Codec::Vp8 => VideoCodec::Vp8,
+            core::Codec::Vp9 => VideoCodec::Vp9,
+            core::Codec::Av1 => VideoCodec::Av1,
+            core::Codec::H265 => VideoCodec::H265,
             core::Codec::Raw => VideoCodec::Raw,
             core::Codec::Png => VideoCodec::Png,
             core::Codec::Mjpeg => VideoCodec::Mjpeg,
@@ -544,9 +562,17 @@ impl PortalConfig {
     /// `Raw` ride a reliable per-frame byte-stream channel and the
     /// receiver decodes back to RGB so the user-facing frame API is
     /// identical. `quality` is `1..=100` for `Mjpeg` and ignored for
-    /// `H264` / `Raw` / `Png`.
-    pub fn add_video(&self, name: String, codec: VideoCodec, quality: u8) {
-        self.inner.lock().add_video(name, codec.into(), quality);
+    /// `H264` / `Raw` / `Png`. `max_bitrate_kbps` caps the H264 encoder's
+    /// peak rate (a ceiling, not a target); `None` uses the default 10 Mbps.
+    /// It is ignored for the byte-stream codecs.
+    pub fn add_video(
+        &self,
+        name: String,
+        codec: VideoCodec,
+        quality: u8,
+        max_bitrate_kbps: Option<u32>,
+    ) {
+        self.inner.lock().add_video(name, codec.into(), quality, max_bitrate_kbps);
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {
@@ -615,7 +641,7 @@ impl PortalConfig {
 
     /// Declared WebRTC video track names (H264).
     pub fn video_tracks(&self) -> Vec<String> {
-        self.inner.lock().video_tracks().to_vec()
+        self.inner.lock().video_track_names().map(String::from).collect()
     }
 
     /// Declared byte-stream video tracks (Raw / Png / Mjpeg) with codec
@@ -688,7 +714,7 @@ impl Portal {
         let cfg = config.inner.lock().clone();
         let state_fields: Vec<String> = cfg.state_fields().map(String::from).collect();
         let action_fields: Vec<String> = cfg.action_fields().map(String::from).collect();
-        let video_tracks = cfg.video_tracks().to_vec();
+        let video_tracks: Vec<String> = cfg.video_track_names().map(String::from).collect();
         let frame_video_tracks: Vec<FrameVideoSpec> = cfg
             .frame_video_tracks()
             .iter()

--- a/livekit-portal/src/codec.rs
+++ b/livekit-portal/src/codec.rs
@@ -18,17 +18,31 @@ use image::{ExtendedColorType, ImageEncoder};
 /// Codec used by a video track.
 ///
 /// Selected per-track at config time via `PortalConfig::add_video`. The codec
-/// also picks the wire transport: `H264` rides the WebRTC media path, every
-/// other variant rides a reliable byte-stream channel and is encoded by this
-/// module. The user-facing payload is RGB in every case.
+/// also picks the wire transport: the WebRTC codecs (`H264` / `Vp8` / `Vp9` /
+/// `Av1`) ride the WebRTC media path and are encoded by libwebrtc, every other
+/// variant rides a reliable byte-stream channel and is encoded by this module.
+/// The user-facing payload is RGB in every case.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Codec {
     /// WebRTC H.264, lossy. Real-time RTP/SRTP transport with libwebrtc's
     /// adaptive bitrate. Best-effort delivery — frames may drop or arrive
     /// late. Lowest end-to-end latency at scale. Encoded by libwebrtc,
     /// not this module — the byte-stream encode/decode helpers below panic
-    /// for `H264`.
+    /// for the WebRTC codecs.
     H264,
+    /// WebRTC VP8, lossy. Same media path and trade-offs as `H264`. Widely
+    /// supported software codec.
+    Vp8,
+    /// WebRTC VP9, lossy. Same media path as `H264`. Better compression than
+    /// VP8/H264 at equal quality, higher CPU cost.
+    Vp9,
+    /// WebRTC AV1, lossy. Same media path as `H264`. Best compression of the
+    /// set, highest CPU cost. Newest codec — confirm both peers support it.
+    Av1,
+    /// WebRTC H.265 / HEVC, lossy. Same media path as `H264`. Support is
+    /// platform- and build-dependent in libwebrtc — confirm both peers
+    /// negotiate it before relying on it.
+    H265,
     /// Uncompressed RGB24. Largest payload, zero encode cost. Use when CPU is
     /// scarce or you want bit-exact frames with no codec dependency.
     Raw,
@@ -45,7 +59,7 @@ impl Codec {
     /// Whether this codec rides the WebRTC media path. The remaining codecs
     /// ride the per-frame byte-stream path.
     pub fn is_webrtc(self) -> bool {
-        matches!(self, Codec::H264)
+        matches!(self, Codec::H264 | Codec::Vp8 | Codec::Vp9 | Codec::Av1 | Codec::H265)
     }
 }
 
@@ -123,8 +137,8 @@ pub fn estimated_encoded_size(width: u32, height: u32, codec: Codec) -> usize {
         Codec::Raw => raw,
         Codec::Png => raw,
         Codec::Mjpeg => (raw / 8).max(1024),
-        Codec::H264 => unreachable!(
-            "Codec::H264 rides the WebRTC media path, not the byte-stream encode path"
+        Codec::H264 | Codec::Vp8 | Codec::Vp9 | Codec::Av1 | Codec::H265 => unreachable!(
+            "WebRTC codecs ride the WebRTC media path, not the byte-stream encode path"
         ),
     }
 }
@@ -194,8 +208,8 @@ pub fn encode_frame_into(
                 .map_err(|e| CodecError::EncodeFailed(e.to_string()))?;
             Ok(())
         }
-        Codec::H264 => unreachable!(
-            "Codec::H264 rides the WebRTC media path, not the byte-stream encode path"
+        Codec::H264 | Codec::Vp8 | Codec::Vp9 | Codec::Av1 | Codec::H265 => unreachable!(
+            "WebRTC codecs ride the WebRTC media path, not the byte-stream encode path"
         ),
     }
 }
@@ -234,8 +248,8 @@ pub fn decode_frame(
             declared_width,
             declared_height,
         ),
-        Codec::H264 => unreachable!(
-            "Codec::H264 rides the WebRTC media path, not the byte-stream decode path"
+        Codec::H264 | Codec::Vp8 | Codec::Vp9 | Codec::Av1 | Codec::H265 => unreachable!(
+            "WebRTC codecs ride the WebRTC media path, not the byte-stream decode path"
         ),
     }
 }

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -7,6 +7,14 @@ use crate::types::{Role, SyncConfig};
 /// natural images, ~10-20x compression versus raw RGB.
 pub const DEFAULT_MJPEG_QUALITY: u8 = 90;
 
+/// Default H264 encoder bitrate ceiling (kbps) for `add_video` when no
+/// explicit `max_bitrate_kbps` is given. 10 Mbps is a generous cap: the
+/// encoder still picks a much lower operating bitrate from content. The cap
+/// only exists so high-motion bursts don't force frame drops. Lower it to
+/// hold a hard bandwidth budget; raise it to let the encoder spend more on
+/// motion.
+pub const DEFAULT_H264_MAX_BITRATE_KBPS: u32 = 10_000;
+
 /// A single schema entry: field name plus declared on-wire dtype.
 ///
 /// Named for parity with the UniFFI-facing `FieldSpec` record the
@@ -62,6 +70,30 @@ impl FrameVideoSpec {
     }
 }
 
+/// One WebRTC video track declaration: name, WebRTC codec, and an optional
+/// encoder bitrate ceiling.
+///
+/// The WebRTC counterpart to `FrameVideoSpec`. These tracks ride the WebRTC
+/// media path (RTP/SRTP). `codec` is always a WebRTC codec (`H264` / `Vp8` /
+/// `Vp9` / `Av1` / `H265`) — `add_video` routes byte-stream codecs to
+/// `FrameVideoSpec` instead. `max_bitrate_kbps` caps the encoder's peak rate
+/// in kilobits per second; `None` means use `DEFAULT_H264_MAX_BITRATE_KBPS`.
+/// The cap is a ceiling, not a target — libwebrtc still picks a lower
+/// operating bitrate from content. Selected at config time by passing a
+/// WebRTC codec to `PortalConfig::add_video`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoTrackSpec {
+    pub name: String,
+    pub codec: Codec,
+    pub max_bitrate_kbps: Option<u32>,
+}
+
+impl VideoTrackSpec {
+    pub fn new(name: impl Into<String>, codec: Codec, max_bitrate_kbps: Option<u32>) -> Self {
+        Self { name: name.into(), codec, max_bitrate_kbps }
+    }
+}
+
 /// Schema for one named action chunk: a fixed-horizon batch of per-field
 /// values that the operator publishes as a single packet.
 ///
@@ -95,7 +127,7 @@ impl ChunkSpec {
 pub struct PortalConfig {
     pub(crate) session: String,
     pub(crate) role: Role,
-    pub(crate) video_tracks: Vec<String>,
+    pub(crate) video_tracks: Vec<VideoTrackSpec>,
     pub(crate) frame_video_tracks: Vec<FrameVideoSpec>,
     pub(crate) state_schema: Vec<FieldSpec>,
     pub(crate) action_schema: Vec<FieldSpec>,
@@ -170,15 +202,22 @@ impl PortalConfig {
     ///
     /// `codec` picks both the encoding and the wire transport:
     ///
-    /// - `Codec::H264` rides the WebRTC media path (RTP/SRTP, lossy,
+    /// - The WebRTC codecs (`Codec::H264`, `Codec::Vp8`, `Codec::Vp9`,
+    ///   `Codec::Av1`, `Codec::H265`) ride the WebRTC media path (RTP/SRTP, lossy,
     ///   best-effort delivery, lowest latency at scale). `quality` is
-    ///   ignored — libwebrtc picks the operating bitrate.
+    ///   ignored — libwebrtc picks the operating bitrate. `max_bitrate_kbps`
+    ///   caps the encoder's peak rate (a ceiling, not a target); `None` uses
+    ///   `DEFAULT_H264_MAX_BITRATE_KBPS` (10 Mbps).
     /// - `Codec::Mjpeg`, `Codec::Png`, `Codec::Raw` ride a reliable
     ///   per-frame byte-stream channel. The receiver decodes back to RGB so
     ///   the user-facing `on_video_frame` / `get_video_frame` API is
     ///   identical to H264. `quality` is in `1..=100` for `Mjpeg` and
     ///   ignored for `Raw` / `Png`. Use `DEFAULT_MJPEG_QUALITY` (90) when
-    ///   in doubt.
+    ///   in doubt. `max_bitrate_kbps` is ignored for these codecs.
+    ///
+    /// `quality` and `max_bitrate_kbps` are independent per-codec knobs: H264
+    /// honors bitrate and ignores quality, the byte-stream codecs honor
+    /// quality and ignore bitrate.
     ///
     /// Track names must be unique across all `add_video` calls regardless
     /// of codec; a duplicate panics.
@@ -189,7 +228,13 @@ impl PortalConfig {
     /// codec whose encoded size fits in one chunk for low-latency
     /// closed-loop work. MJPEG at 224×224 to 480p typically does. Raw at
     /// anything above ~70×70 spills into multiple chunks.
-    pub fn add_video(&mut self, name: impl Into<String>, codec: Codec, quality: u8) {
+    pub fn add_video(
+        &mut self,
+        name: impl Into<String>,
+        codec: Codec,
+        quality: u8,
+        max_bitrate_kbps: Option<u32>,
+    ) {
         let name = name.into();
         assert!(
             !self.has_track(&name),
@@ -202,15 +247,18 @@ impl PortalConfig {
                 "MJPEG quality must be in 1..=100, got {quality}"
             );
         }
+        if let Some(kbps) = max_bitrate_kbps {
+            assert!(kbps > 0, "max_bitrate_kbps must be > 0, got {kbps}");
+        }
         if codec.is_webrtc() {
-            self.video_tracks.push(name);
+            self.video_tracks.push(VideoTrackSpec::new(name, codec, max_bitrate_kbps));
         } else {
             self.frame_video_tracks.push(FrameVideoSpec::new(name, codec, quality));
         }
     }
 
     fn has_track(&self, name: &str) -> bool {
-        self.video_tracks.iter().any(|n| n == name)
+        self.video_tracks.iter().any(|s| s.name == name)
             || self.frame_video_tracks.iter().any(|s| s.name == name)
     }
 
@@ -342,8 +390,15 @@ impl PortalConfig {
         self.reuse_stale_frames = enable;
     }
 
-    pub fn video_tracks(&self) -> &[String] {
+    /// Declared WebRTC (H264) video tracks (name + optional bitrate cap), in
+    /// declaration order.
+    pub fn video_tracks(&self) -> &[VideoTrackSpec] {
         &self.video_tracks
+    }
+
+    /// WebRTC (H264) video track names, derived from `video_tracks`.
+    pub fn video_track_names(&self) -> impl Iterator<Item = &str> {
+        self.video_tracks.iter().map(|s| s.name.as_str())
     }
 
     /// Declared frame-video tracks (name + codec + quality), in declaration

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -83,6 +83,11 @@ struct VideoEntry {
     codec: Codec,
     #[serde(default)]
     quality: Option<u8>,
+    /// WebRTC encoder bitrate ceiling in kilobits per second. Honored for the
+    /// WebRTC codecs (h264, vp8, vp9, av1, h265); rejected for the byte-stream
+    /// codecs. Omit to use the default ceiling.
+    #[serde(default)]
+    max_bitrate_kbps: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -108,11 +113,16 @@ where
     let s = String::deserialize(d)?;
     match s.to_ascii_lowercase().as_str() {
         "h264" => Ok(Codec::H264),
+        "vp8" => Ok(Codec::Vp8),
+        "vp9" => Ok(Codec::Vp9),
+        "av1" => Ok(Codec::Av1),
+        "h265" | "hevc" => Ok(Codec::H265),
         "raw" => Ok(Codec::Raw),
         "png" => Ok(Codec::Png),
         "mjpeg" => Ok(Codec::Mjpeg),
         other => Err(serde::de::Error::custom(format!(
-            "unknown codec '{other}' (expected one of h264, raw, png, mjpeg)"
+            "unknown codec '{other}' \
+             (expected one of h264, vp8, vp9, av1, h265, raw, png, mjpeg)"
         ))),
     }
 }
@@ -167,7 +177,7 @@ impl PortalConfig {
                 Codec::Mjpeg => DEFAULT_MJPEG_QUALITY,
                 _ => 0,
             });
-            cfg.add_video(&v.name, v.codec, quality);
+            cfg.add_video(&v.name, v.codec, quality, v.max_bitrate_kbps);
         }
 
         if !parsed.state.is_empty() {
@@ -245,6 +255,20 @@ fn validate(p: &ConfigFileV1) -> Result<(), ConfigFileError> {
                 )));
             }
         }
+        if let Some(kbps) = v.max_bitrate_kbps {
+            if !v.codec.is_webrtc() {
+                return Err(ConfigFileError::Invalid(format!(
+                    "video '{}': max_bitrate_kbps applies to the WebRTC codecs only, not {:?}",
+                    v.name, v.codec
+                )));
+            }
+            if kbps == 0 {
+                return Err(ConfigFileError::Invalid(format!(
+                    "video '{}': max_bitrate_kbps must be > 0",
+                    v.name
+                )));
+            }
+        }
     }
 
     if let Some(fps) = p.fps {
@@ -301,7 +325,7 @@ reuse_stale_frames: true
 ping_ms: 500
 action_subscription: true
 videos:
-  - { name: front, codec: h264 }
+  - { name: front, codec: h264, max_bitrate_kbps: 4000 }
   - { name: wrist, codec: mjpeg, quality: 80 }
   - { name: depth, codec: png }
 state:
@@ -320,7 +344,8 @@ action_chunks:
     #[test]
     fn full_config_round_trip() {
         let cfg = PortalConfig::from_yaml_str(yaml_full(), "demo", Role::Robot).unwrap();
-        assert_eq!(cfg.video_tracks(), &["front".to_string()]);
+        assert_eq!(cfg.video_track_names().collect::<Vec<_>>(), ["front"]);
+        assert_eq!(cfg.video_tracks()[0].max_bitrate_kbps, Some(4000));
         assert_eq!(cfg.frame_video_tracks().len(), 2);
         assert_eq!(cfg.frame_video_tracks()[0].name, "wrist");
         assert_eq!(cfg.frame_video_tracks()[0].codec, Codec::Mjpeg);
@@ -362,6 +387,63 @@ videos:
 "#;
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
         assert_eq!(cfg.frame_video_tracks()[0].quality, DEFAULT_MJPEG_QUALITY);
+    }
+
+    #[test]
+    fn h264_bitrate_defaults_to_none() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: h264 }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        assert_eq!(cfg.video_tracks()[0].max_bitrate_kbps, None);
+    }
+
+    #[test]
+    fn webrtc_codecs_route_to_video_tracks_with_bitrate() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: a, codec: vp8 }
+  - { name: b, codec: vp9, max_bitrate_kbps: 3000 }
+  - { name: c, codec: av1 }
+  - { name: d, codec: h265 }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        assert_eq!(
+            cfg.video_track_names().collect::<Vec<_>>(),
+            ["a", "b", "c", "d"]
+        );
+        // No byte-stream tracks: every codec here rides the WebRTC path.
+        assert_eq!(cfg.frame_video_tracks().len(), 0);
+        assert_eq!(cfg.video_tracks()[1].codec, Codec::Vp9);
+        assert_eq!(cfg.video_tracks()[1].max_bitrate_kbps, Some(3000));
+    }
+
+    #[test]
+    fn bitrate_on_byte_stream_codec_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: mjpeg, quality: 80, max_bitrate_kbps: 4000 }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        match err {
+            ConfigFileError::Invalid(msg) => assert!(msg.contains("max_bitrate_kbps")),
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn zero_bitrate_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: h264, max_bitrate_kbps: 0 }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        assert!(matches!(err, ConfigFileError::Invalid(_)));
     }
 
     #[test]
@@ -439,7 +521,7 @@ state:
         let yaml = r#"
 version: 1
 videos:
-  - { name: cam, codec: vp8 }
+  - { name: cam, codec: theora }
 "#;
         let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
         assert!(matches!(err, ConfigFileError::Parse(_)));
@@ -466,7 +548,7 @@ state:
   - { name: x, dtype: F32 }
 "#;
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
-        assert_eq!(cfg.video_tracks(), &["cam".to_string()]);
+        assert_eq!(cfg.video_track_names().collect::<Vec<_>>(), ["cam"]);
         assert_eq!(cfg.state_schema()[0].dtype, DType::F32);
     }
 

--- a/livekit-portal/src/frame_video.rs
+++ b/livekit-portal/src/frame_video.rs
@@ -112,8 +112,8 @@ fn codec_id(c: Codec) -> u8 {
         Codec::Raw => 0,
         Codec::Png => 1,
         Codec::Mjpeg => 2,
-        Codec::H264 => unreachable!(
-            "Codec::H264 rides the WebRTC media path, not the byte-stream wire format"
+        Codec::H264 | Codec::Vp8 | Codec::Vp9 | Codec::Av1 | Codec::H265 => unreachable!(
+            "WebRTC codecs ride the WebRTC media path, not the byte-stream wire format"
         ),
     }
 }

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -15,7 +15,10 @@ pub mod types;
 mod video;
 
 pub use codec::Codec;
-pub use config::{ChunkSpec, FieldSpec, FrameVideoSpec, PortalConfig};
+pub use config::{
+    ChunkSpec, DEFAULT_H264_MAX_BITRATE_KBPS, FieldSpec, FrameVideoSpec, PortalConfig,
+    VideoTrackSpec,
+};
 pub use config_file::ConfigFileError;
 pub use frame_video::BYTE_STREAM_CHUNK_SIZE;
 pub use dtype::DType;

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -575,7 +575,7 @@ impl Portal {
         // no publisher means "wrong role" — same shape as `send_state` /
         // `send_action_chunk`.
         if self.config.role != Role::Robot
-            && (self.config.video_tracks.iter().any(|n| n == track_name)
+            && (self.config.video_tracks.iter().any(|s| s.name == track_name)
                 || self
                     .config
                     .frame_video_tracks
@@ -1197,12 +1197,19 @@ impl Portal {
     async fn setup_robot(&self, room: &Room) -> PortalResult<()> {
         let lp = room.local_participant();
 
-        for track_name in &self.config.video_tracks {
+        for spec in &self.config.video_tracks {
+            let track_name = &spec.name;
             let track_metrics = self
                 .metrics
                 .track(track_name)
                 .expect("track metrics registered at construction");
-            let publisher = VideoPublisher::new(track_name, track_metrics, self.config.fps);
+            let publisher = VideoPublisher::new(
+                track_name,
+                track_metrics,
+                self.config.fps,
+                spec.codec,
+                spec.max_bitrate_kbps,
+            );
             if let Err(e) = publisher.publish(&lp).await {
                 // Roll back any earlier publishers so their send tasks stop
                 // and connect() leaves Portal in a clean state.
@@ -1335,7 +1342,8 @@ impl Portal {
 /// when registering metrics and sync-buffer slots, since the consumer-facing
 /// API doesn't distinguish WebRTC and frame-video tracks.
 fn combined_track_names(config: &PortalConfig) -> Vec<String> {
-    let mut names: Vec<String> = config.video_tracks.clone();
+    let mut names: Vec<String> =
+        config.video_tracks.iter().map(|s| s.name.clone()).collect();
     names.extend(config.frame_video_tracks.iter().map(|s| s.name.clone()));
     names
 }
@@ -1480,7 +1488,7 @@ fn handle_room_event(ctx: &EventContext, event: RoomEvent) {
             }
             if let RemoteTrack::Video(video_track) = track {
                 let track_name = publication.name();
-                if ctx.config.video_tracks.contains(&track_name.to_string()) {
+                if ctx.config.video_tracks.iter().any(|s| s.name == track_name) {
                     log::info!(
                         "[{}] subscribed to video track '{track_name}'",
                         ctx.config.session

--- a/livekit-portal/src/video.rs
+++ b/livekit-portal/src/video.rs
@@ -15,6 +15,8 @@ use livekit::webrtc::video_stream::native::NativeVideoStream;
 use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
+use crate::codec::Codec;
+use crate::config::DEFAULT_H264_MAX_BITRATE_KBPS;
 use crate::error::{PortalError, PortalResult};
 use crate::metrics::TrackMetrics;
 use crate::portal::ObservationSink;
@@ -31,15 +33,40 @@ pub(crate) struct VideoPublisher {
     track: LocalVideoTrack,
     metrics: Arc<TrackMetrics>,
     fps: u32,
+    codec: Codec,
+    max_bitrate_kbps: Option<u32>,
+}
+
+/// Map a Portal WebRTC codec to the libwebrtc codec the publish path sets.
+/// Only ever called for WebRTC codecs — `add_video` routes byte-stream codecs
+/// to the frame-video path, so they never reach a `VideoPublisher`.
+fn webrtc_video_codec(codec: Codec) -> VideoCodec {
+    match codec {
+        Codec::H264 => VideoCodec::H264,
+        Codec::Vp8 => VideoCodec::VP8,
+        Codec::Vp9 => VideoCodec::VP9,
+        Codec::Av1 => VideoCodec::AV1,
+        Codec::H265 => VideoCodec::H265,
+        Codec::Raw | Codec::Png | Codec::Mjpeg => unreachable!(
+            "byte-stream codecs never reach a VideoPublisher (add_video routes them \
+             to the frame-video path)"
+        ),
+    }
 }
 
 impl VideoPublisher {
-    pub fn new(name: &str, metrics: Arc<TrackMetrics>, fps: u32) -> Self {
+    pub fn new(
+        name: &str,
+        metrics: Arc<TrackMetrics>,
+        fps: u32,
+        codec: Codec,
+        max_bitrate_kbps: Option<u32>,
+    ) -> Self {
         let resolution = VideoResolution { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
         let source = NativeVideoSource::new(resolution, false);
         let rtc_source = RtcVideoSource::Native(source.clone());
         let track = LocalVideoTrack::create_video_track(name, rtc_source);
-        Self { source, track, metrics, fps }
+        Self { source, track, metrics, fps, codec, max_bitrate_kbps }
     }
 
     pub async fn publish(&self, local_participant: &LocalParticipant) -> PortalResult<()> {
@@ -56,16 +83,20 @@ impl VideoPublisher {
         //
         //   max_framerate = fps * 2 — 2x headroom over the capture rate so the
         //     adaptive-framerate logic never throttles below our cadence.
-        //   max_bitrate   = 10 Mbps — generous ceiling; the encoder still picks
-        //     a much lower operating bitrate based on content. We just don't
-        //     want a tight cap forcing frame drops on high-motion bursts.
+        //   max_bitrate   = per-track ceiling (default 10 Mbps); the encoder
+        //     still picks a much lower operating bitrate based on content. We
+        //     just don't want a tight cap forcing frame drops on high-motion
+        //     bursts. Configurable per track via `add_video`'s
+        //     `max_bitrate_kbps`.
+        let max_bitrate_kbps =
+            self.max_bitrate_kbps.unwrap_or(DEFAULT_H264_MAX_BITRATE_KBPS);
         let options = TrackPublishOptions {
-            video_codec: VideoCodec::H264,
+            video_codec: webrtc_video_codec(self.codec),
             simulcast: false,
             packet_trailer_features: features,
             video_encoding: Some(VideoEncoding {
                 max_framerate: (self.fps as f64) * 2.0,
-                max_bitrate: 10_000_000,
+                max_bitrate: (max_bitrate_kbps as u64) * 1_000,
             }),
             ..Default::default()
         };

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -59,11 +59,13 @@ class LiveKitRobotConfig(RobotConfig):
     # Video transport. `H264` rides the WebRTC media path (default).
     # `MJPEG` / `PNG` / `RAW` ride a reliable per-frame byte stream — pick
     # one of those for policy-grade pixels. `video_quality` is honored only
-    # for `MJPEG`. Both peers must agree, so set the same values on the
-    # operator's `LiveKitRobotConfig` and the robot's
-    # `LiveKitTeleoperatorConfig`.
+    # for `MJPEG`. `video_max_bitrate_kbps` caps the H264 encoder's peak rate
+    # (a ceiling, not a target); `None` uses the default 10 Mbps. Both peers
+    # must agree, so set the same values on the operator's `LiveKitRobotConfig`
+    # and the robot's `LiveKitTeleoperatorConfig`.
     video_codec: VideoCodec = VideoCodec.H264
     video_quality: int = DEFAULT_MJPEG_QUALITY
+    video_max_bitrate_kbps: int | None = None
 
     # Portal tuning.
     slack: int | None = None
@@ -179,6 +181,7 @@ class LiveKitRobot(Robot):
                 cam,
                 codec=self.config.video_codec,
                 quality=self.config.video_quality,
+                max_bitrate_kbps=self.config.video_max_bitrate_kbps,
             )
         if self._state_motors:
             self._portal_cfg.add_state_typed(

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
@@ -49,11 +49,13 @@ class LiveKitTeleoperatorConfig(TeleoperatorConfig):
     # Video transport. `H264` rides the WebRTC media path (default).
     # `MJPEG` / `PNG` / `RAW` ride a reliable per-frame byte stream — pick
     # one of those for policy-grade pixels. `video_quality` is honored only
-    # for `MJPEG`. Both peers must agree, so set the same values on the
-    # robot's `LiveKitTeleoperatorConfig` and the operator's
-    # `LiveKitRobotConfig`.
+    # for `MJPEG`. `video_max_bitrate_kbps` caps the H264 encoder's peak rate
+    # (a ceiling, not a target); `None` uses the default 10 Mbps. Both peers
+    # must agree, so set the same values on the robot's
+    # `LiveKitTeleoperatorConfig` and the operator's `LiveKitRobotConfig`.
     video_codec: VideoCodec = VideoCodec.H264
     video_quality: int = DEFAULT_MJPEG_QUALITY
+    video_max_bitrate_kbps: int | None = None
 
     # Portal tuning.
     slack: int | None = None
@@ -156,6 +158,7 @@ class LiveKitTeleoperator(Teleoperator):
                 cam,
                 codec=self.config.video_codec,
                 quality=self.config.video_quality,
+                max_bitrate_kbps=self.config.video_max_bitrate_kbps,
             )
         if self._state_motors:
             self._portal_cfg.add_state_typed(

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -63,6 +63,19 @@ RpcError = _ffi.RpcError
 # explicit value is given. Mirrors the Rust core's `DEFAULT_MJPEG_QUALITY`.
 DEFAULT_MJPEG_QUALITY: int = 90
 
+# Codecs that ride the WebRTC media path. The rest ride the per-frame
+# byte-stream channel. Mirrors the Rust core's `Codec::is_webrtc`; used to
+# route `add_video` declarations into the right Python-side mirror list.
+_WEBRTC_CODECS = frozenset(
+    {
+        VideoCodec.H264,
+        VideoCodec.VP8,
+        VideoCodec.VP9,
+        VideoCodec.AV1,
+        VideoCodec.H265,
+    }
+)
+
 # A schema entry accepted by add_state_typed/add_action_typed. Either a
 # FieldSpec (record passthrough) or a (name, dtype) tuple — the latter is
 # the natural Python shape.
@@ -737,6 +750,7 @@ class PortalConfig:
         name: str,
         codec: VideoCodec = VideoCodec.H264,
         quality: int = DEFAULT_MJPEG_QUALITY,
+        max_bitrate_kbps: Optional[int] = None,
     ) -> None:
         """Declare a video track.
 
@@ -745,9 +759,13 @@ class PortalConfig:
         `send_video_frame` accepts RGB and `on_video_frame` /
         `get_video_frame` deliver RGB.
 
-          * `VideoCodec.H264` (default) — WebRTC media path. Real-time
-            RTP/SRTP, lossy, best-effort. Lowest end-to-end latency at
-            scale. `quality` is ignored.
+          * `VideoCodec.H264` (default), `VideoCodec.VP8`, `VideoCodec.VP9`,
+            `VideoCodec.AV1`, `VideoCodec.H265` — WebRTC media path.
+            Real-time RTP/SRTP, lossy, best-effort. Lowest end-to-end latency
+            at scale. `quality` is ignored. `max_bitrate_kbps` caps the
+            encoder's peak rate (a ceiling, not a target); `None` uses the
+            default 10 Mbps. AV1/H265 support is platform- and peer-dependent;
+            confirm both ends negotiate the codec before relying on it.
           * `VideoCodec.RAW` — byte-stream, uncompressed RGB24. Largest
             payload, zero encode cost. `quality` is ignored.
           * `VideoCodec.PNG` — byte-stream, lossless. ~2-3x compression on
@@ -758,8 +776,9 @@ class PortalConfig:
             doesn't.
 
         `quality` is in 1..=100 and is honored for `VideoCodec.MJPEG`. It is
-        ignored for every other codec. Track names must be unique across
-        all `add_video` calls; a duplicate raises.
+        ignored for every other codec. `max_bitrate_kbps` is honored for the
+        WebRTC codecs (H264/VP8/VP9/AV1/H265) and ignored otherwise. Track
+        names must be unique across all `add_video` calls; a duplicate raises.
 
         **Byte-stream latency** (non-H264 codecs): each frame's payload is
         fragmented at the LiveKit chunk size (15 KB) and shipped over a
@@ -770,8 +789,8 @@ class PortalConfig:
         typical inference resolutions (224×224 to 480p) MJPEG q=80–95
         usually does.
         """
-        self._inner.add_video(name, codec, quality)
-        if codec == VideoCodec.H264:
+        self._inner.add_video(name, codec, quality, max_bitrate_kbps)
+        if codec in _WEBRTC_CODECS:
             self._video_tracks.append(name)
         else:
             self._frame_video_tracks.append(
@@ -1255,8 +1274,9 @@ class _RoleConfigBase:
         name: str,
         codec: VideoCodec = VideoCodec.H264,
         quality: int = DEFAULT_MJPEG_QUALITY,
+        max_bitrate_kbps: Optional[int] = None,
     ) -> None:
-        self._inner.add_video(name, codec, quality)
+        self._inner.add_video(name, codec, quality, max_bitrate_kbps)
 
     def add_state_typed(self, schema: Iterable[SchemaEntry]) -> None:
         self._inner.add_state_typed(schema)

--- a/python/packages/livekit-portal/tests/integration/conftest.py
+++ b/python/packages/livekit-portal/tests/integration/conftest.py
@@ -43,6 +43,7 @@ collect_ignore = (
         "test_e2ee.py",
         "test_multi_operator.py",
         "test_action_subscription.py",
+        "test_webrtc_codecs.py",
     ]
 )
 

--- a/python/packages/livekit-portal/tests/integration/test_webrtc_codecs.py
+++ b/python/packages/livekit-portal/tests/integration/test_webrtc_codecs.py
@@ -1,0 +1,85 @@
+"""Integration tests for the WebRTC video codecs against a live LiveKit server.
+
+`add_video` with a WebRTC codec (`H264`, `VP8`, `VP9`, `AV1`, `H265`) rides
+the WebRTC media path: libwebrtc encodes, the SFU forwards, libwebrtc decodes
+back to RGB on the receiver. `max_bitrate_kbps` caps the encoder's peak rate.
+
+These scenarios confirm the codec actually negotiates end-to-end and frames
+flow — the publish path maps the Portal codec to the libwebrtc codec, so a
+mapping regression would show up as zero received frames.
+
+Skipped automatically when `LIVEKIT_URL` isn't set (see conftest).
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import numpy as np
+import pytest
+
+from livekit.portal import VideoCodec, VideoFrameData
+
+pytestmark = pytest.mark.asyncio
+
+# WebRTC receive races connect → subscribe → SFU forward → decode → callback.
+# Give the track time to subscribe, then send a burst so something lands.
+SUBSCRIBE_SETTLE_S = 0.5
+DRAIN_S = 1.0
+
+
+def _gradient(width: int, height: int, seed: int = 0) -> np.ndarray:
+    x = np.arange(width, dtype=np.int32)
+    y = np.arange(height, dtype=np.int32)[:, None]
+    r = ((x + seed) % 256).astype(np.uint8)
+    g = ((y + seed) % 256).astype(np.uint8)
+    b = ((x + y + seed) % 256).astype(np.uint8)
+    return np.stack(
+        [np.broadcast_to(r, (height, width)), np.broadcast_to(g, (height, width)), b],
+        axis=-1,
+    )
+
+
+# VP8/VP9/H264 are broadly supported by libwebrtc builds. AV1/H265 negotiation
+# is platform- and build-dependent, so they're excluded from the must-pass
+# matrix to keep the test deterministic.
+@pytest.mark.parametrize("codec", [VideoCodec.H264, VideoCodec.VP8, VideoCodec.VP9])
+async def test_webrtc_codec_frames_flow(pair, codec):
+    """Each WebRTC codec must publish, negotiate, and deliver frames."""
+    pair.robot_cfg.add_video("cam", codec=codec)
+    pair.operator_cfg.add_video("cam", codec=codec)
+
+    received: list[VideoFrameData] = []
+    await pair.start()
+    pair.operator.on_video_frame("cam", lambda name, f: received.append(f))
+
+    # 320x240: above libwebrtc's minimum encode resolution. (VP8 in
+    # particular rescales sub-QVGA frames, so a 64x48 source would come
+    # back resized — irrelevant to whether the codec negotiates.)
+    await asyncio.sleep(SUBSCRIBE_SETTLE_S)
+    for i in range(15):
+        pair.robot.send_video_frame("cam", _gradient(320, 240, seed=i))
+        await asyncio.sleep(0.05)
+    await asyncio.sleep(DRAIN_S)
+
+    assert received, f"no frames received for codec {codec!r}"
+    assert received[0].width > 0 and received[0].height > 0
+
+
+async def test_h264_with_max_bitrate_cap_flows(pair):
+    """An H264 track with an explicit bitrate ceiling still publishes and
+    delivers frames — the cap is a ceiling, not a hard target."""
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.H264, max_bitrate_kbps=2000)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.H264)
+
+    received: list[VideoFrameData] = []
+    await pair.start()
+    pair.operator.on_video_frame("cam", lambda name, f: received.append(f))
+
+    await asyncio.sleep(SUBSCRIBE_SETTLE_S)
+    for i in range(15):
+        pair.robot.send_video_frame("cam", _gradient(320, 240, seed=i))
+        await asyncio.sleep(0.05)
+    await asyncio.sleep(DRAIN_S)
+
+    assert received, "no frames received for bitrate-capped H264 track"


### PR DESCRIPTION
## What

Two related changes to the WebRTC video path, bundled together.

### 1. Per-track max bitrate
`add_video` and the YAML `videos` entry gain an optional `max_bitrate_kbps` — the WebRTC counterpart to MJPEG's `quality`. It caps the encoder's peak rate (a ceiling, not a target). Omitting it uses `DEFAULT_H264_MAX_BITRATE_KBPS` (10 Mbps), the value that was previously hardcoded in `video.rs`. Rejected on the byte-stream codecs.

```yaml
videos:
  - { name: front, codec: h264, max_bitrate_kbps: 8000 }   # capped at 8 Mbps
  - { name: wide,  codec: vp9 }                             # default ceiling
```

### 2. All WebRTC codecs
The `Codec` enum gains `Vp8` / `Vp9` / `Av1` / `H265` alongside `H264`. `is_webrtc()` and a single `Codec -> livekit::VideoCodec` map in `video.rs` are the only codec-aware spots, so adding a codec is now additive. The bitrate knob applies uniformly to every WebRTC codec.

H264 tracks now carry a `VideoTrackSpec { name, codec, max_bitrate_kbps }`, parallel to `FrameVideoSpec`, instead of a bare track name.

## Surface
Wired through core, YAML loader, FFI, Python, and both lerobot plugins (`video_max_bitrate_kbps` config field). Docs updated: `config-file.md`, `portal-api.md`, `frame-video.md`.

## Testing
- 96 Rust unit tests + 37 Python config tests pass.
- New `test_webrtc_codecs.py` validates H264/VP8/VP9 negotiation and a bitrate-capped H264 track **end-to-end against a live LiveKit server** (4 passed). Full frame-video integration suite (21) still green.

## Notes
- **VP8 rescales sub-QVGA frames** — libwebrtc bumped a 64×48 source to 320 wide; H264/VP9 preserved it. Harmless at real teleop resolutions. The e2e test uses 320×240 and asserts frames-arrive rather than exact dimensions.
- **AV1/H265 are excluded from the must-pass e2e matrix.** Their negotiation is platform- and build-dependent in libwebrtc, so a CI test would be flaky. The code path and mapping are in place; docs flag the caveat.