### PR TITLE
Use robotics team CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
-# CODEOWNERS for rust-sdks
-# These owners will be requested for review on all PRs
-* @pham-tuan-binh
-
-livekit-portal/ @ladvoc
-livekit-portal-ffi/ @ladvoc
+# Specify the default code owner for all files with a wildcard:
+* @livekit/robotics-devs


### PR DESCRIPTION
Uses [robotics-devs](https://github.com/orgs/livekit/teams/robotics-devs) as default approvers plus existing owner