### PR TITLE
feat: expose per-track simulcast and screencast toggles

### DIFF
--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -93,7 +93,7 @@ role-specific is a no-op on the wrong side.
 
 | Method | Default | What it does |
 |---|---|---|
-| `add_video(name, codec=..., quality=..., max_bitrate_kbps=...)` | H264 | Declare a camera track. See [Frame video](05-frame-video.md). |
+| `add_video(name, codec=..., quality=..., max_bitrate_kbps=..., simulcast=..., screencast=...)` | H264 | Declare a camera track. See [Frame video](05-frame-video.md). |
 | `add_state_typed([(name, dtype), ...])` | none | Declare the state schema. |
 | `add_action_typed([(name, dtype), ...])` | none | Declare the action schema. |
 | `add_action_chunk(name, horizon, fields)` | none | Declare a fixed-horizon action batch. |
@@ -435,6 +435,41 @@ confirm before relying on either.
 
 `max_bitrate_kbps` is a ceiling, not a target. libwebrtc still picks a lower
 operating bitrate from the content. Omit it for the 10 Mbps default.
+
+#### Simulcast and screencast
+
+Two keyword-only toggles control encoder behavior. Both default to off and
+both apply to the WebRTC codecs only.
+
+```python
+cfg.add_video("front", screencast=True)   # pin the resolution
+cfg.add_video("wide", simulcast=True)     # publish several spatial layers
+```
+
+`simulcast=True` publishes several spatial layers at once. The SFU then hands
+each subscriber the layer their link can carry. This costs encode CPU for
+every extra layer. It only pays off when several operators subscribe over
+links of differing quality. A single-operator teleop session gains nothing
+from it, which is why it is off by default.
+
+`screencast=True` marks the source as screen content. libwebrtc picks its
+degradation preference from that flag, and that choice decides what gives way
+under CPU or bandwidth pressure.
+
+| Setting | libwebrtc preference | Under pressure |
+|---|---|---|
+| `screencast=False` (default) | `MAINTAIN_FRAMERATE` | Holds the frame rate, rescales the frame |
+| `screencast=True` | `MAINTAIN_RESOLUTION` | Holds the resolution, drops frames |
+
+The default is the reason a track can arrive at a resolution that shifts
+during a session. Nothing in Portal resizes the frame. libwebrtc's adapter
+scales it down before the encoder sees it, then scales back up once the
+pressure clears.
+
+Turn `screencast=True` on when a fixed frame shape matters more than smooth
+motion. A policy that consumes pixels is the usual case. Leave it off for
+human-watched teleop preview, where smooth motion is worth more than a
+constant resolution.
 
 **When a policy reads the pixels, H.264 is usually wrong.** It shifts
 colorspace, adds block artifacts, and drifts in quality as the bitrate adapts.

--- a/docs/05-frame-video.md
+++ b/docs/05-frame-video.md
@@ -147,6 +147,9 @@ cfg.add_video(
     codec: VideoCodec = VideoCodec.H264,
     quality: int = 90,
     max_bitrate_kbps: int | None = None,
+    *,
+    simulcast: bool | None = None,
+    screencast: bool | None = None,
 ) -> None
 ```
 
@@ -157,6 +160,9 @@ cfg.add_video(
   roughly 2x more compression. Below 50 is unusable for inference.
 - **`max_bitrate_kbps`** caps the WebRTC encoder's peak rate. It is rejected on
   the byte-stream codecs, because there is no encoder to cap.
+- **`simulcast`** and **`screencast`** configure the WebRTC encoder and default
+  to off. They are rejected on the byte-stream codecs for the same reason. See
+  [Simulcast and screencast](03-portal-api.md#simulcast-and-screencast).
 
 ## Metrics
 

--- a/docs/08-troubleshooting.md
+++ b/docs/08-troubleshooting.md
@@ -147,6 +147,32 @@ is not network. Compare the remainder against your inference time. Frame video
 adds a per-chunk floor on top, covered in
 [Frame video](05-frame-video.md#the-latency-floor).
 
+### Frames arrive at a resolution that changes mid-session
+
+This is libwebrtc adapting, not Portal resizing anything. On the WebRTC codecs
+the encoder defaults to `MAINTAIN_FRAMERATE`. Under CPU overuse or bandwidth
+pressure it holds the frame rate and scales the frame down instead, then scales
+back up once the pressure clears.
+
+Confirm it by logging `frame.width` and `frame.height` in `on_video_frame`. A
+size that drifts up and down over a session is adaptation. A single change at
+startup is something else.
+
+Pin the geometry by marking the source as screen content:
+
+```python
+cfg.add_video("front", screencast=True)
+```
+
+That switches libwebrtc to `MAINTAIN_RESOLUTION`, which drops frames under
+pressure rather than rescaling. You trade smooth motion for a constant frame
+shape. See
+[Simulcast and screencast](03-portal-api.md#simulcast-and-screencast).
+
+Worth checking alongside it: sustained encoder pressure usually means the CPU
+is saturated or `max_bitrate_kbps` is set too low for the resolution and rate
+you are asking for.
+
 ### Video looks wrong after enabling E2EE
 
 If one peer has no key or a different key, decryption fails silently. Video goes

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -148,8 +148,8 @@ instead of silently doing nothing.
 
 ```yaml
 videos:
