### PR TITLE
ci: build aarch64 wheel on glibc 2.35 floor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04        # Linux x86_64  (glibc 2.35)
-          - ubuntu-24.04-arm    # Linux aarch64 (glibc 2.39)
+          - ubuntu-22.04        # Linux x86_64  (glibc 2.35 -> manylinux floor)
+          - ubuntu-22.04-arm    # Linux aarch64 (glibc 2.35 -> manylinux floor)
           - macos-latest        # macOS arm64   (Apple Silicon)
 
     steps:


### PR DESCRIPTION
Build the aarch64 wheel on ubuntu-22.04-arm instead of ubuntu-24.04-arm
so its manylinux floor is glibc 2.35 to match x86_64. The 2.39 floor from
ubuntu-24.04-arm excluded Ubuntu 22.04 aarch64 (glibc 2.35) and similar.
manylinux tags are forward compatible, so the 2.35 wheel still installs on
24.04+.
