### PR TITLE
feat: make every config field readable back

### DIFF
--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -110,6 +110,32 @@ role-specific is a no-op on the wrong side.
 `set_fps`, `set_slack`, and `set_tolerance` are covered in
 [Tuning](04-tuning.md).
 
+Every field is also readable back as a property, which is how you inspect a
+config you loaded from YAML instead of building by hand:
+
+| Property | Type | Reads back |
+|---|---|---|
+| `session` | `str` | Session name. |
+| `role` | `Role` | Pinned role. |
+| `video_tracks` | `list[str]` | WebRTC track names. |
+| `frame_video_tracks` | `list[FrameVideoSpec]` | Byte-stream tracks with codec and quality. |
+| `state_schema` / `action_schema` | `list[FieldSpec]` | Declared schemas, in order. |
+| `action_chunks` | `list[ChunkSpec]` | Declared chunks. |
+| `fps` | `int` | `set_fps`. |
+| `slack` | `int` | `set_slack`. |
+| `tolerance` | `float` | `set_tolerance`. |
+| `state_reliable` / `action_reliable` | `bool` | The reliability flags. |
+| `ping_ms` | `int` | `set_ping_ms`. |
+| `reuse_stale_frames` | `bool` | `set_reuse_stale_frames`. |
+| `action_subscription` | `bool` | `set_action_subscription`. |
+| `has_e2ee_key` | `bool` | Whether a key was set. The bytes are not readable back. |
+
+```python
+cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
+fps = cfg.fps                    # whatever the file declared
+period = 1.0 / cfg.fps
+```
+
 You can also build the whole config from a file with
 `RobotConfig.from_yaml_file("portal.yaml", "session-1")`. See
 [Config from YAML](reference/config-file.md).

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -42,6 +42,16 @@ PortalConfig.from_yaml_file(path: str | os.PathLike, session: str, role: Role) -
 `RobotConfig` and `OperatorConfig` pin the role for you. Use them unless you have
 a reason to drive `PortalConfig` directly.
 
