### PR TITLE
feat: give action chunks the dtype enforcement scalar actions already had

### DIFF
--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -287,10 +287,10 @@ op.send_action_chunk("act", policy_output)         # what most VLAs emit
 **The dict form is dtype-checked**, by the same rules `send_action` applies to a
 scalar. A `BOOL` field wants `bool` or `numpy.bool_`, an integer field wants an
 integer type, a float field takes any real. A mismatch raises
-`DtypeMismatch` before anything crosses the FFI boundary, so a float column
-against a `BOOL` gripper fails at your call site rather than arriving as a
-silently coerced `1.0`. numpy columns are checked once via the array's dtype,
-so the check does not scale with horizon.
+`DtypeMismatch` before the chunk is sent, so a float column against a `BOOL`
+gripper fails at your call site rather than arriving as a silently coerced
+`1.0`. numpy columns are checked once via the array's dtype, so the check does
+not scale with horizon.
 
 **The array form is not dtype-checked.** One uniform tensor spread across a
 mixed schema is exactly what that shape is for, and a `float32` array is a

--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -81,6 +81,33 @@ Each field declares a dtype that fixes its width on the wire.
 Values you pass to `send_state` and `send_action` stay ordinary Python values.
 Conversion happens at the wire boundary.
 
+### Declaring an action chunk
+
+A chunk is a named `[horizon, fields]` tensor for policies that emit several
+future timesteps per inference. Its fields are typed exactly like the state and
+action schemas, with the same `DType` values from the table above.
+
+```python
+JOINTS = [
+    ("joint1", DType.F32),
+    ("joint2", DType.F32),
+    ("gripper", DType.BOOL),
+]
+
+cfg.add_action_typed(JOINTS)
+cfg.add_action_chunk("act", horizon=16, fields=JOINTS)
+```
+
+Declaring the same field list for both is the common case and worth doing
+deliberately: a chunk timestep and a scalar action then describe the same
+robot, so you can fall back from chunked to per-tick control without a second
+schema.
+
+The chunk's name, horizon, **and** per-field dtypes all feed its fingerprint.
+Both peers must declare all three identically or the receiver drops the stream.
+Nothing about a chunk is untyped: see [Action chunks](#action-chunks) for the
+send and receive surface.
+
 > **Note.** Field order is part of the contract, not just the names. Reordering
 > two fields on one side changes the schema fingerprint and all traffic drops.
 > A [shared YAML file](reference/config-file.md) is the reliable way to keep
@@ -96,7 +123,7 @@ role-specific is a no-op on the wrong side.
 | `add_video(name, codec=..., quality=..., max_bitrate_kbps=...)` | H264 | Declare a camera track. See [Frame video](05-frame-video.md). |
 | `add_state_typed([(name, dtype), ...])` | none | Declare the state schema. |
 | `add_action_typed([(name, dtype), ...])` | none | Declare the action schema. |
-| `add_action_chunk(name, horizon, fields)` | none | Declare a fixed-horizon action batch. |
+| `add_action_chunk(name, horizon, [(name, dtype), ...])` | none | Declare a fixed-horizon action batch. Fields are typed, same as the state and action schemas. |
 | `set_fps(int)` | 30 | Capture rate. Drives the match window. |
 | `set_slack(int)` | 5 | Ticks of buffer headroom. |
 | `set_tolerance(float)` | 1.5 | Match window, in ticks. |
@@ -238,13 +265,46 @@ op.send_action(values, timestamp_us=None, in_reply_to_ts_us=None)
 op.send_action_chunk(name, data, timestamp_us=None, in_reply_to_ts_us=None)
 ```
 
-`send_action_chunk` accepts either a dict of per-field columns of length
-`horizon`, or a single NumPy array of shape `(horizon, n_fields)` in declared
-field order. The array form is what most VLA policies emit already. Columns of
-the wrong length are zero-padded.
-
 Chunks travel as byte streams rather than data packets, so a full horizon is
 not bounded by the 15 KB packet limit.
+
+### Action chunks
+
+`send_action_chunk` accepts two input shapes, and they differ in more than
+convenience.
+
+```python
+# Dict of per-field columns, each of length horizon. Dtype-checked per column.
+op.send_action_chunk("act", {
+    "joint1": np.array([...], dtype=np.float32),   # declared F32
+    "gripper": [True, False, ...],                 # declared BOOL
+})
+
+# One (horizon, n_fields) array in declared field order. Shape-checked only.
+op.send_action_chunk("act", policy_output)         # what most VLAs emit
+```
+
+**The dict form is dtype-checked**, by the same rules `send_action` applies to a
+scalar. A `BOOL` field wants `bool` or `numpy.bool_`, an integer field wants an
+integer type, a float field takes any real. A mismatch raises
+`DtypeMismatch` before anything crosses the FFI boundary, so a float column
+against a `BOOL` gripper fails at your call site rather than arriving as a
+silently coerced `1.0`. numpy columns are checked once via the array's dtype,
+so the check does not scale with horizon.
+
+**The array form is not dtype-checked.** One uniform tensor spread across a
+mixed schema is exactly what that shape is for, and a `float32` array is a
+legitimate way to express a `BOOL` gripper column inside it. Values coerce to
+each field's declared dtype. Use the dict form when you want the check.
+
+Either way, out-of-range values saturate at the wire boundary and warn once per
+field, the same as a scalar action. `500` into an `I8` column arrives as `127`.
+
+Columns that aren't exactly `horizon` long are still accepted: short and
+missing columns zero-pad, long ones truncate, each warning once per field with
+[`chunk-length`](08-troubleshooting.md#chunk-length). Treat those zeros as real
+commands. A chunk is a whole unit, so an omitted column does **not** carry
+forward the way an omitted scalar action field does.
 
 ## Receiving data
 
@@ -284,10 +344,10 @@ op.on_drop(on_drop)
 
 ### Typed values on receive
 
-`Action`, `State`, `Observation`, and `ActionChunk` are typed by default.
-`.values` (and `observation.state`) hold Python-native types per your declared
-schema. `.raw_values` (and `observation.raw_state`) hold the lossless all-`f64`
-view.
+`Action`, `State`, `Observation`, and `ActionChunk` are all typed by default.
+Each carries the declared-type view plus a lossless all-`f64` view, under names
+that match its shape: scalars use `.values` / `.raw_values`, and a chunk uses
+`.data` / `.raw_data` because its fields are columns rather than single values.
 
 ```python
 def on_action(action):
@@ -297,9 +357,43 @@ def on_action(action):
     action.raw_values           # Dict[str, float], every field widened
 ```
 
-The Rust core mirrors this. `Action`, `State`, and `Observation` carry
-`values: HashMap<String, TypedValue>` alongside `raw_values: HashMap<String,
-f64>`. Declare a dtype, send an ordinary value, receive the declared type.
+For `Observation`, the same pair is named `.state` / `.raw_state`.
+
+A chunk's `.data` gives one NumPy array per field, each of length `horizon` and
+already in the field's declared dtype, so a `float32` policy output does not
+come back widened:
+
+```python
+def on_chunk(chunk):
+    chunk.data["joint1"].dtype   # dtype('float32'), per the declaration
+    chunk.data["gripper"]        # array([True, False, ...]), a real bool array
+    chunk.data["joint1"][3]      # timestep 3 of that field
+    chunk.raw_data               # Dict[str, list[float]], every column widened
+```
+
+Reach for `.raw_data` when you want to skip the per-field NumPy reconstruction
+and write straight into your own buffer.
+
+The Rust core mirrors this for scalars: `Action`, `State`, and `Observation`
+carry `values: HashMap<String, TypedValue>` alongside `raw_values:
+HashMap<String, f64>`. Declare a dtype, send an ordinary value, receive the
+declared type.
+
+`ActionChunk` is the one deliberate exception. Its `data` is
+`HashMap<String, Vec<f64>>` with no `TypedValue` column equivalent, because an
+enum-of-vectors is friction for exactly the numeric code that consumes a chunk,
+and a Rust caller already holds the `ChunkSpec` it declared. The dtypes are not
+lost, they just live in the schema rather than in the payload. The Python
+binding re-casts against that schema on your behalf, which NumPy makes nearly
+free.
+
+On the send side that asymmetry reverses, and Rust gets the stronger guarantee.
+A Rust caller passes `ChunkColumn::typed(dtype, values)` to claim a column's
+dtype and have the core reject a disagreement with `DtypeMismatch`, or
+`ChunkColumn::untyped(values)` to waive the check and coerce. Python always
+sends unclaimed columns and runs the category check described under
+[Action chunks](#action-chunks), because a Python `int` is a legitimate `I8`
+*and* `I32` and an exact claim would be invented rather than observed.
 
 ## The active operator
 
@@ -489,7 +583,10 @@ These are the behaviors that surprise people. Each one is deliberate.
 field, or a `bool` into an `F32` field, raises
 `PortalError.DtypeMismatch` before any packet is built. There is no silent
 cast. `int` is accepted for float dtypes. `bool` is rejected everywhere except
-`BOOL`.
+`BOOL`. This applies to `send_action_chunk`'s dict form column by column, with
+one carve-out: its `(horizon, n_fields)` array form is shape-checked only, since
+a uniform tensor across a mixed schema is the reason that shape exists. See
+[Action chunks](#action-chunks).
 
 **Schema mismatch is detected but never raises.** Every packet carries a `u32`
 fingerprint over the ordered field names and dtypes. A peer whose schema
@@ -527,7 +624,7 @@ sender's side. Check `op.active_operator()`.
 | `WrongFrameSize` | Buffer length is not `width * height * 3`. |
 | `InvalidFrameDimensions` | Width or height is odd. |
 | `WrongRole` | `send_action` on a robot, or `send_state` on an operator. |
-| `DtypeMismatch` | A sent value's Python type disagrees with the declared dtype. |
+| `DtypeMismatch` | A sent value's Python type disagrees with the declared dtype. Also raised per column by `send_action_chunk`'s dict form. |
 | `Deserialization` | A received payload could not be parsed. |
 | `Codec` | Frame encode or decode failed. |
 | `Rpc` | The remote handler raised. Carries the `RpcError`. |

--- a/docs/08-troubleshooting.md
+++ b/docs/08-troubleshooting.md
@@ -304,6 +304,27 @@ The peer receives the clamped value and never learns the original. `NaN` becomes
 
 **Fix.** Widen the dtype, or scale the value before sending.
 
+### chunk-length
+
+```
+[chunk-length] chunk 'act': field 'j3' has 10 of 16 timesteps, padded with 6 zeros
+[chunk-length] chunk 'act': field 'j4' missing, padded with 16 zeros
+[chunk-length] chunk 'act': field 'j5' has 20 of 16 timesteps, truncated to 16
+```
+
+A chunk column was not exactly `horizon` long. The send still goes out: short
+columns and missing columns zero-pad, long ones truncate. Logged once per field,
+then silent.
+
+Read the zeros literally. A chunk is a whole unit, not a partial update, so an
+omitted column does **not** carry forward the way an omitted scalar action field
+does. Zero is a real commanded value, and for a position target it means move to
+zero.
+
+**Fix.** Send the full column. If your policy emits a shorter horizon than you
+declared, redeclare the chunk at the horizon it actually produces rather than
+letting the tail pad.
+
 ### unknown-chunk
 
 ```

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -233,6 +233,10 @@ Multiple chunks are allowed. Each is dispatched to its own callback by schema
 fingerprint, and the fingerprint mixes in the name and horizon, so two chunks
 cannot collide.
 
+These dtypes do more than fix the wire width. Received columns arrive as NumPy
+arrays already in the declared dtype, and outgoing columns are type-checked
+against it. See [Action chunks](../03-portal-api.md#action-chunks).
+
 Chunks travel as byte streams rather than data packets, so a full horizon is not
 bounded by the 15 KB packet limit.
 

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -208,6 +208,29 @@ pub struct ChunkSpec {
     pub fields: Vec<FieldSpec>,
 }
 
+/// One column of an outgoing action chunk. Mirrors `core::ChunkColumn`:
+/// `values` is the column widened to `f64`, and `dtype` is the dtype the
+/// caller claims it holds.
+///
+/// A binding sets `dtype` when it knows the caller's intent per column, and
+/// leaves it `None` when it doesn't. The Python binding leaves it `None` and
+/// runs its own category check, for the same reason `send_action` does: a
+/// Python `int` is a legitimate `I8` *and* `I32`, so an exact claim would be
+/// invented rather than observed.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct ChunkColumn {
+    pub values: Vec<f64>,
+    pub dtype: Option<DType>,
+}
+
+fn chunk_columns_to_core(data: HashMap<String, ChunkColumn>) -> HashMap<String, core::ChunkColumn> {
+    data.into_iter()
+        .map(|(name, c)| {
+            (name, core::ChunkColumn { values: c.values, dtype: c.dtype.map(Into::into) })
+        })
+        .collect()
+}
+
 /// Decoded video frame. `data` is packed RGB24 (R,G,B byte order, `W*H*3`
 /// bytes) on both sides — `send_video_frame` accepts RGB, and receive-side
 /// frames are color-converted from I420 (WebRTC) or codec-decoded (frame
@@ -846,16 +869,23 @@ impl Portal {
     }
 
     /// Publish an action chunk on the named declaration. `data` is
-    /// `field -> column of length horizon` widened to `f64`.
+    /// `field -> column of length horizon` widened to `f64`, each column
+    /// optionally claiming a dtype the core checks against the declared
+    /// field.
     pub fn send_action_chunk(
         &self,
         chunk_name: String,
-        data: HashMap<String, Vec<f64>>,
+        data: HashMap<String, ChunkColumn>,
         timestamp_us: Option<u64>,
         in_reply_to_ts_us: Option<u64>,
     ) -> PortalResult<()> {
         self.inner
-            .send_action_chunk(&chunk_name, &data, timestamp_us, in_reply_to_ts_us)
+            .send_action_chunk(
+                &chunk_name,
+                &chunk_columns_to_core(data),
+                timestamp_us,
+                in_reply_to_ts_us,
+            )
             .map_err(Into::into)
     }
 
@@ -1365,7 +1395,7 @@ impl Operator {
     pub fn send_action_chunk(
         &self,
         chunk_name: String,
-        data: HashMap<String, Vec<f64>>,
+        data: HashMap<String, ChunkColumn>,
         timestamp_us: Option<u64>,
         in_reply_to_ts_us: Option<u64>,
     ) -> PortalResult<()> {

--- a/livekit-portal/src/data.rs
+++ b/livekit-portal/src/data.rs
@@ -20,7 +20,7 @@ use crate::serialization::{
     deserialize_values, schema_fingerprint, serialize_action, serialize_chunk, serialize_values,
 };
 use crate::sync_buffer::{SyncBuffer, SyncOutput};
-use crate::types::{Action, ActionChunk, Role, State, TypedValue, to_value_maps};
+use crate::types::{Action, ActionChunk, ChunkColumn, Role, State, TypedValue, to_value_maps};
 use crate::video::now_us;
 
 /// Reserved Portal topics. State and action travel as data packets;
@@ -247,6 +247,57 @@ impl DataPublisher {
     }
 }
 
+/// Reject a chunk column whose claimed dtype disagrees with the declared
+/// field. The scalar counterpart is `DataPublisher::check_dtypes`, and the
+/// semantics match: declarations are compared and values are never
+/// inspected, so this stays O(fields) regardless of horizon. A column that
+/// claims nothing is coerced to the declared dtype at encode.
+///
+/// Free-standing so it's testable without a live `LocalParticipant`.
+fn check_chunk_dtypes(
+    fields: &[FieldSpec],
+    data: &HashMap<String, ChunkColumn>,
+) -> PortalResult<()> {
+    for field in fields {
+        // Absent fields skip the check and zero-fill, matching how the
+        // scalar path skips absent keys (there they carry forward instead).
+        if let Some(column) = data.get(&field.name)
+            && let Some(claimed) = column.dtype
+            && claimed != field.dtype
+        {
+            return Err(PortalError::DtypeMismatch {
+                field: field.name.clone(),
+                expected: field.dtype,
+                got: claimed.variant_name(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// How a column's length compares to the declared horizon, and therefore
+/// what `serialize_chunk` will do about it. Carries lengths rather than a
+/// formatted message so classification never allocates — the message is
+/// built only for a column that actually warns.
+#[derive(Debug, PartialEq)]
+enum ColumnFill {
+    Exact,
+    Missing,
+    /// Column is `n` long against a longer horizon, so the tail zero-pads.
+    Short(usize),
+    /// Column is `n` long against a shorter horizon, so the tail is dropped.
+    Long(usize),
+}
+
+fn classify_column_len(got: Option<usize>, horizon: usize) -> ColumnFill {
+    match got {
+        None => ColumnFill::Missing,
+        Some(n) if n == horizon => ColumnFill::Exact,
+        Some(n) if n < horizon => ColumnFill::Short(n),
+        Some(n) => ColumnFill::Long(n),
+    }
+}
+
 /// Update `last` in place with values from `map` for each declared field,
 /// leaving other slots untouched (carry-forward). Typed values are
 /// lossless-widened to `f64` on the way in.
@@ -384,6 +435,10 @@ pub(crate) struct ChunkPublisher {
     /// matches `serialize_chunk`'s output channel.
     warned_saturated: Mutex<HashSet<usize>>,
     warned_unknown_keys: Mutex<HashSet<String>>,
+    /// Fields already warned about a column length that isn't `horizon`.
+    /// Keyed by field name, so a caller that is consistently short warns
+    /// once rather than once per send.
+    warned_length: Mutex<HashSet<String>>,
 }
 
 impl ChunkPublisher {
@@ -414,6 +469,7 @@ impl ChunkPublisher {
             metrics,
             warned_saturated: Mutex::new(HashSet::new()),
             warned_unknown_keys: Mutex::new(HashSet::new()),
+            warned_length: Mutex::new(HashSet::new()),
         }
     }
 
@@ -422,19 +478,26 @@ impl ChunkPublisher {
     /// dtype; integer overflow saturates and warns once per
     /// `(t, field_index)`.
     ///
+    /// A column that claims a dtype (`ChunkColumn::dtype == Some`) is
+    /// checked against the declared field and a mismatch is rejected,
+    /// mirroring `DataPublisher::check_dtypes` for scalar actions.
+    ///
     /// `timestamp_us = None` resolves to `now_us()`. `in_reply_to_ts_us`
     /// links the chunk back to the observation that produced it for
     /// `metrics.policy.e2e_us_*`. Wrong-length columns are accepted and
     /// padded with `0.0` (rather than rejected) so partial fills during
     /// development don't fail noisily — production callers should always
-    /// supply the full column.
+    /// supply the full column, and a length that isn't `horizon` warns
+    /// once per field.
     pub fn send(
         &self,
-        data: &HashMap<String, Vec<f64>>,
+        data: &HashMap<String, ChunkColumn>,
         timestamp_us: Option<u64>,
         in_reply_to_ts_us: Option<u64>,
     ) -> PortalResult<()> {
+        self.check_dtypes(data)?;
         self.warn_unknown_keys(data);
+        self.warn_length(data);
         let ts = timestamp_us.unwrap_or_else(now_us);
         let out = serialize_chunk(self.fingerprint, ts, in_reply_to_ts_us, &self.spec, data);
         if !out.saturated_indices.is_empty() {
@@ -456,7 +519,11 @@ impl ChunkPublisher {
         Ok(())
     }
 
-    fn warn_unknown_keys(&self, data: &HashMap<String, Vec<f64>>) {
+    fn check_dtypes(&self, data: &HashMap<String, ChunkColumn>) -> PortalResult<()> {
+        check_chunk_dtypes(&self.spec.fields, data)
+    }
+
+    fn warn_unknown_keys(&self, data: &HashMap<String, ChunkColumn>) {
         for key in data.keys() {
             if self.spec.fields.iter().any(|f| &f.name == key) {
                 continue;
@@ -469,6 +536,45 @@ impl ChunkPublisher {
                     key
                 );
             }
+        }
+    }
+
+    /// Report columns that aren't exactly `horizon` long. `serialize_chunk`
+    /// pads with `0.0` and truncates the overflow, which for joint targets
+    /// means commanding zero rather than doing nothing — silent is the wrong
+    /// default even though accepting the send is.
+    fn warn_length(&self, data: &HashMap<String, ChunkColumn>) {
+        let horizon = self.spec.horizon as usize;
+        for field in &self.spec.fields {
+            let fill = classify_column_len(data.get(&field.name).map(|c| c.values.len()), horizon);
+            if fill == ColumnFill::Exact {
+                continue;
+            }
+            // Claim the warn slot before formatting. A caller that is
+            // consistently short would otherwise build a message per send
+            // for the lifetime of the publisher and throw it away.
+            {
+                let mut warned = self.warned_length.lock();
+                if !warned.insert(field.name.clone()) {
+                    continue;
+                }
+            }
+            let detail = match fill {
+                ColumnFill::Exact => unreachable!("filtered above"),
+                ColumnFill::Missing => format!("missing, padded with {horizon} zeros"),
+                ColumnFill::Short(n) => {
+                    format!("has {n} of {horizon} timesteps, padded with {} zeros", horizon - n)
+                }
+                ColumnFill::Long(n) => {
+                    format!("has {n} of {horizon} timesteps, truncated to {horizon}")
+                }
+            };
+            log::warn!(
+                "[chunk-length] chunk '{}': field '{}' {}",
+                self.spec.name,
+                field.name,
+                detail
+            );
         }
     }
 
@@ -725,6 +831,76 @@ mod tests {
         assert_eq!(err.0, "gripper");
         assert_eq!(err.1, DType::Bool);
         assert_eq!(err.2, "F32");
+    }
+
+    fn chunk_fields() -> Vec<FieldSpec> {
+        vec![
+            FieldSpec::new("joint", DType::F32),
+            FieldSpec::new("gripper", DType::Bool),
+            FieldSpec::new("mode", DType::I8),
+        ]
+    }
+
+    #[test]
+    fn chunk_claimed_dtype_matching_declaration_passes() {
+        let data: HashMap<String, ChunkColumn> = [
+            ("joint".to_string(), ChunkColumn::typed(DType::F32, vec![0.5, 0.25])),
+            ("gripper".to_string(), ChunkColumn::typed(DType::Bool, vec![1.0, 0.0])),
+        ]
+        .into_iter()
+        .collect();
+        assert!(check_chunk_dtypes(&chunk_fields(), &data).is_ok());
+    }
+
+    #[test]
+    fn chunk_claimed_dtype_mismatch_is_rejected() {
+        // An F32 column against the declared Bool gripper — the chunk
+        // equivalent of handing `send_action` a `TypedValue::F32` for a
+        // Bool field.
+        let data: HashMap<String, ChunkColumn> =
+            [("gripper".to_string(), ChunkColumn::typed(DType::F32, vec![1.0, 0.0]))]
+                .into_iter()
+                .collect();
+        let err = check_chunk_dtypes(&chunk_fields(), &data).unwrap_err();
+        match err {
+            PortalError::DtypeMismatch { field, expected, got } => {
+                assert_eq!(field, "gripper");
+                assert_eq!(expected, DType::Bool);
+                assert_eq!(got, "F32");
+            }
+            other => panic!("expected DtypeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chunk_unclaimed_dtype_waives_the_check() {
+        // The uniform-tensor path: one f32 policy output fanned across a
+        // mixed schema can't honestly claim Bool for the gripper, so it
+        // claims nothing and coerces instead of failing.
+        let data: HashMap<String, ChunkColumn> = chunk_fields()
+            .iter()
+            .map(|f| (f.name.clone(), ChunkColumn::untyped(vec![1.0, 0.0])))
+            .collect();
+        assert!(check_chunk_dtypes(&chunk_fields(), &data).is_ok());
+    }
+
+    #[test]
+    fn chunk_dtype_check_ignores_absent_and_unknown_fields() {
+        // Absent declared field: skipped here, zero-filled at encode.
+        // Unknown key: skipped here, warned separately by warn_unknown_keys.
+        let data: HashMap<String, ChunkColumn> =
+            [("extra".to_string(), ChunkColumn::typed(DType::U8, vec![1.0]))].into_iter().collect();
+        assert!(check_chunk_dtypes(&chunk_fields(), &data).is_ok());
+    }
+
+    #[test]
+    fn column_length_classification_covers_pad_truncate_and_missing() {
+        assert_eq!(classify_column_len(Some(16), 16), ColumnFill::Exact);
+        assert_eq!(classify_column_len(None, 16), ColumnFill::Missing);
+        assert_eq!(classify_column_len(Some(10), 16), ColumnFill::Short(10));
+        assert_eq!(classify_column_len(Some(20), 16), ColumnFill::Long(20));
+        // An empty column is missing data, not a zero-length exact match.
+        assert_eq!(classify_column_len(Some(0), 16), ColumnFill::Short(0));
     }
 
     #[test]

--- a/livekit-portal/src/dtype.rs
+++ b/livekit-portal/src/dtype.rs
@@ -20,6 +20,23 @@ pub enum DType {
 }
 
 impl DType {
+    /// Stable variant name, for error messages. Matches the `TypedValue`
+    /// variant that carries this dtype so `DtypeMismatch` reads the same
+    /// whether it came from a scalar value or a chunk column.
+    pub fn variant_name(self) -> &'static str {
+        match self {
+            DType::F64 => "F64",
+            DType::F32 => "F32",
+            DType::I32 => "I32",
+            DType::I16 => "I16",
+            DType::I8 => "I8",
+            DType::U32 => "U32",
+            DType::U16 => "U16",
+            DType::U8 => "U8",
+            DType::Bool => "Bool",
+        }
+    }
+
     /// Byte width on the wire.
     pub fn size_bytes(self) -> usize {
         match self {

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -29,5 +29,6 @@ pub use metrics::{
 pub use portal::{ACTIVE_OPERATOR_ATTR_KEY, Portal, ROLE_ATTR_KEY, SET_ACTIVE_OPERATOR_RPC};
 pub use rpc::{RpcError, RpcHandler, RpcInvocationData};
 pub use types::{
-    Action, ActionChunk, Observation, Role, State, SyncConfig, TypedValue, VideoFrameData,
+    Action, ActionChunk, ChunkColumn, Observation, Role, State, SyncConfig, TypedValue,
+    VideoFrameData,
 };

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -664,13 +664,20 @@ impl Portal {
     /// Publish an action chunk on the named chunk schema (operator only).
     ///
     /// `data` is `field -> column of length horizon`. Columns shorter than
-    /// `horizon` are zero-padded, longer columns are truncated, and unknown
-    /// keys are warned-and-ignored once each. Use `in_reply_to_ts_us` the
-    /// same way as `send_action` to feed `metrics.policy.e2e_us_*`.
+    /// `horizon` are zero-padded, longer columns are truncated, both with a
+    /// warn-once, and unknown keys are warned-and-ignored once each. Use
+    /// `in_reply_to_ts_us` the same way as `send_action` to feed
+    /// `metrics.policy.e2e_us_*`.
+    ///
+    /// A column built with `ChunkColumn::typed` is checked against the
+    /// declared field dtype and returns `PortalError::DtypeMismatch` on
+    /// disagreement, the same rejection `send_action` gives a `TypedValue`
+    /// of the wrong variant. `ChunkColumn::untyped` (and the `From<Vec<f64>>`
+    /// conversion) waives the check and coerces.
     pub fn send_action_chunk(
         &self,
         chunk_name: &str,
-        data: &HashMap<String, Vec<f64>>,
+        data: &HashMap<String, ChunkColumn>,
         timestamp_us: Option<u64>,
         in_reply_to_ts_us: Option<u64>,
     ) -> PortalResult<()> {
@@ -710,7 +717,7 @@ impl Portal {
                 .fields
                 .iter()
                 .map(|f| {
-                    let mut col = data.get(&f.name).cloned().unwrap_or_default();
+                    let mut col = data.get(&f.name).map(|c| c.values.clone()).unwrap_or_default();
                     if col.len() < horizon {
                         col.resize(horizon, 0.0);
                     } else if col.len() > horizon {

--- a/livekit-portal/src/serialization.rs
+++ b/livekit-portal/src/serialization.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::config::{ChunkSpec, FieldSpec};
 use crate::dtype::DType;
 use crate::error::PortalError;
+use crate::types::ChunkColumn;
 
 /// Plain-stream wire prefix: 4-byte schema fingerprint + 8-byte
 /// `timestamp_us`. Used by `portal_state`.
@@ -201,7 +202,8 @@ pub(crate) fn deserialize_action(
 /// `data` is `field_name -> column of length horizon`. Missing fields
 /// fill with `0.0` (caller's responsibility to provide the column —
 /// chunk schema doesn't carry-forward like scalar state/action because
-/// chunks are whole units, not partial updates).
+/// chunks are whole units, not partial updates). Each column's claimed
+/// dtype is validated upstream in `ChunkPublisher::send`, not here.
 ///
 /// `saturated_indices` returns flat `(t * fields.len() + f)` indices so
 /// the caller can map back to `(field_name, t)` for warnings.
@@ -210,7 +212,7 @@ pub(crate) fn serialize_chunk(
     timestamp_us: u64,
     in_reply_to_ts_us: Option<u64>,
     spec: &ChunkSpec,
-    data: &HashMap<String, Vec<f64>>,
+    data: &HashMap<String, ChunkColumn>,
 ) -> EncodeResult {
     let row_bytes: usize = spec.fields.iter().map(|f| f.dtype.size_bytes()).sum();
     let payload_bytes = row_bytes * spec.horizon as usize;
@@ -221,8 +223,11 @@ pub(crate) fn serialize_chunk(
     let mut saturated_indices = Vec::new();
     let n_fields = spec.fields.len();
     let empty: Vec<f64> = Vec::new();
-    let columns: Vec<&Vec<f64>> =
-        spec.fields.iter().map(|f| data.get(&f.name).unwrap_or(&empty)).collect();
+    let columns: Vec<&Vec<f64>> = spec
+        .fields
+        .iter()
+        .map(|f| data.get(&f.name).map(|c| &c.values).unwrap_or(&empty))
+        .collect();
     for t in 0..spec.horizon as usize {
         for (fi, field) in spec.fields.iter().enumerate() {
             let v = columns[fi].get(t).copied().unwrap_or(0.0);
@@ -511,8 +516,8 @@ mod tests {
         let spec = chunk_spec("act", 3, &[("j1", DType::F32), ("j2", DType::F32)]);
         let fp = chunk_fingerprint(&spec);
         let mut data = HashMap::new();
-        data.insert("j1".to_string(), vec![0.1, 0.2, 0.3]);
-        data.insert("j2".to_string(), vec![1.0, 1.5, 2.0]);
+        data.insert("j1".to_string(), vec![0.1, 0.2, 0.3].into());
+        data.insert("j2".to_string(), vec![1.0, 1.5, 2.0].into());
         let out = serialize_chunk(fp, 999, Some(500), &spec, &data);
         let (ts, reply, columns) = deserialize_chunk(&out.payload, fp, &spec).unwrap();
         assert_eq!(ts, 999);
@@ -533,9 +538,9 @@ mod tests {
         );
         let fp = chunk_fingerprint(&spec);
         let mut data = HashMap::new();
-        data.insert("joint".to_string(), vec![0.5, -0.25]);
-        data.insert("gripper".to_string(), vec![1.0, 0.0]);
-        data.insert("mode".to_string(), vec![3.0, -1.0]);
+        data.insert("joint".to_string(), vec![0.5, -0.25].into());
+        data.insert("gripper".to_string(), vec![1.0, 0.0].into());
+        data.insert("mode".to_string(), vec![3.0, -1.0].into());
         let out = serialize_chunk(fp, 1, None, &spec, &data);
         // Header (20) + 2 rows of (4 + 1 + 1) = 12 → 32 bytes total.
         assert_eq!(out.payload.len(), CORRELATED_HEADER_LEN + 2 * (4 + 1 + 1));
@@ -552,7 +557,7 @@ mod tests {
         let spec = chunk_spec("act", 2, &[("j1", DType::F64), ("j2", DType::F64)]);
         let fp = chunk_fingerprint(&spec);
         let mut data = HashMap::new();
-        data.insert("j1".to_string(), vec![1.0, 2.0]);
+        data.insert("j1".to_string(), vec![1.0, 2.0].into());
         // j2 omitted — should serialize as zeros, not panic.
         let out = serialize_chunk(fp, 0, None, &spec, &data);
         let (_, _, columns) = deserialize_chunk(&out.payload, fp, &spec).unwrap();
@@ -579,9 +584,9 @@ mod tests {
         let spec = chunk_spec("act", 3, &[("a", DType::F64), ("b", DType::I8)]);
         let fp = chunk_fingerprint(&spec);
         let mut data = HashMap::new();
-        data.insert("a".to_string(), vec![0.0, 0.0, 0.0]);
+        data.insert("a".to_string(), vec![0.0, 0.0, 0.0].into());
         // b at t=1 saturates.
-        data.insert("b".to_string(), vec![0.0, 500.0, 0.0]);
+        data.insert("b".to_string(), vec![0.0, 500.0, 0.0].into());
         let out = serialize_chunk(fp, 0, None, &spec, &data);
         // n_fields=2, t=1, fi=1 → flat = 1 * 2 + 1 = 3.
         assert_eq!(out.saturated_indices, vec![3]);

--- a/livekit-portal/src/types.rs
+++ b/livekit-portal/src/types.rs
@@ -76,17 +76,7 @@ impl TypedValue {
 
     /// Static name of the variant, for error messages.
     pub fn variant_name(self) -> &'static str {
-        match self {
-            TypedValue::F64(_) => "F64",
-            TypedValue::F32(_) => "F32",
-            TypedValue::I32(_) => "I32",
-            TypedValue::I16(_) => "I16",
-            TypedValue::I8(_) => "I8",
-            TypedValue::U32(_) => "U32",
-            TypedValue::U16(_) => "U16",
-            TypedValue::U8(_) => "U8",
-            TypedValue::Bool(_) => "Bool",
-        }
+        self.dtype().variant_name()
     }
 
     /// Lossless widening back to `f64`. Useful when a consumer wants to
@@ -141,6 +131,54 @@ pub struct Action {
     /// `Portal::active_operator()` to label rows so the label cannot
     /// race with a handoff.
     pub sender: String,
+}
+
+/// One column of an outgoing action chunk: `horizon` values widened to
+/// `f64`, plus the dtype the caller claims they are.
+///
+/// **Why the claim.** A scalar action crosses `Portal::send_action` as a
+/// `TypedValue`, whose variant states the caller's intent, and
+/// `check_dtypes` compares that against the declared schema. Chunk columns
+/// are `Vec<f64>` because a horizon of rows wants to stay a flat numeric
+/// buffer, so the variant tag has nowhere to live. `dtype` is that tag,
+/// hoisted to the column. It gives chunks the same send-time dtype
+/// rejection scalar actions already get.
+///
+/// Note that the check compares declarations, not values, exactly as
+/// `check_dtypes` does. Nothing here inspects the `f64`s. Out-of-range
+/// values still saturate at encode and warn once per `(t, field)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChunkColumn {
+    /// The column, length `horizon`. Short columns zero-pad and long ones
+    /// truncate, both with a warn-once.
+    pub values: Vec<f64>,
+    /// The dtype the caller claims this column holds. `Some(d)` is checked
+    /// against the field's declared dtype and a mismatch is rejected with
+    /// `PortalError::DtypeMismatch`. `None` waives the check and coerces to
+    /// the declared dtype, which is what a uniform policy tensor needs: a
+    /// single `f32` array fanned out across a mixed schema cannot honestly
+    /// claim `Bool` for the gripper column.
+    pub dtype: Option<DType>,
+}
+
+impl ChunkColumn {
+    /// A column that claims a dtype. Mismatches against the declared field
+    /// are rejected at send.
+    pub fn typed(dtype: DType, values: Vec<f64>) -> Self {
+        Self { values, dtype: Some(dtype) }
+    }
+
+    /// A column that claims nothing and coerces to the declared dtype.
+    pub fn untyped(values: Vec<f64>) -> Self {
+        Self { values, dtype: None }
+    }
+}
+
+impl From<Vec<f64>> for ChunkColumn {
+    /// Bare columns coerce, matching the pre-`ChunkColumn` behaviour.
+    fn from(values: Vec<f64>) -> Self {
+        Self::untyped(values)
+    }
 }
 
 /// One action chunk received from the operator. Surfaces in

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -283,11 +283,61 @@ class Observation:
     timestamp_us: int
 
 
+def _validate_chunk_column(
+    name: str, column: Any, dtype: DType
+) -> None:
+    """Reject a chunk column whose element types disagree with the declared
+    dtype. The scalar counterpart is `_validate_send_values`, and the rules
+    are identical — this is the same category check applied per element.
+
+    Like the scalar path, the claim is a *category*, not an exact dtype: a
+    Python `int` is a legitimate `I8` and `I32` both, so this cannot narrow
+    further and does not try. Out-of-range values still saturate at encode
+    and warn once per `(t, field)`, exactly as an out-of-range action does.
+
+    numpy columns are checked once via `column.dtype`, not per element, so a
+    long horizon costs the same as a short one. Only list-like columns pay
+    per-element cost, and only up to the first offender.
+    """
+    if _np is not None and isinstance(column, _np.ndarray):
+        kind = column.dtype.kind
+        if dtype == DType.BOOL:
+            ok = kind == "b"
+        elif dtype in _INT_DTYPES:
+            ok = kind in ("i", "u")
+        else:  # float dtype
+            ok = kind in ("f", "i", "u")
+        if not ok:
+            raise PortalError.DtypeMismatch(
+                f"chunk field '{name}' declared as {dtype} but sent as an "
+                f"array of {column.dtype}"
+            )
+        return
+    for value in column:
+        if dtype == DType.BOOL:
+            ok = isinstance(value, _NUMPY_BOOL_TYPES)
+        elif dtype in _INT_DTYPES:
+            ok = (
+                isinstance(value, numbers.Integral)
+                and not isinstance(value, _NUMPY_BOOL_TYPES)
+            )
+        else:  # float dtype
+            ok = (
+                isinstance(value, numbers.Real)
+                and not isinstance(value, _NUMPY_BOOL_TYPES)
+            )
+        if not ok:
+            raise PortalError.DtypeMismatch(
+                f"chunk field '{name}' declared as {dtype} but sent as "
+                f"{type(value).__name__}"
+            )
+
+
 def _normalize_chunk_data(
     data: Any, schema: List[FieldSpec]
-) -> Dict[str, List[float]]:
-    """Coerce send-side chunk data into the `Dict[str, list[float]]` the
-    FFI accepts. Two input shapes:
+) -> Dict[str, "_ffi.ChunkColumn"]:
+    """Coerce send-side chunk data into the `Dict[str, ChunkColumn]` the FFI
+    accepts. Two input shapes:
 
     * `numpy.ndarray` of shape `(horizon, len(schema))` — split into
       per-field columns in declared order. Convenient for uniform-dtype
@@ -295,26 +345,46 @@ def _normalize_chunk_data(
     * `Dict[str, ndarray | list]` — pass-through, with each column cast
       to a `list[float]`. Unknown keys go through to the core, which
       warns once each.
+
+    The dict form is dtype-checked per column (see `_validate_chunk_column`).
+    The ndarray form is **not**: one uniform tensor spread across a mixed
+    schema is the case that shape exists for, and an `f32` array is a
+    legitimate way to express a `Bool` gripper column there. It is validated
+    for shape only.
+
+    Every column crosses the FFI with `dtype=None`, waiving the core's
+    `check_chunk_dtypes`, because the category check above has already run
+    and a Python value cannot claim an exact dtype honestly. `dtype` is for
+    Rust callers, who can.
     """
     if _np is not None and isinstance(data, _np.ndarray):
         if data.ndim != 2 or data.shape[1] != len(schema):
             raise PortalError.Deserialization(
                 f"chunk ndarray must be shape (horizon, {len(schema)}); got {data.shape}"
             )
-        cols: Dict[str, List[float]] = {}
+        cols: Dict[str, "_ffi.ChunkColumn"] = {}
         for i, field in enumerate(schema):
-            cols[field.name] = data[:, i].astype(_np.float64).tolist()
+            cols[field.name] = _ffi.ChunkColumn(
+                values=data[:, i].astype(_np.float64).tolist(), dtype=None
+            )
         return cols
     if not isinstance(data, dict):
         raise PortalError.Deserialization(
             "chunk data must be a dict or 2D numpy array"
         )
+    declared: Dict[str, DType] = {f.name: f.dtype for f in schema}
     cols = {}
     for name, column in data.items():
+        dtype = declared.get(name)
+        # Unknown keys skip validation — the core warns once each, matching
+        # how `_validate_send_values` leaves them to the publisher.
+        if dtype is not None:
+            _validate_chunk_column(name, column, dtype)
         if _np is not None and isinstance(column, _np.ndarray):
-            cols[name] = column.astype(_np.float64).tolist()
+            values = column.astype(_np.float64).tolist()
         else:
-            cols[name] = [float(v) for v in column]
+            values = [float(v) for v in column]
+        cols[name] = _ffi.ChunkColumn(values=values, dtype=None)
     return cols
 
 

--- a/python/packages/livekit-portal/tests/integration/test_chunks.py
+++ b/python/packages/livekit-portal/tests/integration/test_chunks.py
@@ -157,7 +157,11 @@ async def test_nan_inf_round_trip(pair):
 
 async def test_i8_saturation_clamps(pair):
     """I8 column with out-of-range values. Encoder saturates to
-    [-128, 127] and emits a one-shot warn; decode still succeeds."""
+    [-128, 127] and emits a one-shot warn; decode still succeeds.
+
+    The column is `int`, not `float`: the send-side dtype check rejects a
+    float column for an integer field, same as `send_action` rejects a
+    float scalar. Saturation is about range, not type."""
     pair.robot_cfg.add_action_chunk(
         "ctrl", horizon=4, fields=[("mode", DType.I8)]
     )
@@ -169,9 +173,7 @@ async def test_i8_saturation_clamps(pair):
     await pair.start()
     pair.robot.on_action_chunk("ctrl", lambda c: received.append(c))
 
-    pair.operator.send_action_chunk(
-        "ctrl", {"mode": [500.0, -500.0, 42.0, 0.0]}
-    )
+    pair.operator.send_action_chunk("ctrl", {"mode": [500, -500, 42, 0]})
     await asyncio.sleep(SETTLE_S)
 
     assert len(received) == 1
@@ -179,7 +181,13 @@ async def test_i8_saturation_clamps(pair):
 
 
 async def test_bool_round_trip(pair):
-    """BOOL column: any non-zero non-NaN is truthy."""
+    """BOOL column round trips as bools.
+
+    The wire encoder's f64 rule (any non-zero non-NaN is truthy, NaN is
+    false and flags saturation) is covered by `dtype::tests::
+    bool_maps_zero_and_nonzero`. It isn't reachable from here on purpose:
+    the send-side dtype check rejects a float column for a BOOL field, the
+    same way `send_action` rejects a float scalar."""
     pair.robot_cfg.add_action_chunk(
         "grip", horizon=4, fields=[("g", DType.BOOL)]
     )
@@ -191,7 +199,7 @@ async def test_bool_round_trip(pair):
     await pair.start()
     pair.robot.on_action_chunk("grip", lambda c: received.append(c))
 
-    pair.operator.send_action_chunk("grip", {"g": [1.0, 0.0, -1.0, 0.5]})
+    pair.operator.send_action_chunk("grip", {"g": [True, False, True, True]})
     await asyncio.sleep(SETTLE_S)
 
     assert len(received) == 1

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -398,6 +398,124 @@ def test_send_action_chunk_accepts_2d_ndarray():
         pass
 
 
+# --- Chunk send-side dtype enforcement --------------------------------------
+#
+# Parity with the scalar checks above. The dict form is validated per column
+# with the same category rules `_validate_send_values` applies to a scalar.
+# The 2D ndarray form is deliberately exempt: one uniform policy tensor
+# fanned across a mixed schema is the case that shape exists for.
+
+
+def _chunk_portal():
+    cfg = PortalConfig("vla", Role.OPERATOR)
+    cfg.add_action_chunk(
+        "act",
+        horizon=2,
+        fields=[("j1", DType.F32), ("gripper", DType.BOOL), ("mode", DType.I8)],
+    )
+    return Portal(cfg)
+
+
+def test_send_chunk_rejects_float_column_for_bool_field():
+    portal = _chunk_portal()
+    with pytest.raises(PortalError.DtypeMismatch) as info:
+        portal.send_action_chunk("act", {"gripper": [0.0, 1.0]})
+    msg = str(info.value)
+    assert "gripper" in msg
+    assert "BOOL" in msg
+
+
+def test_send_chunk_rejects_float_column_for_int_field():
+    portal = _chunk_portal()
+    with pytest.raises(PortalError.DtypeMismatch):
+        portal.send_action_chunk("act", {"mode": [3.5, 1.0]})
+
+
+def test_send_chunk_rejects_bool_column_for_int_field():
+    portal = _chunk_portal()
+    with pytest.raises(PortalError.DtypeMismatch):
+        portal.send_action_chunk("act", {"mode": [True, False]})
+
+
+def test_send_chunk_rejects_float_ndarray_column_for_bool_field():
+    # The per-column ndarray check reads `column.dtype` once rather than
+    # walking `horizon` elements, so cover it separately from the list path.
+    np = pytest.importorskip("numpy")
+    portal = _chunk_portal()
+    with pytest.raises(PortalError.DtypeMismatch) as info:
+        portal.send_action_chunk(
+            "act", {"gripper": np.array([0.0, 1.0], dtype=np.float32)}
+        )
+    assert "gripper" in str(info.value)
+
+
+def test_send_chunk_accepts_correctly_typed_columns():
+    np = pytest.importorskip("numpy")
+    portal = _chunk_portal()
+    try:
+        portal.send_action_chunk(
+            "act",
+            {
+                "j1": np.array([0.5, 0.25], dtype=np.float32),
+                "gripper": np.array([True, False]),
+                "mode": [3, -1],
+            },
+        )
+    except PortalError.DtypeMismatch as e:
+        pytest.fail(f"correctly typed chunk columns rejected: {e}")
+    except PortalError:
+        # No connected peer — validation passed, which is what we test.
+        pass
+
+
+def test_send_chunk_accepts_int_column_for_float_field():
+    # Same numeric promotion the scalar path allows.
+    portal = _chunk_portal()
+    try:
+        portal.send_action_chunk("act", {"j1": [1, 2]})
+    except PortalError.DtypeMismatch:
+        pytest.fail("int column should coerce into a float-declared field")
+    except PortalError:
+        pass
+
+
+def test_send_chunk_unknown_column_is_not_blocked_by_validator():
+    portal = _chunk_portal()
+    try:
+        portal.send_action_chunk("act", {"j1": [0.5, 0.25], "nope": [1.0, 2.0]})
+    except PortalError.DtypeMismatch:
+        pytest.fail("unknown chunk columns must not trigger dtype validation")
+    except PortalError:
+        pass
+
+
+def test_send_chunk_ndarray_form_waives_the_dtype_check():
+    # A uniform f32 tensor against a schema with a BOOL and an I8 field.
+    # Per-field checking would reject this, and it is the documented shape
+    # for VLA output, so it has to pass.
+    np = pytest.importorskip("numpy")
+    portal = _chunk_portal()
+    arr = np.array([[0.5, 1.0, 3.0], [0.25, 0.0, -1.0]], dtype=np.float32)
+    try:
+        portal.send_action_chunk("act", arr)
+    except PortalError.DtypeMismatch as e:
+        pytest.fail(f"uniform ndarray form must not be dtype-checked: {e}")
+    except PortalError:
+        pass
+
+
+def test_send_chunk_short_column_still_accepted():
+    # Length is a warn-and-pad in the core, not a rejection. Only the dtype
+    # check raises.
+    portal = _chunk_portal()
+    try:
+        portal.send_action_chunk("act", {"j1": [0.5]})
+    except PortalError.DtypeMismatch:
+        pytest.fail("a short column must not raise DtypeMismatch")
+    except PortalError:
+        pass
+
+
 def test_send_action_chunk_unknown_name_raises():
     cfg = PortalConfig("vla", Role.OPERATOR)
     cfg.add_action_chunk("act", horizon=3, fields=[("j1", DType.F32)])


### PR DESCRIPTION
Chunk fields were already typed at declaration and on the wire. What was missing was enforcement on send, and any mention of the typing in the docs people actually read.

A float column into a `BOOL` field coerced silently, while the same mistake in `send_action` raised `DtypeMismatch`. Short and missing columns zero-padded with no warning.

## Why it needed a new type

Enforcement for scalar actions is split across two layers, and chunks had neither:

| Layer | Actions | Chunks before | Chunks after |
|---|---|---|---|
| Python binding | category check, `_validate_send_values` | none | category check, `_validate_chunk_column` |
| Core, for Rust callers | exact check, `check_dtypes` | not expressible | exact check, `check_chunk_dtypes` |
| Short / missing column | n/a, carry-forward | silent zero-pad | `[chunk-length]` warn-once |

The core check needs somewhere for the caller's intent to live. A scalar crosses `send_action` as a `TypedValue` whose variant states that intent. Chunk columns are `Vec<f64>` — a flat numeric buffer is the right shape for a horizon of rows — so the variant tag has nowhere to sit.

Hence `ChunkColumn`:

```rust
pub struct ChunkColumn {
    pub values: Vec<f64>,
    pub dtype: Option<DType>,   // Some = checked, None = coerce
}

impl ChunkColumn {
    pub fn typed(dtype: DType, values: Vec<f64>) -> Self;
    pub fn untyped(values: Vec<f64>) -> Self;
}

impl From<Vec<f64>> for ChunkColumn;   // bare columns still work, unclaimed
```

It compares declarations without inspecting values, exactly as `check_dtypes` does, so it stays O(fields) regardless of horizon.

## Why Python does something different

Python sends unclaimed columns and runs a category check instead. A Python `int` is a legitimate `I8` **and** `I32`, so an exact claim would be invented rather than observed.

That is not a shortcut, it mirrors the scalar path: `f64_to_typed` builds `TypedValue` from the *declared* dtype, which means the core check can never fail for a Python caller and `_validate_send_values` is the real gate. Chunks now have the same division of labour.

numpy columns are checked once via `column.dtype` rather than per element, so the check does not scale with horizon. Only list-like columns pay per-element cost, and only up to the first offender.

## The ndarray form stays exempt

`send_action_chunk` accepts a `(horizon, n_fields)` array, and that form is shape-checked only.

One uniform tensor spread across a mixed schema is exactly what it exists for, and an `f32` array is a legitimate way to express a `BOOL` gripper column inside it. Per-field checking would reject the most common VLA call site. The dict form is there when you want the check.

## Two existing tests were wrong

`test_i8_saturation_clamps` and `test_bool_round_trip` sent float columns into `I8` and `BOOL` fields, which the scalar path already rejects. They were asserting against the unchecked path, so they now express the same intent with typed inputs.

No coverage lost: `dtype::tests::bool_maps_zero_and_nonzero` and `int_saturates_on_overflow` already cover the f64 encoder rules at the layer that owns them, and that layer is no longer reachable from Python by design.

## Docs

The gap was concentrated in `03-portal-api.md`, the primary reference:

- `add_action_chunk(name, horizon, fields)` showed a bare `fields` while its two neighbours spelled out `[(name, dtype), ...]`. A reader could reasonably conclude chunk fields were untyped.
- The "typed values on receive" section listed `ActionChunk` among the typed types, then documented `.values` / `.raw_values`, which `ActionChunk` does not have. It carries `.data` / `.raw_data`.
- No example anywhere in `docs/` declared a chunk, though `examples/python/inference/policy.py` does it correctly.

Fixed, plus: a declare example, the send-side rules for both input forms, why the Rust `ActionChunk` stays f64-only on receive, a `chunk-length` entry in the troubleshooting tag reference, and a pointer from the YAML reference.

## Compatibility

Wire format unchanged, so no cross-version break. `chunk_fingerprint` untouched.

The FFI `send_action_chunk` signature changed, and so did `Portal::send_action_chunk` in the core. Migration for a Rust caller is `.into()` per column, or nothing if the map was already built from `Vec<f64>`. There were no in-tree Rust callers besides the FFI wrappers.

Python signatures are unchanged. The only behaviour change for a Python caller is that a send which was already wrong now raises instead of coercing.

## Testing

- 106 Rust tests, 5 new: claimed-dtype match, mismatch, unclaimed waiver, absent/unknown field handling, and column-length classification.
- 56 Python unit tests, 10 new, covering both input forms and the exemption.
- Full integration suite green against a local dev server, including all 14 chunk tests.
- All three `[chunk-length]` messages confirmed firing end to end with real output.
- `cargo clippy` and `cargo test --workspace --locked` clean.

## Left open

Two things deliberately not in this PR:

1. **A wholly missing column still succeeds**, and so does `send_action_chunk("act", {})` — it ships a full horizon of zeros, which a robot executes as a command to drive every joint to zero. It now warns, where before it was silent. Rejecting an absent column outright would be the stronger call, since there is no legitimate reason to omit an entire column from a whole-unit tensor, but it breaks existing sends so it wants its own decision.

2. **fps is in no fingerprint.** A chunk's `dt` is inferred from `set_fps`, which is correct and needs no second declaration, but two peers that agree on the schema and disagree on fps pass every check and read a different `dt` out of the same horizon. Worth a "both sides must set the same fps" line in the docs at least.
