### PR TITLE
test: fix flaky large raw-frame roundtrips (poll instead of fixed settle)

### DIFF
--- a/python/packages/livekit-portal/tests/integration/conftest.py
+++ b/python/packages/livekit-portal/tests/integration/conftest.py
@@ -48,6 +48,31 @@ collect_ignore = (
 )
 
 
+async def wait_for(
+    predicate,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.05,
+) -> bool:
+    """Poll `predicate` until it returns truthy or `timeout_s` elapses, then
+    return its final value.
+
+    Use this instead of a fixed `asyncio.sleep` before a receive assertion.
+    Large byte-stream payloads (e.g. a 25 MB raw frame) can take several
+    seconds to traverse the SFU, so a fixed settle window races the transfer
+    and flakes under load. Polling returns as soon as the data arrives and
+    only waits out the full timeout on genuine failure.
+    """
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(interval_s)
+    return bool(predicate())
+
+
 def _make_token(
     identity: str,
     room: str,

--- a/python/packages/livekit-portal/tests/integration/test_frame_video.py
+++ b/python/packages/livekit-portal/tests/integration/test_frame_video.py
@@ -262,9 +262,11 @@ async def test_large_frame_above_data_packet_cap(pair):
     )
     sent = _gradient(1280, 720, seed=3)
     pair.robot.send_video_frame("cam", sent)
-    # Larger payloads need more settle time.
-    await asyncio.sleep(SETTLE_S + 1.0)
-    assert len(received) == 1
+    # ~2.7 MB raw over the byte-stream path. Poll for arrival rather than
+    # race a fixed settle window, which flakes under load (issue #60).
+    from integration.conftest import wait_for
+
+    assert await wait_for(lambda: len(received) == 1, timeout_s=15.0)
     arr = frame_bytes_to_numpy_rgb(
         bytes(received[0].data), received[0].width, received[0].height
     )

--- a/python/packages/livekit-portal/tests/integration/test_frame_video_stress.py
+++ b/python/packages/livekit-portal/tests/integration/test_frame_video_stress.py
@@ -89,13 +89,16 @@ async def test_4k_frame_roundtrip(pair, codec):
 
     t0 = time.perf_counter()
     pair.robot.send_video_frame("cam", sent)
-    # Generous settle — 25 MB has to traverse the SFU and decode locally.
-    await asyncio.sleep(SETTLE_S + 4.0)
+    # 25 MB raw can take several seconds to traverse the SFU and decode.
+    # Poll up to a generous ceiling rather than race a fixed settle window,
+    # which flakes under load (issue #60).
+    from integration.conftest import wait_for
+
+    timeout_s = 30.0
+    ok = await wait_for(lambda: len(received) == 1, timeout_s=timeout_s)
     elapsed = time.perf_counter() - t0
 
-    assert len(received) == 1, (
-        f"4K {codec} not received within {SETTLE_S + 4.0}s; got {len(received)}"
-    )
+    assert ok, f"4K {codec} not received within {timeout_s}s; got {len(received)}"
     got = received[0]
     assert (got.width, got.height) == (3840, 2160)
     arr = frame_bytes_to_numpy_rgb(bytes(got.data), got.width, got.height)


### PR DESCRIPTION
Fixes #60.

## Problem

Two frame-video integration tests flaked:

- `test_frame_video.py::test_large_frame_above_data_packet_cap` (2.7 MB raw)
- `test_frame_video_stress.py::test_4k_frame_roundtrip[raw]` (24.9 MB raw)

They slept a fixed window then asserted the frame had arrived. Profiling showed a 25 MB raw frame takes ~4.6s over the byte-stream path, essentially equal to the test's 4.6s window. Under any load the assert raced the transfer and failed. The transfer itself is correct and byte-exact (the PNG/MJPEG variants, which compress small, always passed).

## Fix

Test-only. Add a `wait_for(predicate, timeout_s)` polling helper to `conftest.py` and use it in both tests. Poll for arrival up to a generous ceiling (15s / 30s) instead of racing a fixed sleep. It returns as soon as the frame lands, so the fast path stays fast and only a genuine failure waits out the timeout.

No production code changed. This is the transport-latency characteristic already documented for the byte-stream path, the tests just need to tolerate it.

## Verification

Against a local LiveKit server:
- The two previously-failing cases, run together, twice: pass
- Both full frame-video files in one process (the contention scenario): 44 passed, 0 failed

Branched from `main`, independent of #58 and #61.