+Everything the file declared is readable back off the loaded config, so a value
+the file owns doesn't have to be duplicated in your process:
+
+```python
+cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
+period = 1.0 / cfg.fps        # the file's rate, not a second copy of it
+```
+
+See [the full property list](../03-portal-api.md#full-config-surface).
+
 ## A minimal file
 
 ```yaml

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -682,6 +682,63 @@ impl PortalConfig {
     pub fn action_chunks(&self) -> Vec<ChunkSpec> {
         self.inner.lock().action_chunks().iter().map(chunkspec_from_core).collect()
     }
+
+    /// Session name this config was built for.
+    pub fn session(&self) -> String {
+        self.inner.lock().session().to_string()
+    }
+
+    /// Role this config is pinned to.
+    pub fn role(&self) -> Role {
+        self.inner.lock().role().into()
+    }
+
+    /// Unified observation rate in Hz. Defaults to 30.
+    pub fn fps(&self) -> u32 {
+        self.inner.lock().fps()
+    }
+
+    /// Ticks of pipeline headroom. Defaults to 5.
+    pub fn slack(&self) -> u32 {
+        self.inner.lock().slack()
+    }
+
+    /// Frame-match window, in tick intervals at `fps`. Defaults to 1.5.
+    pub fn tolerance(&self) -> f32 {
+        self.inner.lock().tolerance()
+    }
+
+    /// RTT ping cadence in milliseconds; `0` means active pinging is off.
+    pub fn ping_ms(&self) -> u64 {
+        self.inner.lock().ping_ms()
+    }
+
+    /// Whether state packets are published on the reliable channel.
+    pub fn state_reliable(&self) -> bool {
+        self.inner.lock().state_reliable()
+    }
+
+    /// Whether action packets are published on the reliable channel.
+    pub fn action_reliable(&self) -> bool {
+        self.inner.lock().action_reliable()
+    }
+
+    /// Whether a state past its video match window reuses the last emitted
+    /// frame instead of being dropped.
+    pub fn reuse_stale_frames(&self) -> bool {
+        self.inner.lock().reuse_stale_frames()
+    }
+
+    /// Whether action subscription is enabled (operator-side opt-in).
+    pub fn action_subscription(&self) -> bool {
+        self.inner.lock().action_subscription()
+    }
+
+    /// Whether a shared E2EE key has been set. The key bytes are not
+    /// readable back — this only reports presence.
+    pub fn has_e2ee_key(&self) -> bool {
+        self.inner.lock().has_e2ee_key()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1096,6 +1153,52 @@ impl RobotConfig {
     pub fn action_chunks(&self) -> Vec<ChunkSpec> {
         self.inner.action_chunks()
     }
+
+    pub fn session(&self) -> String {
+        self.inner.session()
+    }
+
+    pub fn role(&self) -> Role {
+        self.inner.role()
+    }
+
+    pub fn fps(&self) -> u32 {
+        self.inner.fps()
+    }
+
+    pub fn slack(&self) -> u32 {
+        self.inner.slack()
+    }
+
+    pub fn tolerance(&self) -> f32 {
+        self.inner.tolerance()
+    }
+
+    pub fn ping_ms(&self) -> u64 {
+        self.inner.ping_ms()
+    }
+
+    pub fn state_reliable(&self) -> bool {
+        self.inner.state_reliable()
+    }
+
+    pub fn action_reliable(&self) -> bool {
+        self.inner.action_reliable()
+    }
+
+    pub fn reuse_stale_frames(&self) -> bool {
+        self.inner.reuse_stale_frames()
+    }
+
+    /// Always reports what was set, but the robot ignores the flag — it
+    /// always processes actions. Kept for surface symmetry.
+    pub fn action_subscription(&self) -> bool {
+        self.inner.action_subscription()
+    }
+
+    pub fn has_e2ee_key(&self) -> bool {
+        self.inner.has_e2ee_key()
+    }
 }
 
 /// Operator-side session config. Same declarative surface as `RobotConfig`;
@@ -1201,6 +1304,50 @@ impl OperatorConfig {
 
     pub fn action_chunks(&self) -> Vec<ChunkSpec> {
         self.inner.action_chunks()
+    }
+
+    pub fn session(&self) -> String {
+        self.inner.session()
+    }
+
+    pub fn role(&self) -> Role {
+        self.inner.role()
+    }
+
+    pub fn fps(&self) -> u32 {
+        self.inner.fps()
+    }
+
+    pub fn slack(&self) -> u32 {
+        self.inner.slack()
+    }
+
+    pub fn tolerance(&self) -> f32 {
+        self.inner.tolerance()
+    }
+
+    pub fn ping_ms(&self) -> u64 {
+        self.inner.ping_ms()
+    }
+
+    pub fn state_reliable(&self) -> bool {
+        self.inner.state_reliable()
+    }
+
+    pub fn action_reliable(&self) -> bool {
+        self.inner.action_reliable()
+    }
+
+    pub fn reuse_stale_frames(&self) -> bool {
+        self.inner.reuse_stale_frames()
+    }
+
+    pub fn action_subscription(&self) -> bool {
+        self.inner.action_subscription()
+    }
+
+    pub fn has_e2ee_key(&self) -> bool {
+        self.inner.has_e2ee_key()
     }
 }
 

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -435,6 +435,58 @@ impl PortalConfig {
         &self.action_chunks
     }
 
+    /// Session name this config was built for.
+    pub fn session(&self) -> &str {
+        &self.session
+    }
+
+    /// Role this config is pinned to.
+    pub fn role(&self) -> Role {
+        self.role
+    }
+
+    /// Unified observation rate in Hz. Defaults to 30.
+    pub fn fps(&self) -> u32 {
+        self.fps
+    }
+
+    /// Ticks of pipeline headroom. Defaults to 5.
+    pub fn slack(&self) -> u32 {
+        self.slack
+    }
+
+    /// Frame-match window, in tick intervals at `fps`. Defaults to 1.5.
+    pub fn tolerance(&self) -> f32 {
+        self.tolerance
+    }
+
+    /// RTT ping cadence in milliseconds; `0` means active pinging is off.
+    pub fn ping_ms(&self) -> u64 {
+        self.ping_ms
+    }
+
+    /// Whether state packets are published on the reliable channel.
+    pub fn state_reliable(&self) -> bool {
+        self.state_reliable
+    }
+
+    /// Whether action packets are published on the reliable channel.
+    pub fn action_reliable(&self) -> bool {
+        self.action_reliable
+    }
+
+    /// Whether a state past its video match window reuses the last emitted
+    /// frame instead of being dropped.
+    pub fn reuse_stale_frames(&self) -> bool {
+        self.reuse_stale_frames
+    }
+
+    /// Whether a shared E2EE key has been set. The key bytes are not
+    /// readable back — this only reports presence.
+    pub fn has_e2ee_key(&self) -> bool {
+        self.shared_key.is_some()
+    }
+
     /// Derived sync config used internally by the sync buffer. Not public.
     pub(crate) fn sync_config(&self) -> SyncConfig {
         let search_range_us = (self.tolerance * 1_000_000.0 / self.fps as f32) as u64;

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -356,7 +356,17 @@ action_chunks:
         assert_eq!(cfg.action_chunks().len(), 1);
         assert_eq!(cfg.action_chunks()[0].horizon, 16);
 
+        assert_eq!(cfg.session(), "demo");
+        assert_eq!(cfg.role(), Role::Robot);
+        assert_eq!(cfg.fps(), 60);
+        assert_eq!(cfg.slack(), 8);
+        assert_eq!(cfg.tolerance(), 1.0);
+        assert_eq!(cfg.ping_ms(), 500);
+        assert!(!cfg.state_reliable());
+        assert!(!cfg.action_reliable());
+        assert!(cfg.reuse_stale_frames());
         assert!(cfg.action_subscription());
+        assert!(!cfg.has_e2ee_key());
     }
 
     #[test]
@@ -369,6 +379,13 @@ action_chunks:
         assert_eq!(cfg.state_schema().len(), 0);
         assert_eq!(cfg.action_schema().len(), 0);
         assert_eq!(cfg.action_chunks().len(), 0);
+        assert_eq!(cfg.fps(), 30);
+        assert_eq!(cfg.slack(), 5);
+        assert_eq!(cfg.tolerance(), 1.5);
+        assert_eq!(cfg.ping_ms(), 1000);
+        assert!(cfg.state_reliable());
+        assert!(cfg.action_reliable());
+        assert!(!cfg.reuse_stale_frames());
         assert!(!cfg.action_subscription());
     }
 

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -745,6 +745,60 @@ class PortalConfig:
         """All declared action chunks, in declaration order."""
         return list(self._action_chunks)
 
+    # Sync / transport knobs are not mirrored Python-side — read them back
+    # from the FFI config, which owns the authoritative value.
+
+    @property
+    def fps(self) -> int:
+        """Unified observation rate in Hz. Defaults to 30."""
+        return self._inner.fps()
+
+    @property
+    def slack(self) -> int:
+        """Ticks of pipeline headroom. Defaults to 5."""
+        return self._inner.slack()
+
+    @property
+    def tolerance(self) -> float:
+        """Frame-match window, in tick intervals at `fps`. Defaults to 1.5."""
+        return self._inner.tolerance()
+
+    @property
+    def ping_ms(self) -> int:
+        """RTT ping cadence in milliseconds; `0` means active pinging is off."""
+        return self._inner.ping_ms()
+
+    @property
+    def state_reliable(self) -> bool:
+        """Whether state packets go out on the reliable channel."""
+        return self._inner.state_reliable()
+
+    @property
+    def action_reliable(self) -> bool:
+        """Whether action packets go out on the reliable channel."""
+        return self._inner.action_reliable()
+
+    @property
+    def reuse_stale_frames(self) -> bool:
+        """Whether a state past its video match window reuses the last
+        emitted frame instead of being dropped.
+        """
+        return self._inner.reuse_stale_frames()
+
+    @property
+    def action_subscription(self) -> bool:
+        """Whether action subscription is enabled. Operator-side only —
+        the robot always processes actions.
+        """
+        return self._inner.action_subscription()
+
+    @property
+    def has_e2ee_key(self) -> bool:
+        """Whether a shared E2EE key has been set. The key bytes are not
+        readable back — this only reports presence.
+        """
+        return self._inner.has_e2ee_key()
+
     def add_video(
         self,
         name: str,
@@ -1305,6 +1359,58 @@ class _RoleConfigBase:
     @property
     def action_chunks(self) -> List[ChunkSpec]:
         return list(self._inner.action_chunks())
+
+    @property
+    def fps(self) -> int:
+        """Unified observation rate in Hz. Defaults to 30."""
+        return self._inner.fps()
+
+    @property
+    def slack(self) -> int:
+        """Ticks of pipeline headroom. Defaults to 5."""
+        return self._inner.slack()
+
+    @property
+    def tolerance(self) -> float:
+        """Frame-match window, in tick intervals at `fps`. Defaults to 1.5."""
+        return self._inner.tolerance()
+
+    @property
+    def ping_ms(self) -> int:
+        """RTT ping cadence in milliseconds; `0` means active pinging is off."""
+        return self._inner.ping_ms()
+
+    @property
+    def state_reliable(self) -> bool:
+        """Whether state packets go out on the reliable channel."""
+        return self._inner.state_reliable()
+
+    @property
+    def action_reliable(self) -> bool:
+        """Whether action packets go out on the reliable channel."""
+        return self._inner.action_reliable()
+
+    @property
+    def reuse_stale_frames(self) -> bool:
+        """Whether a state past its video match window reuses the last
+        emitted frame instead of being dropped.
+        """
+        return self._inner.reuse_stale_frames()
+
+    @property
+    def action_subscription(self) -> bool:
+        """Whether action subscription is enabled. Reports what was set;
+        on `RobotConfig` the flag has no effect — the robot always
+        processes actions.
+        """
+        return self._inner.action_subscription()
+
+    @property
+    def has_e2ee_key(self) -> bool:
+        """Whether a shared E2EE key has been set. The key bytes are not
+        readable back — this only reports presence.
+        """
+        return self._inner.has_e2ee_key()
 
     def add_video(
         self,

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -1,7 +1,16 @@
 """Config builder smoke tests. No networking, no runtime."""
 import pytest
 
-from livekit.portal import DType, FieldSpec, Portal, PortalConfig, PortalError, Role
+from livekit.portal import (
+    DType,
+    FieldSpec,
+    OperatorConfig,
+    Portal,
+    PortalConfig,
+    PortalError,
+    RobotConfig,
+    Role,
+)
 
 
 def test_new_config_constructs():
@@ -43,6 +52,50 @@ def test_mixed_dtype_schema_is_accepted():
         FieldSpec(name="mode", dtype=DType.I8),
         FieldSpec(name="counter", dtype=DType.U16),
     ]
+
+
+@pytest.mark.parametrize(
+    "make_cfg",
+    [
+        lambda: PortalConfig("demo", Role.ROBOT),
+        lambda: RobotConfig("demo"),
+        lambda: OperatorConfig("demo"),
+    ],
+    ids=["portal", "robot", "operator"],
+)
+def test_config_knobs_default_and_round_trip(make_cfg):
+    cfg = make_cfg()
+    # Defaults, as documented in docs/03-portal-api.md.
+    assert cfg.fps == 30
+    assert cfg.slack == 5
+    assert cfg.tolerance == pytest.approx(1.5)
+    assert cfg.ping_ms == 1000
+    assert cfg.state_reliable is True
+    assert cfg.action_reliable is True
+    assert cfg.reuse_stale_frames is False
+    assert cfg.action_subscription is False
+    assert cfg.has_e2ee_key is False
+
+    cfg.set_fps(60)
+    cfg.set_slack(8)
+    cfg.set_tolerance(0.5)
+    cfg.set_ping_ms(0)
+    cfg.set_state_reliable(False)
+    cfg.set_action_reliable(False)
+    cfg.set_reuse_stale_frames(True)
+    cfg.set_action_subscription(True)
+    cfg.set_e2ee_key(b"0" * 32)
+
+    assert cfg.fps == 60
+    assert cfg.slack == 8
+    assert cfg.tolerance == pytest.approx(0.5)
+    assert cfg.ping_ms == 0
+    assert cfg.state_reliable is False
+    assert cfg.action_reliable is False
+    assert cfg.reuse_stale_frames is True
+    assert cfg.action_subscription is True
+    # Presence only — the key bytes are deliberately not readable back.
+    assert cfg.has_e2ee_key is True
 
 
 def test_set_fps_zero_raises():

--- a/python/packages/livekit-portal/tests/test_config_yaml.py
+++ b/python/packages/livekit-portal/tests/test_config_yaml.py
@@ -165,6 +165,29 @@ def test_operator_config_from_yaml_str():
     assert len(cfg.action_chunks) == 1
 
 
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        PortalConfig.from_yaml_str(YAML_FULL, "demo", Role.ROBOT),
+        RobotConfig.from_yaml_str(YAML_FULL, "demo"),
+        OperatorConfig.from_yaml_str(YAML_FULL, "demo"),
+    ],
+    ids=["portal", "robot", "operator"],
+)
+def test_yaml_sync_knobs_are_readable(cfg):
+    # A YAML-built config is the main case where the caller doesn't already
+    # know these values — reading them back is the only way to find out.
+    assert cfg.fps == 60
+    assert cfg.slack == 8
+    assert cfg.tolerance == pytest.approx(1.0)
+    assert cfg.state_reliable is False
+    assert cfg.action_reliable is False
+    assert cfg.reuse_stale_frames is True
+    assert cfg.ping_ms == 500
+    assert cfg.action_subscription is True
+    assert cfg.has_e2ee_key is False
+
+
 def test_robot_config_from_yaml_file():
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".yaml", delete=False


### PR DESCRIPTION
## Problem

The config classes were write-only for the sync and transport knobs: `set_fps` with no `fps`, `set_slack` with no `slack`, and so on. Reading one back raised `AttributeError`:

```python
cfg = RobotConfig("session-1")
cfg.set_fps(30)
period = 1.0 / cfg.fps    # AttributeError: 'RobotConfig' object has no attribute 'fps'
```

That bites hardest on a YAML-loaded config, where the caller genuinely doesn't know the values — the file owns them, but the only way to use one in the loop was to duplicate it in the process that loads the file.

## Change

- **Core** (`livekit-portal/src/config.rs`): getters on `PortalConfig` for `session`, `role`, `fps`, `slack`, `tolerance`, `ping_ms`, `state_reliable`, `action_reliable`, `reuse_stale_frames`, `has_e2ee_key`. `action_subscription()` already existed.
- **FFI** (`livekit-portal-ffi/src/lib.rs`): exposed on `PortalConfig`, `RobotConfig`, and `OperatorConfig`, so the role split stays symmetrical.
- **Python**: properties on `_RoleConfigBase` (backing `RobotConfig` / `OperatorConfig`) and on the v0.1 `PortalConfig`. They read through to the FFI config rather than mirroring Python-side, so a YAML-built config reports what was actually parsed.
- **Docs**: read-back property table in `docs/03-portal-api.md` beside the setter table, plus a pointer from `docs/reference/config-file.md`.

```python
cfg = RobotConfig.from_yaml_file("portal.yaml", "session-1")
period = 1.0 / cfg.fps     # the file's rate, not a second copy of it
```

### One deliberate asymmetry

`set_e2ee_key(bytes)` reads back as `has_e2ee_key -> bool`, not the key bytes. Presence is the useful signal; handing a shared secret back out of the config isn't worth the convenience. Easy to widen later if there's a real need.

## Tests

- `test_config.py`: defaults and setter round-trip, parametrized across `PortalConfig` / `RobotConfig` / `OperatorConfig`.
- `test_config_yaml.py`: the knobs read back off YAML-built configs, same three classes.
- Rust `full_config_round_trip` / `defaults_apply_when_fields_omitted`: now assert fps/slack/tolerance/ping_ms/reliability. **The YAML loader's wiring for those fields had no coverage before** — nothing could read them, so nothing checked the loader actually applied them.

Verified locally: `cargo test -p livekit-portal` (101 passed), `cargo fmt --all --check` clean, no new clippy findings in the touched files, 53 Python tests pass.