-  - { name: front,   codec: h264, max_bitrate_kbps: 8000 }
-  - { name: wide,    codec: vp9 }
+  - { name: front,   codec: h264, max_bitrate_kbps: 8000, screencast: true }
+  - { name: wide,    codec: vp9, simulcast: true }
   - { name: wrist,   codec: mjpeg, quality: 90 }
   - { name: depth,   codec: png }
   - { name: raw_cam, codec: raw }
@@ -161,12 +161,21 @@ videos:
 | `codec` | string | **Required.** One of `h264`, `vp8`, `vp9`, `av1`, `h265`, `mjpeg`, `png`, `raw`. Case-insensitive, and `hevc` is an alias for `h265`. |
 | `quality` | int | Optional. `1` to `100`, for `mjpeg` only. Defaults to `90`. Ignored for every other codec. |
 | `max_bitrate_kbps` | int | Optional. Encoder bitrate ceiling for the WebRTC codecs. Defaults to `10000`. Rejected on the byte-stream codecs. |
+| `simulcast` | bool | Optional. Publish several spatial layers. Defaults to `false`. Rejected on the byte-stream codecs. |
+| `screencast` | bool | Optional. Pin the resolution and drop frames under pressure instead of rescaling. Defaults to `false`. Rejected on the byte-stream codecs. |
 
 The codec picks both the encoding and the transport.
 
 **`h264`, `vp8`, `vp9`, `av1`, `h265`** use the WebRTC media path. Real-time
 RTP, lossy, best-effort delivery. libwebrtc picks the operating bitrate up to
