### PR TITLE
docs: fix obs.frames type (VideoFrameData, not np.ndarray)

### DIFF
--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -165,7 +165,7 @@ async def main():
     def on_observation(obs):
         # obs.frames: dict[str, VideoFrameData]  # one per video track; .data is RGB24 bytes
         #   -> frame_bytes_to_numpy_rgb(f.data, f.width, f.height) for an (H, W, 3) array
-        # obs.state:  dict[str, float]
+        # obs.state:  dict[str, bool|int|float]  # native per dtype; obs.raw_state is all-float
         # obs.timestamp_us: int                  # sender clock
         action = policy(obs)                     # or teleop.get_action(), etc.
         portal.send_action(action)

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -163,7 +163,8 @@ async def main():
     portal = Operator(cfg)
 
     def on_observation(obs):
-        # obs.frames: dict[str, np.ndarray]      # one per registered video track
+        # obs.frames: dict[str, VideoFrameData]  # one per video track; .data is RGB24 bytes
+        #   -> frame_bytes_to_numpy_rgb(f.data, f.width, f.height) for an (H, W, 3) array
         # obs.state:  dict[str, float]
         # obs.timestamp_us: int                  # sender clock
         action = policy(obs)                     # or teleop.get_action(), etc.

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -29,10 +29,14 @@ mechanics.
 Robotics policies expect a single bundled tuple per step:
 
 ```
-Observation { frames: {cam1: ndarray, cam2: ndarray, ...},
+Observation { frames: {cam1: VideoFrameData, cam2: VideoFrameData, ...},
               state:  {joint1: 0.1, joint2: -0.3, ...},
               timestamp_us: int }
 ```
+
+Each `VideoFrameData` carries packed RGB24 bytes in `.data` plus `.width`,
+`.height`, and `.timestamp_us`. Call `frame_bytes_to_numpy_rgb(f.data,
+f.width, f.height)` to get an `(H, W, 3)` uint8 array.
 
 LiveKit doesn't deliver data that way. Video tracks, state streams, and action
 streams each have their own pacing, codec path, and retransmission. On the

--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -133,7 +133,7 @@ async def main():
     def on_observation(obs):
         # obs.frames: dict[str, VideoFrameData]  # one per video track; .data is RGB24 bytes
         #   -> frame_bytes_to_numpy_rgb(f.data, f.width, f.height) for an (H, W, 3) array
-        # obs.state:  dict[str, float]
+        # obs.state:  dict[str, bool|int|float]  # native per dtype; obs.raw_state is all-float
         # obs.timestamp_us: int               # sender clock
         action = model.select_action(obs)
         portal.send_action(action)
@@ -389,7 +389,7 @@ robot.on_active_operator_changed(cb)
 
 # rpc, metrics, lifecycle
 robot.register_rpc_method(name, handler) / robot.unregister_rpc_method(name)
-await robot.perform_rpc(name, payload, destination=None)
+await robot.perform_rpc(method, payload, destination=None, response_timeout_ms=None)
 robot.metrics() / robot.reset_metrics()
 await robot.connect(url, token) / await robot.disconnect()
 ```
@@ -413,7 +413,7 @@ op.on_active_operator_changed(cb)
 
 # rpc, metrics, lifecycle
 op.register_rpc_method(name, handler) / op.unregister_rpc_method(name)
-await op.perform_rpc(name, payload, destination=None)
+await op.perform_rpc(method, payload, destination=None, response_timeout_ms=None)
 op.metrics() / op.reset_metrics()
 await op.connect(url, token) / await op.disconnect()
 ```

--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -131,7 +131,8 @@ async def main():
     portal = Operator(cfg)
 
     def on_observation(obs):
-        # obs.frames: dict[str, np.ndarray]   # one per registered video track
+        # obs.frames: dict[str, VideoFrameData]  # one per video track; .data is RGB24 bytes
+        #   -> frame_bytes_to_numpy_rgb(f.data, f.width, f.height) for an (H, W, 3) array
         # obs.state:  dict[str, float]
         # obs.timestamp_us: int               # sender clock
         action = model.select_action(obs)


### PR DESCRIPTION
## What

The docs annotate `Observation.frames` values as `dict[str, np.ndarray]`, but the authoritative receive-side type is `VideoFrameData` — `.data` (packed RGB24 bytes), `.width`, `.height`, `.timestamp_us`. The `np.ndarray` annotation was a simplification. You get an `(H, W, 3)` array by calling `frame_bytes_to_numpy_rgb(f.data, f.width, f.height)`.

## Changes

- `docs/03-portal-api.md` — `on_observation` callback comment
- `docs/01-quickstart.md` — `on_observation` callback comment
- `docs/02-concepts.md` — observation-model block + a note on `VideoFrameData`

Left untouched: the **send-side** numpy mentions (`send_video_frame`, lerobot `get_observation()["camera"]`) — those genuinely take/return `(H, W, 3)` uint8 arrays and are accurate. `docs/05-frame-video.md` already shows the correct receive-side path.