### PR TITLE
feat(sync): add deadline-based drop to fix head-of-line blocking

### DIFF
--- a/docs/04-tuning.md
+++ b/docs/04-tuning.md
@@ -119,6 +119,35 @@ freeze. Any alert keyed on it needs rescoping. `last_blocker_track` only updates
 while a track is still waiting for its first frame, so it will not identify a
 freeze after startup.
 
+## Sync deadline
+
+Off by default (`0`). Set `cfg.set_sync_deadline_ms(N)` to bound how long a
+state will wait for a stalled video track before it is dropped.
+
+Without it, if a track stops sending, its head state blocks until the state
+buffer overflows (`slack`-many states later) — or forever, if state output also
+pauses. The deadline drops the stuck head once the **fastest-advancing stream's
+sender timestamp** has moved `N` ms past it, decoupling the drop from the state
+rate and from buffer size.
+
+```python
+cfg.set_sync_deadline_ms(200)   # give up on a stuck moment after 200 ms
+```
+
+The window is measured in **sender-clock time** (the robot's own timestamps),
+not wall-clock, so behavior is reproducible and testable. A value below the
+match window (`search_range`) is raised to it automatically. If *every* stream
+freezes at once there is no advancing clock, so capacity eviction remains the
+hard safety net.
+
+Deadline drops are counted in `metrics.sync.states_dropped_deadline` (a subset
+of `states_dropped`) and logged as a throttled `[sync-deadline]` line.
+
+| Use case | Pick |
+|---|---|
+| Real-time control on a flaky link | `100`–`300` ms — bound the stall, keep the loop moving. |
+| Data collection | `0` (off) or large — wait for the sample; pair with `reuse_stale_frames`. |
+
 ## Transport reliability
 
 State and actions use **reliable** delivery by default, which is lossless and

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -267,6 +267,9 @@ pub struct SyncMetrics {
     pub observations_emitted: u64,
     pub stale_observations_emitted: u64,
     pub states_dropped: u64,
+    /// Subset of `states_dropped` shed by the optional sync deadline
+    /// (`sync_deadline_ms`). 0 when the deadline is disabled.
+    pub states_dropped_deadline: u64,
     pub match_delta_us_p50: Option<u64>,
     pub match_delta_us_p95: Option<u64>,
     pub last_blocker_track: Option<String>,
@@ -621,6 +624,13 @@ impl PortalConfig {
 
     pub fn set_reuse_stale_frames(&self, enable: bool) {
         self.inner.lock().set_reuse_stale_frames(enable);
+    }
+
+    /// Stream-time deadline (ms) for dropping a state stuck behind a stalled
+    /// video track. `0` (default) disables it. See
+    /// `livekit_portal::PortalConfig::set_sync_deadline_ms`.
+    pub fn set_sync_deadline_ms(&self, ms: u32) {
+        self.inner.lock().set_sync_deadline_ms(ms);
     }
 
     pub fn set_e2ee_key(&self, key: Vec<u8>) {
@@ -1071,6 +1081,13 @@ impl RobotConfig {
         self.inner.set_reuse_stale_frames(enable);
     }
 
+    /// Stream-time deadline (ms) for dropping a state stuck behind a stalled
+    /// video track. `0` (default) disables it. See
+    /// `PortalConfig::set_sync_deadline_ms` for full semantics.
+    pub fn set_sync_deadline_ms(&self, ms: u32) {
+        self.inner.set_sync_deadline_ms(ms);
+    }
+
     /// No-op on the Robot side — the robot always processes actions. Kept on
     /// the surface so `RobotConfig` and `OperatorConfig` stay symmetrical.
     pub fn set_action_subscription(&self, enable: bool) {
@@ -1174,6 +1191,13 @@ impl OperatorConfig {
 
     pub fn set_reuse_stale_frames(&self, enable: bool) {
         self.inner.set_reuse_stale_frames(enable);
+    }
+
+    /// Stream-time deadline (ms) for dropping a state stuck behind a stalled
+    /// video track. `0` (default) disables it. See
+    /// `PortalConfig::set_sync_deadline_ms` for full semantics.
+    pub fn set_sync_deadline_ms(&self, ms: u32) {
+        self.inner.set_sync_deadline_ms(ms);
     }
 
     /// Operator-side opt-in to receiving executed actions ("HITL recording").
@@ -1557,6 +1581,7 @@ fn metrics_from_core(m: core::PortalMetrics) -> PortalMetrics {
             observations_emitted: m.sync.observations_emitted,
             stale_observations_emitted: m.sync.stale_observations_emitted,
             states_dropped: m.sync.states_dropped,
+            states_dropped_deadline: m.sync.states_dropped_deadline,
             match_delta_us_p50: m.sync.match_delta_us_p50,
             match_delta_us_p95: m.sync.match_delta_us_p95,
             last_blocker_track: m.sync.last_blocker_track,

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -135,6 +135,11 @@ pub struct PortalConfig {
     pub(crate) tolerance: f32,
     pub(crate) ping_ms: u64,
     pub(crate) reuse_stale_frames: bool,
+    /// Sync deadline in milliseconds of sender-clock time. `0` (the default)
+    /// disables the deadline; a positive value is clamped up to at least the
+    /// match window (`search_range`) in `sync_config()`. See
+    /// `set_sync_deadline_ms`.
+    pub(crate) sync_deadline_ms: u32,
     pub(crate) shared_key: Option<Vec<u8>>,
     /// Operator-side: subscribe to executed actions. Off by default —
     /// most operators are pure controllers and do not want the bandwidth
@@ -168,6 +173,7 @@ impl PortalConfig {
             tolerance: 1.5,
             ping_ms: 1000,
             reuse_stale_frames: false,
+            sync_deadline_ms: 0,
             shared_key: None,
             action_subscription: false,
         }
@@ -386,6 +392,31 @@ impl PortalConfig {
         self.reuse_stale_frames = enable;
     }
 
+    /// Optional stream-time deadline for shedding a stuck state, in
+    /// milliseconds. Normally a head state that cannot be matched (because a
+    /// video track has stalled) waits until buffer capacity evicts it — or
+    /// forever, if state output also pauses. With a deadline set, the state
+    /// is dropped once the fastest-advancing stream's sender timestamp has
+    /// moved this many milliseconds past it, bounding the stall to a
+    /// predictable, tunable window instead of `slack`-many state intervals.
+    ///
+    /// The deadline is measured purely in sender-clock time (never
+    /// wall-clock), so sync decisions stay reproducible and testable. `0`
+    /// (the default) disables it, preserving the strict wait-until-eviction
+    /// behavior. A value below the match window (`search_range`) is raised to
+    /// it in [`sync_config`](Self::sync_config), since a shorter deadline
+    /// could drop a state that a slightly-late in-range frame would still
+    /// match.
+    ///
+    /// Complements [`set_reuse_stale_frames`](Self::set_reuse_stale_frames):
+    /// with reuse on, a track that has already emitted freezes on its last
+    /// frame instead of blocking, so the deadline mainly governs the startup
+    /// window before a track's first emission; with reuse off (the default),
+    /// it governs every stall.
+    pub fn set_sync_deadline_ms(&mut self, ms: u32) {
+        self.sync_deadline_ms = ms;
+    }
+
     /// Declared WebRTC (H264) video tracks (name + optional bitrate cap), in
     /// declaration order.
     pub fn video_tracks(&self) -> &[VideoTrackSpec] {
@@ -438,11 +469,68 @@ impl PortalConfig {
     /// Derived sync config used internally by the sync buffer. Not public.
     pub(crate) fn sync_config(&self) -> SyncConfig {
         let search_range_us = (self.tolerance * 1_000_000.0 / self.fps as f32) as u64;
+        // `0` disables the deadline. Any positive value is clamped up to at
+        // least the match window: a deadline shorter than `search_range`
+        // could drop a state that a frame arriving slightly late (but still
+        // in range) would have matched.
+        let sync_deadline_us = match self.sync_deadline_ms {
+            0 => None,
+            ms => {
+                let requested = ms as u64 * 1_000;
+                if requested < search_range_us {
+                    log::debug!(
+                        "[sync-deadline] requested deadline {ms}ms ({requested}us) is below the \
+                         match window ({search_range_us}us); raising to the match window"
+                    );
+                    Some(search_range_us)
+                } else {
+                    Some(requested)
+                }
+            }
+        };
         SyncConfig {
             video_buffer_size: self.slack,
             state_buffer_size: self.slack,
             search_range_us,
             reuse_stale_frames: self.reuse_stale_frames,
+            sync_deadline_us,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_deadline_defaults_to_disabled() {
+        let cfg = PortalConfig::new("demo", Role::Robot);
+        assert_eq!(cfg.sync_config().sync_deadline_us, None);
+    }
+
+    #[test]
+    fn sync_deadline_converts_ms_to_us() {
+        let mut cfg = PortalConfig::new("demo", Role::Robot);
+        cfg.set_fps(30);
+        cfg.set_tolerance(1.5); // search_range = 1.5 * 1e6 / 30 = 50_000us
+        cfg.set_sync_deadline_ms(200);
+        assert_eq!(cfg.sync_config().sync_deadline_us, Some(200_000));
+    }
+
+    #[test]
+    fn sync_deadline_below_match_window_is_clamped_up() {
+        let mut cfg = PortalConfig::new("demo", Role::Robot);
+        cfg.set_fps(30);
+        cfg.set_tolerance(1.5); // search_range = 50_000us (50ms)
+        cfg.set_sync_deadline_ms(10); // 10ms < 50ms window
+        let sc = cfg.sync_config();
+        assert_eq!(sc.sync_deadline_us, Some(sc.search_range_us));
+    }
+
+    #[test]
+    fn sync_deadline_zero_disables() {
+        let mut cfg = PortalConfig::new("demo", Role::Robot);
+        cfg.set_sync_deadline_ms(0);
+        assert_eq!(cfg.sync_config().sync_deadline_us, None);
     }
 }

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -61,6 +61,8 @@ struct ConfigFileV1 {
     #[serde(default)]
     reuse_stale_frames: Option<bool>,
     #[serde(default)]
+    sync_deadline_ms: Option<u32>,
+    #[serde(default)]
     ping_ms: Option<u64>,
     #[serde(default)]
     action_subscription: Option<bool>,
@@ -212,6 +214,9 @@ impl PortalConfig {
         if let Some(v) = parsed.reuse_stale_frames {
             cfg.set_reuse_stale_frames(v);
         }
+        if let Some(v) = parsed.sync_deadline_ms {
+            cfg.set_sync_deadline_ms(v);
+        }
         if let Some(v) = parsed.ping_ms {
             cfg.set_ping_ms(v);
         }
@@ -316,6 +321,7 @@ tolerance: 1.0
 state_reliable: false
 action_reliable: false
 reuse_stale_frames: true
+sync_deadline_ms: 250
 ping_ms: 500
 action_subscription: true
 videos:
@@ -349,6 +355,9 @@ action_chunks:
         let state: Vec<&str> = cfg.state_fields().collect();
         assert_eq!(state, vec!["joint_pos", "gripper"]);
         assert_eq!(cfg.state_schema()[1].dtype, DType::Bool);
+
+        // 250ms deadline, well above the fps=60 / tolerance=1.0 match window.
+        assert_eq!(cfg.sync_config().sync_deadline_us, Some(250_000));
 
         let action: Vec<&str> = cfg.action_fields().collect();
         assert_eq!(action, vec!["joint_pos"]);

--- a/livekit-portal/src/metrics.rs
+++ b/livekit-portal/src/metrics.rs
@@ -24,6 +24,12 @@ pub struct SyncMetrics {
     /// rate signals a silently frozen video track.
     pub stale_observations_emitted: u64,
     pub states_dropped: u64,
+    /// Subset of `states_dropped` shed specifically by the optional sync
+    /// deadline (`sync_deadline_ms`) — a head state given up on because a
+    /// video track stalled past the deadline. Always 0 when the deadline is
+    /// disabled. A rising counter points at a stalled or chronically-behind
+    /// video track; pair it with `last_blocker_track`.
+    pub states_dropped_deadline: u64,
     /// Worst per-track alignment `max_t |state_ts − frame_ts|` across the
     /// tracks in each emitted observation, over a rolling 256-sample window.
     pub match_delta_us_p50: Option<u64>,
@@ -127,6 +133,7 @@ pub(crate) struct MetricsRegistry {
     observations_emitted: AtomicU64,
     stale_observations_emitted: AtomicU64,
     states_dropped: AtomicU64,
+    states_dropped_deadline: AtomicU64,
     match_deltas: Mutex<SampleRing>,
     // Index into `track_order`; `usize::MAX` means "no blocker recorded".
     // Stored as an atomic so `record_blocker` allocates nothing on the hot path.
@@ -160,6 +167,7 @@ impl MetricsRegistry {
             observations_emitted: AtomicU64::new(0),
             stale_observations_emitted: AtomicU64::new(0),
             states_dropped: AtomicU64::new(0),
+            states_dropped_deadline: AtomicU64::new(0),
             match_deltas: Mutex::new(SampleRing::new(SAMPLE_RING_CAP)),
             last_blocker_track: AtomicUsize::new(usize::MAX),
             rtt_samples: Mutex::new(SampleRing::new(SAMPLE_RING_CAP)),
@@ -228,6 +236,15 @@ impl MetricsRegistry {
         self.states_dropped.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Record a deadline-driven drop. Counts toward both `states_dropped`
+    /// (the total) and `states_dropped_deadline` (the deadline-specific
+    /// subset), so callers invoke this instead of `record_state_dropped`
+    /// for deadline drops rather than in addition to it.
+    pub fn record_state_dropped_deadline(&self, n: u64) {
+        self.states_dropped.fetch_add(n, Ordering::Relaxed);
+        self.states_dropped_deadline.fetch_add(n, Ordering::Relaxed);
+    }
+
     pub fn record_blocker(&self, track_index: usize) {
         self.last_blocker_track.store(track_index, Ordering::Relaxed);
     }
@@ -290,6 +307,7 @@ impl MetricsRegistry {
                 observations_emitted: self.observations_emitted.load(Ordering::Relaxed),
                 stale_observations_emitted: self.stale_observations_emitted.load(Ordering::Relaxed),
                 states_dropped: self.states_dropped.load(Ordering::Relaxed),
+                states_dropped_deadline: self.states_dropped_deadline.load(Ordering::Relaxed),
                 match_delta_us_p50: match_p50,
                 match_delta_us_p95: match_p95,
                 last_blocker_track,
@@ -342,6 +360,7 @@ impl MetricsRegistry {
         self.observations_emitted.store(0, Ordering::Relaxed);
         self.stale_observations_emitted.store(0, Ordering::Relaxed);
         self.states_dropped.store(0, Ordering::Relaxed);
+        self.states_dropped_deadline.store(0, Ordering::Relaxed);
         self.match_deltas.lock().clear();
         self.last_blocker_track.store(usize::MAX, Ordering::Relaxed);
         self.rtt_samples.lock().clear();

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -114,6 +114,11 @@ pub(crate) struct SyncBuffer {
     // see `DropWarn`.
     drop_warn: DropWarn,
 
+    // Rate-limiter for the deadline-drop warning. Separate from `drop_warn`
+    // so a stalled-track deadline burst and a horizon-drop burst each keep
+    // their own throttle window. Logging only.
+    deadline_warn: DropWarn,
+
     metrics: Arc<MetricsRegistry>,
 }
 
@@ -145,6 +150,7 @@ impl SyncBuffer {
             last_emitted_frames,
             in_overflow_burst: false,
             drop_warn: DropWarn::default(),
+            deadline_warn: DropWarn::default(),
             metrics,
         }
     }
@@ -189,6 +195,67 @@ impl SyncBuffer {
         self.drop_warn.last_log = Some(now);
         self.drop_warn.count = 0;
         self.drop_warn.worst_ahead_us = 0;
+    }
+
+    /// Count one deadline-driven drop and emit a throttled warning.
+    /// `waited_us` is how far the fastest-advancing stream's sender clock had
+    /// moved past the dropped state (`logical_now - state_ts`), i.e. how long
+    /// the state was stuck in stream-time. Same throttle shape as
+    /// `note_unsyncable_drop`, on its own `deadline_warn` window.
+    fn note_deadline_drop(&mut self, waited_us: u64) {
+        self.deadline_warn.count += 1;
+        self.deadline_warn.worst_ahead_us = self.deadline_warn.worst_ahead_us.max(waited_us);
+
+        let now = Instant::now();
+        let elapsed = self.deadline_warn.last_log.map(|t| now.duration_since(t));
+        let should_log = match elapsed {
+            None => true,
+            Some(d) => d >= DROP_WARN_INTERVAL,
+        };
+        if !should_log {
+            return;
+        }
+
+        let deadline_ms = self.config.sync_deadline_us.unwrap_or(0) as f64 / 1_000.0;
+        let waited_ms = self.deadline_warn.worst_ahead_us as f64 / 1_000.0;
+        match elapsed {
+            // First drop in a burst. Cause and fix live at docs/logging.md#sync-deadline.
+            None => log::warn!(
+                "[sync-deadline] dropping states: head unmatched for {waited_ms:.0}ms of stream \
+                 time (deadline {deadline_ms:.0}ms) — a video track has likely stalled. \
+                 Throttling further [sync-deadline] warnings to once per {}s.",
+                DROP_WARN_INTERVAL.as_secs(),
+            ),
+            // Sustained burst: one rolled-up summary per interval.
+            Some(d) => log::warn!(
+                "[sync-deadline] dropped {} more states in {:.0}s past the {deadline_ms:.0}ms \
+                 deadline (worst stall {waited_ms:.0}ms).",
+                self.deadline_warn.count,
+                d.as_secs_f64(),
+            ),
+        }
+        self.deadline_warn.last_log = Some(now);
+        self.deadline_warn.count = 0;
+        self.deadline_warn.worst_ahead_us = 0;
+    }
+
+    /// Largest sender timestamp currently buffered across every stream — the
+    /// newest state plus each track's newest frame. Serves as a monotonic
+    /// "logical clock" for the optional sync deadline: it advances whenever
+    /// *any* stream is still flowing, so a stalled track can be detected via
+    /// the clocks of the streams that aren't stalled. Reads only sender
+    /// timestamps (never a wall clock), keeping deadline decisions
+    /// reproducible. Always `>= self.state_buffer[0]` (the head), since the
+    /// head is the front of `state_buffer` and its back is `>=` the front.
+    /// O(tracks); only called when a state would otherwise wait.
+    fn logical_now(&self) -> u64 {
+        let mut now = self.state_buffer.back().map(|(ts, _)| *ts).unwrap_or(0);
+        for buf in &self.video_buffers {
+            if let Some(frame) = buf.back() {
+                now = now.max(frame.timestamp_us);
+            }
+        }
+        now
     }
 
     /// Build the typed state map once per emission. Separate so the two
@@ -292,6 +359,7 @@ impl SyncBuffer {
         self.blocker = None;
         self.in_overflow_burst = false;
         self.drop_warn = DropWarn::default();
+        self.deadline_warn = DropWarn::default();
     }
 
     fn try_sync(&mut self) -> SyncOutput {
@@ -464,6 +532,28 @@ impl SyncBuffer {
             }
 
             if let Some(b) = iter_blocker {
+                // Optional deadline: rather than waiting on the blocking track
+                // indefinitely, drop the head if the fastest-advancing stream
+                // has moved past it by at least the deadline (in sender-clock
+                // time). This bounds head-of-line blocking when a track stalls
+                // — without it, the head waits until state-buffer capacity
+                // evicts it, or forever if state output has also paused. The
+                // deadline never fires while every track can still match; it
+                // only converts an otherwise-indefinite wait into a timely
+                // drop. Purely sender-timestamp driven, so it stays
+                // reproducible (see `logical_now`).
+                if let Some(deadline) = self.config.sync_deadline_us {
+                    let waited = self.logical_now().saturating_sub(state_ts);
+                    if waited >= deadline {
+                        self.note_deadline_drop(waited);
+                        let (_, values) = self.state_buffer.pop_front().unwrap();
+                        output.drops.push(self.build_typed_state_map(&values));
+                        self.metrics.record_state_dropped_deadline(1);
+                        // Head changed; the blocker hint no longer applies.
+                        self.blocker = None;
+                        continue;
+                    }
+                }
                 self.blocker = Some(b);
                 self.metrics.record_blocker(b);
                 return output;
@@ -623,6 +713,89 @@ mod tests {
         assert!(buf.push_state(50_000, vec![1.0]).is_empty());
         let out = push_f(&mut buf, "cam1", 50_010);
         assert_eq!(out.observations.len(), 1);
+    }
+
+    // --- Sync deadline ----------------------------------------------------
+
+    /// With no deadline set (the default), a head state blocked by a stalled
+    /// track waits — it is not dropped even as other streams race far ahead.
+    /// Guards backward compatibility.
+    #[test]
+    fn deadline_disabled_waits_indefinitely() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let config = SyncConfig {
+            video_buffer_size: 10,
+            state_buffer_size: 10,
+            search_range_us: 1_000,
+            sync_deadline_us: None, // disabled
+            ..Default::default()
+        };
+        let mut buf = mk(&tracks, fields, config);
+
+        // cam1 has a frame at the head; cam2 never sends (stalled).
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        assert!(buf.push_state(10_000, vec![1.0]).is_empty(), "waits on cam2");
+
+        // Advance the state stream far past any deadline-sized gap. Without a
+        // deadline the head still just waits — no drop, no observation.
+        let out = buf.push_state(500_000, vec![2.0]);
+        assert!(out.observations.is_empty());
+        assert!(out.drops.is_empty(), "no deadline → head waits, never drops");
+    }
+
+    /// With a deadline set, a head state blocked by a stalled track is dropped
+    /// once the fastest-advancing stream's sender clock passes it by the
+    /// deadline — before state-buffer capacity would have evicted it.
+    #[test]
+    fn deadline_drops_stuck_head() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let config = SyncConfig {
+            video_buffer_size: 10,
+            state_buffer_size: 10, // large, so capacity is not what drops it
+            search_range_us: 1_000,
+            sync_deadline_us: Some(50_000), // 50ms of stream time
+            ..Default::default()
+        };
+        let mut buf = mk(&tracks, fields, config);
+
+        // cam1 matches the first state; cam2 stalls (never sends).
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        assert!(buf.push_state(10_000, vec![1.0]).is_empty(), "waits on cam2");
+
+        // The state clock advances 60ms past the head (10_000 → 70_000),
+        // exceeding the 50ms deadline. The head is dropped, not stalled.
+        let out = buf.push_state(70_000, vec![2.0]);
+        assert_eq!(out.drops.len(), 1, "stuck head dropped at the deadline");
+        assert_eq!(out.drops[0]["j1"], TypedValue::F64(1.0));
+        assert!(out.observations.is_empty());
+
+        let snap = buf.metrics.snapshot(HashMap::new(), 0);
+        assert_eq!(snap.sync.states_dropped_deadline, 1);
+        assert_eq!(snap.sync.states_dropped, 1, "deadline drops count in the total too");
+    }
+
+    /// A small deadline must never drop a state that actually has an in-range
+    /// match on every track — no spurious drops during normal operation.
+    #[test]
+    fn deadline_does_not_drop_matched_states() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let config = SyncConfig {
+            search_range_us: 1_000,
+            sync_deadline_us: Some(5_000),
+            ..Default::default()
+        };
+        let mut buf = mk(&tracks, fields, config);
+
+        let _ = push_f(&mut buf, "cam1", 100_000);
+        let out = buf.push_state(100_000, vec![1.0]);
+        assert_eq!(out.observations.len(), 1, "aligned frame+state → observation");
+        assert!(out.drops.is_empty());
+
+        let snap = buf.metrics.snapshot(HashMap::new(), 0);
+        assert_eq!(snap.sync.states_dropped_deadline, 0);
     }
 
     #[test]
@@ -953,6 +1126,7 @@ mod tests {
             state_buffer_size: 5,
             search_range_us: 500,
             reuse_stale_frames: true,
+            sync_deadline_us: None,
         }
     }
 
@@ -1157,6 +1331,7 @@ mod tests {
             state_buffer_size: 5,
             search_range_us: 100,
             reuse_stale_frames: true,
+            sync_deadline_us: None,
         };
         let mut buf = mk(&tracks, fields, config);
 

--- a/livekit-portal/src/types.rs
+++ b/livekit-portal/src/types.rs
@@ -226,6 +226,17 @@ pub struct SyncConfig {
     /// emitted at least once. Default is `false`, preserving the strict
     /// drop-on-horizon behavior.
     pub reuse_stale_frames: bool,
+    /// Optional "logical" deadline, in microseconds of sender-clock time.
+    /// When set, a head state that would otherwise wait indefinitely (a
+    /// video track has stalled but not yet advanced past the match horizon)
+    /// is dropped once the fastest-advancing stream's sender timestamp has
+    /// moved at least this far past the state's timestamp. Measured purely
+    /// from sender timestamps — it never consults a wall clock, so sync
+    /// decisions stay reproducible. Always `>= search_range_us` (a shorter
+    /// deadline could drop a state a slightly-late in-range frame would
+    /// still match). `None` (the default) preserves the wait-until-eviction
+    /// behavior. Derived from the user-facing `sync_deadline_ms` knob.
+    pub sync_deadline_us: Option<u64>,
 }
 
 impl Default for SyncConfig {
@@ -235,6 +246,7 @@ impl Default for SyncConfig {
             state_buffer_size: 5,    // ~83ms at 60fps
             search_range_us: 10_000, // 10ms — half a frame interval at 60fps
             reuse_stale_frames: false,
+            sync_deadline_us: None,
         }
     }
 }

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -878,6 +878,21 @@ class PortalConfig:
         """
         self._inner.set_reuse_stale_frames(enable)
 
+    def set_sync_deadline_ms(self, ms: int) -> None:
+        """Drop a state stuck behind a stalled video track after ``ms``
+        milliseconds of stream time, instead of waiting indefinitely.
+
+        Without this, if a video track stops sending, its head state blocks
+        until buffer capacity evicts it (or forever, if state output also
+        pauses), stalling every observation. With a deadline set, the state
+        is dropped once the fastest-advancing stream's timestamp has moved
+        ``ms`` past it — bounding the stall to a predictable window.
+
+        Measured in sender-clock time, not wall-clock. ``0`` (the default)
+        disables it. Values below the match window are raised to it.
+        """
+        self._inner.set_sync_deadline_ms(ms)
+
     def set_action_subscription(self, enable: bool) -> None:
         """Operator-side opt-in to receiving executed actions.
 
@@ -1352,6 +1367,13 @@ class _RoleConfigBase:
 
     def set_reuse_stale_frames(self, enable: bool) -> None:
         self._inner.set_reuse_stale_frames(enable)
+
+    def set_sync_deadline_ms(self, ms: int) -> None:
+        """Drop a state stuck behind a stalled video track after ``ms``
+        milliseconds of stream time. ``0`` (default) disables it. See
+        `RobotConfig.set_sync_deadline_ms` for full semantics.
+        """
+        self._inner.set_sync_deadline_ms(ms)
 
     def set_action_subscription(self, enable: bool) -> None:
         """Operator-side opt-in to receiving executed actions ("HITL

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -1,13 +1,31 @@
 """Config builder smoke tests. No networking, no runtime."""
 import pytest
 
-from livekit.portal import DType, FieldSpec, Portal, PortalConfig, PortalError, Role
+from livekit.portal import (
+    DType,
+    FieldSpec,
+    OperatorConfig,
+    Portal,
+    PortalConfig,
+    PortalError,
+    RobotConfig,
+    Role,
+)
 
 
 def test_new_config_constructs():
     cfg = PortalConfig("demo", Role.OPERATOR)
     assert cfg.session == "demo"
     assert cfg.role == Role.OPERATOR
+
+
+def test_set_sync_deadline_ms_is_accepted():
+    # No getter is exposed for the deadline, so this is a smoke test that the
+    # setter is wired through every config type without error. 0 disables it;
+    # a positive value enables the stalled-track deadline drop.
+    PortalConfig("demo", Role.OPERATOR).set_sync_deadline_ms(200)
+    RobotConfig("demo").set_sync_deadline_ms(0)
+    OperatorConfig("demo").set_sync_deadline_ms(200)
 
 
 def test_config_adders_are_captured():

--- a/python/packages/livekit-portal/tests/test_config_yaml.py
+++ b/python/packages/livekit-portal/tests/test_config_yaml.py
@@ -34,6 +34,7 @@ YAML_FULL = textwrap.dedent(
     state_reliable: false
     action_reliable: false
     reuse_stale_frames: true
+    sync_deadline_ms: 250
     ping_ms: 500
     action_subscription: true
     videos:


### PR DESCRIPTION
Fixes the "frozen camera" problem documented in docs/09-synchronization.md.

**The problem:** If one camera track stops sending frames, the entire sync engine freezes — no observations come out at all, even from healthy cameras.
This could lock up forever.

**The fix:** New `sync_deadline_ms` setting (default: off). When enabled, if a camera has been stuck for longer than the deadline, the system skips that moment and keeps moving instead of waiting forever.

**Key details:**
- Off by default — no change for existing users
- Uses sender timestamps (not wall clock) so behavior is predictable and testable
- New metric: `states_dropped_deadline` to track how often this fires
- Works from Python, YAML config, or code