-`max_bitrate_kbps`. Lowest end-to-end latency at scale.
+`max_bitrate_kbps`. Lowest end-to-end latency at scale. These are also the only
+codecs that honor `simulcast` and `screencast`.
+
+`screencast: true` is the setting to reach for when a track arrives at a
+resolution that changes mid-session. By default libwebrtc treats the source as
+camera content and rescales frames under CPU or bandwidth pressure. Marking it
+as screen content pins the geometry and drops frames instead. See
+[Simulcast and screencast](../03-portal-api.md#simulcast-and-screencast).
 
 **`mjpeg`** is a per-frame byte stream, lossy. Roughly 10 to 20x compression at
 q=90, with sub-millisecond decode. Each frame is independent.
@@ -275,7 +284,7 @@ The loader produces the same config you would build by hand.
 | `reuse_stale_frames` | `cfg.set_reuse_stale_frames(...)` |
 | `ping_ms` | `cfg.set_ping_ms(...)` |
 | `action_subscription` | `cfg.set_action_subscription(...)` |
-| `videos[]` | `cfg.add_video(name, codec, quality, max_bitrate_kbps)` |
+| `videos[]` | `cfg.add_video(name, codec, quality, max_bitrate_kbps, simulcast=..., screencast=...)` |
 | `state[]` | `cfg.add_state_typed([...])` |
 | `action[]` | `cfg.add_action_typed([...])` |
 | `action_chunks[]` | `cfg.add_action_chunk(name, horizon, fields)` |
@@ -296,7 +305,8 @@ identical: same fingerprints, same registered tracks, same sync config.
 
 `Invalid` covers duplicate track names, duplicate chunk names, `horizon: 0`,
 MJPEG quality outside `1..=100`, `max_bitrate_kbps` on a byte-stream codec or set
-to zero, and `fps`, `slack`, or `tolerance` at zero or negative.
+to zero, `simulcast` or `screencast` on a byte-stream codec, and `fps`, `slack`,
+or `tolerance` at zero or negative.
 
 ```python
 from livekit.portal import ConfigFileError, RobotConfig

--- a/docs/reference/wire-protocol.md
+++ b/docs/reference/wire-protocol.md
@@ -262,9 +262,10 @@ matched. A subscribed track from a publisher that does not set it is unsupported
 Either republish it through a Portal-compatible publisher, or enable the trailer
 upstream.
 
-Portal publishes with simulcast off and `max_framerate` set to twice the
-configured fps. Neither is required for interop, but matching them avoids
-surprises.
+Portal publishes with simulcast off by default and `max_framerate` set to twice
+the configured fps. Neither is required for interop, but matching them avoids
+surprises. Simulcast is per-track configurable via `add_video(simulcast=True)`,
+as is libwebrtc's content-type hint via `screencast=True`.
 
 ## RTT
 

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -566,14 +566,29 @@ impl PortalConfig {
     /// `H264` / `Raw` / `Png`. `max_bitrate_kbps` caps the H264 encoder's
     /// peak rate (a ceiling, not a target); `None` uses the default 10 Mbps.
     /// It is ignored for the byte-stream codecs.
+    ///
+    /// `simulcast` publishes several spatial layers so the SFU can choose per
+    /// subscriber, at the cost of encode CPU per layer. `screencast` marks the
+    /// source as screen content, which pins the resolution and drops frames
+    /// under CPU or bandwidth pressure instead of rescaling the frame. Both
+    /// apply to the WebRTC codecs only and default to `false`.
     pub fn add_video(
         &self,
         name: String,
         codec: VideoCodec,
         quality: u8,
         max_bitrate_kbps: Option<u32>,
+        simulcast: Option<bool>,
+        screencast: Option<bool>,
     ) {
-        self.inner.lock().add_video(name, codec.into(), quality, max_bitrate_kbps);
+        self.inner.lock().add_video(
+            name,
+            codec.into(),
+            quality,
+            max_bitrate_kbps,
+            simulcast,
+            screencast,
+        );
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {
@@ -1023,8 +1038,10 @@ impl RobotConfig {
         codec: VideoCodec,
         quality: u8,
         max_bitrate_kbps: Option<u32>,
+        simulcast: Option<bool>,
+        screencast: Option<bool>,
     ) {
-        self.inner.add_video(name, codec, quality, max_bitrate_kbps);
+        self.inner.add_video(name, codec, quality, max_bitrate_kbps, simulcast, screencast);
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {
@@ -1128,8 +1145,10 @@ impl OperatorConfig {
         codec: VideoCodec,
         quality: u8,
         max_bitrate_kbps: Option<u32>,
+        simulcast: Option<bool>,
+        screencast: Option<bool>,
     ) {
-        self.inner.add_video(name, codec, quality, max_bitrate_kbps);
+        self.inner.add_video(name, codec, quality, max_bitrate_kbps, simulcast, screencast);
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -70,8 +70,8 @@ impl FrameVideoSpec {
     }
 }
 
-/// One WebRTC video track declaration: name, WebRTC codec, and an optional
-/// encoder bitrate ceiling.
+/// One WebRTC video track declaration: name, WebRTC codec, an optional
+/// encoder bitrate ceiling, and the two encoder-behavior toggles.
 ///
 /// The WebRTC counterpart to `FrameVideoSpec`. These tracks ride the WebRTC
 /// media path (RTP/SRTP). `codec` is always a WebRTC codec (`H264` / `Vp8` /
@@ -81,16 +81,34 @@ impl FrameVideoSpec {
 /// The cap is a ceiling, not a target — libwebrtc still picks a lower
 /// operating bitrate from content. Selected at config time by passing a
 /// WebRTC codec to `PortalConfig::add_video`.
+///
+/// `simulcast` and `screencast` both default to `false`. See
+/// `PortalConfig::add_video` for what each one does.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VideoTrackSpec {
     pub name: String,
     pub codec: Codec,
     pub max_bitrate_kbps: Option<u32>,
+    /// Publish multiple spatial layers so the SFU can pick per subscriber.
+    /// Costs encode CPU and only pays off with several subscribers on
+    /// varied networks.
+    pub simulcast: bool,
+    /// Mark the source as screen content. Flips libwebrtc's degradation
+    /// preference from `MAINTAIN_FRAMERATE` to `MAINTAIN_RESOLUTION`, so
+    /// congestion and CPU pressure drop framerate instead of rescaling the
+    /// frame.
+    pub screencast: bool,
 }
 
 impl VideoTrackSpec {
-    pub fn new(name: impl Into<String>, codec: Codec, max_bitrate_kbps: Option<u32>) -> Self {
-        Self { name: name.into(), codec, max_bitrate_kbps }
+    pub fn new(
+        name: impl Into<String>,
+        codec: Codec,
+        max_bitrate_kbps: Option<u32>,
+        simulcast: bool,
+        screencast: bool,
+    ) -> Self {
+        Self { name: name.into(), codec, max_bitrate_kbps, simulcast, screencast }
     }
 }
 
@@ -215,6 +233,24 @@ impl PortalConfig {
     /// honors bitrate and ignores quality, the byte-stream codecs honor
     /// quality and ignore bitrate.
     ///
+    /// `simulcast` and `screencast` apply to the WebRTC codecs only and are
+    /// ignored for the byte-stream codecs. Both default to `false` when
+    /// `None` is passed.
+    ///
+    /// - `simulcast` publishes several spatial layers at once so the SFU can
+    ///   hand each subscriber the layer their link can carry. This costs
+    ///   encode CPU per extra layer and only pays off when several operators
+    ///   subscribe over links of differing quality. A single-operator teleop
+    ///   session gains nothing from it.
+    /// - `screencast` marks the source as screen content. libwebrtc picks its
+    ///   degradation preference from this flag: camera content defaults to
+    ///   `MAINTAIN_FRAMERATE`, which holds the frame rate and *rescales the
+    ///   frame* whenever CPU or bandwidth gets tight. Screen content uses
+    ///   `MAINTAIN_RESOLUTION` instead, which pins the frame geometry and
+    ///   drops frames under the same pressure. Turn this on when a stable,
+    ///   unchanging resolution matters more than smooth motion. A policy
+    ///   consuming fixed-shape frames is the usual case.
+    ///
     /// Track names must be unique across all `add_video` calls regardless
     /// of codec; a duplicate panics.
     ///
@@ -230,6 +266,8 @@ impl PortalConfig {
         codec: Codec,
         quality: u8,
         max_bitrate_kbps: Option<u32>,
+        simulcast: Option<bool>,
+        screencast: Option<bool>,
     ) {
         let name = name.into();
         assert!(
@@ -247,7 +285,13 @@ impl PortalConfig {
             assert!(kbps > 0, "max_bitrate_kbps must be > 0, got {kbps}");
         }
         if codec.is_webrtc() {
-            self.video_tracks.push(VideoTrackSpec::new(name, codec, max_bitrate_kbps));
+            self.video_tracks.push(VideoTrackSpec::new(
+                name,
+                codec,
+                max_bitrate_kbps,
+                simulcast.unwrap_or(false),
+                screencast.unwrap_or(false),
+            ));
         } else {
             self.frame_video_tracks.push(FrameVideoSpec::new(name, codec, quality));
         }

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -88,6 +88,15 @@ struct VideoEntry {
     /// codecs. Omit to use the default ceiling.
     #[serde(default)]
     max_bitrate_kbps: Option<u32>,
+    /// Publish multiple spatial layers. WebRTC codecs only. Defaults to
+    /// `false`.
+    #[serde(default)]
+    simulcast: Option<bool>,
+    /// Treat the source as screen content, pinning resolution and dropping
+    /// frames under pressure instead of rescaling. WebRTC codecs only.
+    /// Defaults to `false`.
+    #[serde(default)]
+    screencast: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -177,7 +186,7 @@ impl PortalConfig {
                 Codec::Mjpeg => DEFAULT_MJPEG_QUALITY,
                 _ => 0,
             });
-            cfg.add_video(&v.name, v.codec, quality, v.max_bitrate_kbps);
+            cfg.add_video(&v.name, v.codec, quality, v.max_bitrate_kbps, v.simulcast, v.screencast);
         }
 
         if !parsed.state.is_empty() {
@@ -263,6 +272,16 @@ fn validate(p: &ConfigFileV1) -> Result<(), ConfigFileError> {
                 return Err(ConfigFileError::Invalid(format!(
                     "video '{}': max_bitrate_kbps must be > 0",
                     v.name
+                )));
+            }
+        }
+        // Both toggles configure the WebRTC encoder, which byte-stream tracks
+        // never reach. Reject rather than silently ignore, same as bitrate.
+        for (field, set) in [("simulcast", v.simulcast), ("screencast", v.screencast)] {
+            if set.is_some() && !v.codec.is_webrtc() {
+                return Err(ConfigFileError::Invalid(format!(
+                    "video '{}': {field} applies to the WebRTC codecs only, not {:?}",
+                    v.name, v.codec
                 )));
             }
         }
@@ -410,6 +429,76 @@ videos:
         assert_eq!(cfg.frame_video_tracks().len(), 0);
         assert_eq!(cfg.video_tracks()[1].codec, Codec::Vp9);
         assert_eq!(cfg.video_tracks()[1].max_bitrate_kbps, Some(3000));
+    }
+
+    #[test]
+    fn simulcast_and_screencast_default_to_false() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: h264 }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        assert!(!cfg.video_tracks()[0].simulcast);
+        assert!(!cfg.video_tracks()[0].screencast);
+    }
+
+    #[test]
+    fn simulcast_and_screencast_parsed_per_track() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: a, codec: h264, simulcast: true }
+  - { name: b, codec: vp9, screencast: true }
+  - { name: c, codec: av1, simulcast: true, screencast: true }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        let t = cfg.video_tracks();
+        assert_eq!((t[0].simulcast, t[0].screencast), (true, false));
+        assert_eq!((t[1].simulcast, t[1].screencast), (false, true));
+        assert_eq!((t[2].simulcast, t[2].screencast), (true, true));
+    }
+
+    /// Explicit `simulcast: false` is preserved rather than being folded into
+    /// "unset", so the YAML reads the same as the resolved config.
+    #[test]
+    fn explicit_false_is_accepted() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: h264, simulcast: false, screencast: false }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        assert!(!cfg.video_tracks()[0].simulcast);
+        assert!(!cfg.video_tracks()[0].screencast);
+    }
+
+    #[test]
+    fn simulcast_on_byte_stream_codec_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: mjpeg, quality: 80, simulcast: true }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        match err {
+            ConfigFileError::Invalid(msg) => assert!(msg.contains("simulcast")),
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn screencast_on_byte_stream_codec_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: cam, codec: raw, screencast: false }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        match err {
+            ConfigFileError::Invalid(msg) => assert!(msg.contains("screencast")),
+            other => panic!("expected Invalid, got {other:?}"),
+        }
     }
 
     #[test]

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -1210,6 +1210,8 @@ impl Portal {
                 self.config.fps,
                 spec.codec,
                 spec.max_bitrate_kbps,
+                spec.simulcast,
+                spec.screencast,
             );
             if let Err(e) = publisher.publish(&lp).await {
                 // Roll back any earlier publishers so their send tasks stop

--- a/livekit-portal/src/video.rs
+++ b/livekit-portal/src/video.rs
@@ -37,6 +37,7 @@ pub(crate) struct VideoPublisher {
     fps: u32,
     codec: Codec,
     max_bitrate_kbps: Option<u32>,
+    simulcast: bool,
 }
 
 /// Map a Portal WebRTC codec to the libwebrtc codec the publish path sets.
@@ -63,12 +64,22 @@ impl VideoPublisher {
         fps: u32,
         codec: Codec,
         max_bitrate_kbps: Option<u32>,
+        simulcast: bool,
+        screencast: bool,
     ) -> Self {
         let resolution = VideoResolution { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
-        let source = NativeVideoSource::new(resolution, false);
+        // `screencast` is libwebrtc's content-type hint, and it is the only
+        // handle the SDK gives us on degradation preference (there is no
+        // `degradation_preference` field on `TrackPublishOptions`). Camera
+        // content (`false`) means `MAINTAIN_FRAMERATE`: under CPU overuse or
+        // bitrate pressure the adapter rescales frames before they reach the
+        // encoder, so subscribers see the resolution shift mid-session.
+        // Screen content (`true`) means `MAINTAIN_RESOLUTION`, which pins the
+        // geometry and sheds frames instead.
+        let source = NativeVideoSource::new(resolution, screencast);
         let rtc_source = RtcVideoSource::Native(source.clone());
         let track = LocalVideoTrack::create_video_track(name, rtc_source);
-        Self { source, track, metrics, fps, codec, max_bitrate_kbps }
+        Self { source, track, metrics, fps, codec, max_bitrate_kbps, simulcast }
     }
 
     pub async fn publish(&self, local_participant: &LocalParticipant) -> PortalResult<()> {
@@ -93,7 +104,7 @@ impl VideoPublisher {
         let max_bitrate_kbps = self.max_bitrate_kbps.unwrap_or(DEFAULT_H264_MAX_BITRATE_KBPS);
         let options = TrackPublishOptions {
             video_codec: webrtc_video_codec(self.codec),
-            simulcast: false,
+            simulcast: self.simulcast,
             packet_trailer_features: features,
             video_encoding: Some(VideoEncoding {
                 max_framerate: (self.fps as f64) * 2.0,

--- a/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
+++ b/python/packages/lerobot-robot-livekit/lerobot_robot_livekit/robot.py
@@ -67,6 +67,16 @@ class LiveKitRobotConfig(RobotConfig):
     video_quality: int = DEFAULT_MJPEG_QUALITY
     video_max_bitrate_kbps: int | None = None
 
+    # WebRTC encoder behavior. Both default to off and apply to the WebRTC
+    # codecs only. `video_simulcast` publishes several spatial layers so the
+    # SFU can choose per subscriber, at the cost of encode CPU per layer.
+    # `video_screencast` marks the source as screen content, which pins the
+    # resolution and drops frames under CPU or bandwidth pressure instead of
+    # rescaling the frame. Turn the latter on if frames arrive at a changing
+    # resolution mid-session and your policy needs a fixed frame shape.
+    video_simulcast: bool | None = None
+    video_screencast: bool | None = None
+
     # Portal tuning.
     slack: int | None = None
     tolerance: float | None = None
@@ -182,6 +192,8 @@ class LiveKitRobot(Robot):
                 codec=self.config.video_codec,
                 quality=self.config.video_quality,
                 max_bitrate_kbps=self.config.video_max_bitrate_kbps,
+                simulcast=self.config.video_simulcast,
+                screencast=self.config.video_screencast,
             )
         if self._state_motors:
             self._portal_cfg.add_state_typed(

--- a/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
+++ b/python/packages/lerobot-teleoperator-livekit/lerobot_teleoperator_livekit/teleoperator.py
@@ -57,6 +57,16 @@ class LiveKitTeleoperatorConfig(TeleoperatorConfig):
     video_quality: int = DEFAULT_MJPEG_QUALITY
     video_max_bitrate_kbps: int | None = None
 
+    # WebRTC encoder behavior. Both default to off and apply to the WebRTC
+    # codecs only. `video_simulcast` publishes several spatial layers so the
+    # SFU can choose per subscriber, at the cost of encode CPU per layer.
+    # `video_screencast` marks the source as screen content, which pins the
+    # resolution and drops frames under CPU or bandwidth pressure instead of
+    # rescaling the frame. Turn the latter on if frames arrive at a changing
+    # resolution mid-session and your policy needs a fixed frame shape.
+    video_simulcast: bool | None = None
+    video_screencast: bool | None = None
+
     # Portal tuning.
     slack: int | None = None
     tolerance: float | None = None
@@ -159,6 +169,8 @@ class LiveKitTeleoperator(Teleoperator):
                 codec=self.config.video_codec,
                 quality=self.config.video_quality,
                 max_bitrate_kbps=self.config.video_max_bitrate_kbps,
+                simulcast=self.config.video_simulcast,
+                screencast=self.config.video_screencast,
             )
         if self._state_motors:
             self._portal_cfg.add_state_typed(

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -751,6 +751,9 @@ class PortalConfig:
         codec: VideoCodec = VideoCodec.H264,
         quality: int = DEFAULT_MJPEG_QUALITY,
         max_bitrate_kbps: Optional[int] = None,
+        *,
+        simulcast: Optional[bool] = None,
+        screencast: Optional[bool] = None,
     ) -> None:
         """Declare a video track.
 
@@ -780,6 +783,23 @@ class PortalConfig:
         WebRTC codecs (H264/VP8/VP9/AV1/H265) and ignored otherwise. Track
         names must be unique across all `add_video` calls; a duplicate raises.
 
+        `simulcast` and `screencast` are keyword-only, apply to the WebRTC
+        codecs only, and both default to `False`.
+
+          * `simulcast=True` publishes several spatial layers at once so the
+            SFU can hand each subscriber the layer their link can carry. Costs
+            encode CPU per extra layer. Worth it only when several operators
+            subscribe over links of differing quality. A single-operator
+            teleop session gains nothing.
+          * `screencast=True` marks the source as screen content. libwebrtc
+            picks its degradation preference from this flag. Camera content
+            (the default) uses MAINTAIN_FRAMERATE, which holds the frame rate
+            and **rescales the frame** whenever CPU or bandwidth gets tight,
+            so subscribers see the resolution shift mid-session. Screen
+            content uses MAINTAIN_RESOLUTION, which pins the frame geometry
+            and drops frames under the same pressure. Turn this on when a
+            policy needs a fixed frame shape more than it needs smooth motion.
+
         **Byte-stream latency** (non-H264 codecs): each frame's payload is
         fragmented at the LiveKit chunk size (15 KB) and shipped over a
         single SCTP data channel. Per-frame latency is roughly `1 ms + 2 ms
@@ -789,7 +809,9 @@ class PortalConfig:
         typical inference resolutions (224×224 to 480p) MJPEG q=80–95
         usually does.
         """
-        self._inner.add_video(name, codec, quality, max_bitrate_kbps)
+        self._inner.add_video(
+            name, codec, quality, max_bitrate_kbps, simulcast, screencast
+        )
         if codec in _WEBRTC_CODECS:
             self._video_tracks.append(name)
         else:
@@ -1312,8 +1334,13 @@ class _RoleConfigBase:
         codec: VideoCodec = VideoCodec.H264,
         quality: int = DEFAULT_MJPEG_QUALITY,
         max_bitrate_kbps: Optional[int] = None,
+        *,
+        simulcast: Optional[bool] = None,
+        screencast: Optional[bool] = None,
     ) -> None:
-        self._inner.add_video(name, codec, quality, max_bitrate_kbps)
+        self._inner.add_video(
+            name, codec, quality, max_bitrate_kbps, simulcast, screencast
+        )
 
     def add_state_typed(self, schema: Iterable[SchemaEntry]) -> None:
         self._inner.add_state_typed(_to_field_specs(schema))

--- a/python/packages/livekit-portal/tests/integration/test_ffi_role_split.py
+++ b/python/packages/livekit-portal/tests/integration/test_ffi_role_split.py
@@ -83,12 +83,12 @@ async def ffi_pair():
     robot_cfg = ffi.RobotConfig(room)
     robot_cfg.add_state_typed([_f("j")])
     robot_cfg.add_action_typed([_f("a")])
-    robot_cfg.add_video("cam", ffi.VideoCodec.MJPEG, 90, None)
+    robot_cfg.add_video("cam", ffi.VideoCodec.MJPEG, 90, None, None, None)
 
     operator_cfg = ffi.OperatorConfig(room)
     operator_cfg.add_state_typed([_f("j")])
     operator_cfg.add_action_typed([_f("a")])
-    operator_cfg.add_video("cam", ffi.VideoCodec.MJPEG, 90, None)
+    operator_cfg.add_video("cam", ffi.VideoCodec.MJPEG, 90, None, None, None)
 
     robot_cb = _Recorder()
     operator_cb = _Recorder()

--- a/python/packages/livekit-portal/tests/integration/test_webrtc_codecs.py
+++ b/python/packages/livekit-portal/tests/integration/test_webrtc_codecs.py
@@ -83,3 +83,39 @@ async def test_h264_with_max_bitrate_cap_flows(pair):
     await asyncio.sleep(DRAIN_S)
 
     assert received, "no frames received for bitrate-capped H264 track"
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        pytest.param({"screencast": True}, id="screencast"),
+        pytest.param({"simulcast": True}, id="simulcast"),
+        pytest.param({"simulcast": True, "screencast": True}, id="both"),
+    ],
+)
+async def test_encoder_toggles_publish_and_deliver(pair, flags):
+    """`simulcast` and `screencast` must not break publish or negotiation.
+
+    `screencast` flips the libwebrtc content-type hint, which decides the
+    degradation preference. `simulcast` changes the number of published
+    encodings. Both alter `TrackPublishOptions` and the track source, so a
+    regression in either shows up here as zero received frames.
+
+    Only the publisher sets the flags. They are encoder-side, so the
+    subscriber declares a plain track and must still decode normally.
+    """
+    pair.robot_cfg.add_video("cam", codec=VideoCodec.H264, **flags)
+    pair.operator_cfg.add_video("cam", codec=VideoCodec.H264)
+
+    received: list[VideoFrameData] = []
+    await pair.start()
+    pair.operator.on_video_frame("cam", lambda name, f: received.append(f))
+
+    await asyncio.sleep(SUBSCRIBE_SETTLE_S)
+    for i in range(15):
+        pair.robot.send_video_frame("cam", _gradient(320, 240, seed=i))
+        await asyncio.sleep(0.05)
+    await asyncio.sleep(DRAIN_S)
+
+    assert received, f"no frames received with {flags}"
+    assert received[0].width > 0 and received[0].height > 0

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -1,7 +1,16 @@
 """Config builder smoke tests. No networking, no runtime."""
 import pytest
 
-from livekit.portal import DType, FieldSpec, Portal, PortalConfig, PortalError, Role
+from livekit.portal import (
+    DEFAULT_MJPEG_QUALITY,
+    DType,
+    FieldSpec,
+    Portal,
+    PortalConfig,
+    PortalError,
+    Role,
+    VideoCodec,
+)
 
 
 def test_new_config_constructs():
@@ -24,6 +33,32 @@ def test_config_adders_are_captured():
     ]
     assert cfg.state_schema == expected
     assert cfg.action_schema == expected
+
+
+def test_simulcast_and_screencast_are_accepted_on_webrtc_codecs():
+    cfg = PortalConfig("demo", Role.ROBOT)
+    cfg.add_video("plain")
+    cfg.add_video("pinned", screencast=True)
+    cfg.add_video("layered", simulcast=True)
+    cfg.add_video("both", simulcast=True, screencast=True)
+    assert cfg.video_tracks == ["plain", "pinned", "layered", "both"]
+
+
+def test_simulcast_and_screencast_are_keyword_only():
+    cfg = PortalConfig("demo", Role.ROBOT)
+    # Guards the signature: a fifth positional would silently land on a
+    # future parameter if these ever stopped being keyword-only.
+    with pytest.raises(TypeError):
+        cfg.add_video("cam", VideoCodec.H264, DEFAULT_MJPEG_QUALITY, None, True)
+
+
+def test_screencast_on_byte_stream_codec_is_ignored_not_rejected():
+    # The programmatic API mirrors `max_bitrate_kbps`: silently ignored on
+    # the byte-stream path. Only the YAML loader rejects it outright.
+    cfg = PortalConfig("demo", Role.ROBOT)
+    cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=80, screencast=True)
+    assert cfg.video_tracks == []
+    assert [t.name for t in cfg.frame_video_tracks] == ["cam"]
 
 
 def test_mixed_dtype_schema_is_accepted():


### PR DESCRIPTION
## What

Make `simulcast` and `screencast` per-track config on `add_video`, instead of values hardcoded in the publish path. Both default to their previous values, so nothing changes unless a caller opts in.

```python
cfg.add_video("front", screencast=True)              # pin the resolution
cfg.add_video("wide", simulcast=True)                # publish several spatial layers
```

```yaml
videos:
  - { name: front, codec: h264, screencast: true }
```

## Why

`simulcast` was pinned off, and the track source was always constructed as camera content.

That second one has a visible consequence. libwebrtc picks its degradation preference from the source content type. Camera content means `MAINTAIN_FRAMERATE`, so under CPU overuse or bandwidth pressure the adapter rescales frames before the encoder sees them. Subscribers watch the resolution shift mid-session, and there was no way to opt out.

| Setting | libwebrtc preference | Under pressure |
|---|---|---|
| `screencast=False` (default) | `MAINTAIN_FRAMERATE` | Holds the frame rate, rescales the frame |
| `screencast=True` | `MAINTAIN_RESOLUTION` | Holds the resolution, drops frames |

That trade is workload-dependent. A human watching a teleop preview wants smooth motion. A policy consuming pixels usually wants a fixed frame shape. Only the caller knows which.

`TrackPublishOptions` has no `degradation_preference` field, so the content-type hint on `NativeVideoSource` is the only handle the SDK gives us. Hence the name `screencast` rather than something more descriptive of the effect.

`simulcast` is the smaller half. It was already off and off is the right default for single-operator teleop, since extra spatial layers cost encode CPU and only pay off across subscribers on links of differing quality. It is exposed here because it is the same plumbing.

## Commits

1. **feat** — plumb both through `VideoTrackSpec`, `PortalConfig::add_video`, the YAML loader, the three UniFFI `add_video` sites, the Python facades, and the two lerobot configs.
2. **test** — config-level and integration coverage.
3. **docs** — API section, troubleshooting entry, and reference updates.

Both toggles apply to the WebRTC codecs only. The YAML loader rejects them on the byte-stream codecs, matching how `max_bitrate_kbps` is already handled. The programmatic API ignores them there instead, also matching `max_bitrate_kbps`.

On the Python side they are keyword-only, so the positional list does not grow to six arguments.

## Verification

- `cargo clippy --workspace --all-features` clean
- `cargo fmt --all --check` clean
- `cargo test --workspace --locked`, 106 passed
- `pytest` unit suite, 50 passed
- Full integration suite against a local LiveKit dev server, 132 passed
- All three commits compile individually

New tests: 5 Rust YAML cases, 3 Python config cases, and 3 integration cases publishing with `screencast`, `simulcast`, and both.

## Notes

The integration tests prove the flags publish and deliver correctly. They do not prove `screencast=True` eliminates resolution drift under load, since reproducing that needs real encoder pressure. Confirm on a live workload by logging `frame.width` and `frame.height` across a session.

`cargo clippy --all-targets` fails on three pre-existing `approx_constant` errors in `dtype.rs` and `serialization.rs`. Those files are untouched here, and CI does not pass `--all-targets`, so nothing is blocked. Worth a separate cleanup.

Generated bindings (`livekit_portal_ffi.py`, the cdylib) are gitignored and built in CI, so they are not in the diff.