### PR TITLE
fix: repair two merge-order regressions breaking CI on main

### DIFF
--- a/livekit-portal/src/video.rs
+++ b/livekit-portal/src/video.rs
@@ -105,7 +105,7 @@ impl VideoPublisher {
         let options = TrackPublishOptions {
             video_codec: webrtc_video_codec(self.codec),
             simulcast: self.simulcast,
-            packet_trailer_features: features,
+            frame_metadata_features: features,
             video_encoding: Some(VideoEncoding {
                 max_framerate: (self.fps as f64) * 2.0,
                 max_bitrate: (max_bitrate_kbps as u64) * 1_000,

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -5,9 +5,11 @@ from livekit.portal import (
     DEFAULT_MJPEG_QUALITY,
     DType,
     FieldSpec,
+    OperatorConfig,
     Portal,
     PortalConfig,
     PortalError,
+    RobotConfig,
     Role,
     VideoCodec,
 )


### PR DESCRIPTION
`main` has been red since #78. Two separate regressions, one cause.

#78 was branched before both #79 and #76, and merged without a rebase. Its stale diff context overwrote the newer code in two places.

## 1. Renamed SDK field, `livekit-portal/src/video.rs`

#79 moved the `livekit` dependency from the git SDK to registry 0.8.3 and renamed `TrackPublishOptions::packet_trailer_features` to `frame_metadata_features`. #78 put the old name back when it added the `simulcast` field to the same struct literal.

```
error[E0560]: struct `TrackPublishOptions` has no field named `packet_trailer_features`
   --> livekit-portal/src/video.rs:108:13
```

The lib stopped compiling, which took down both CI jobs. The pytest job failed at the FFI build step, and the cargo job failed at the clippy lint step before it ever reached the tests.

Note that #78 only reverted this one line. The rest of #79's changes to `video.rs` survived, including the matching `FrameMetadataFeatures` import, which is why the failure is a field error rather than an unresolved import.

## 2. Dropped test imports, `test_config.py`

#76 added `RobotConfig` and `OperatorConfig` to the import block alongside the parametrize cases that construct them. #78 restored the older import block. The parametrize cases survived, the imports did not.

```
E   NameError: name 'OperatorConfig' is not defined
```

This one was masked. CI never got far enough to run pytest, so it would have surfaced as a fresh failure on the next green build.

## Verification

Ran the exact CI steps locally on the pinned 1.96.0 toolchain.

- `cargo clippy` under `RUSTFLAGS=-D warnings`, clean
- `cargo test --workspace --locked`, 111 passed
- `bash scripts/build_ffi_python.sh release`, builds and generates bindings
- `uv run pytest packages/livekit-portal/tests`, 65 passed

## Out of scope

`cargo clippy --all-targets` reports three `approx_constant` errors on `-3.14` literals in `serialization.rs` test code. CI runs bare `cargo clippy`, which does not lint test targets, so these do not affect the build. Left alone.