### PR TITLE
feat(sync): per-track stall behavior, keeping healthy cameras visible when one dies

### DIFF
--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -130,7 +130,11 @@ role-specific is a no-op on the wrong side.
 | `set_state_reliable(bool)` | `True` | Reliable delivery for state. |
 | `set_action_reliable(bool)` | `True` | Reliable delivery for actions. |
 | `set_ping_ms(int)` | 1000 | RTT probe cadence. `0` disables probing on this side. |
-| `set_reuse_stale_frames(bool)` | `False` | Freeze video on loss instead of dropping state. |
+| `set_on_stall(StallPolicy)` | `DROP` | What to do about a moment a silent track cannot cover: `DROP`, `FREEZE`, or `OMIT`. |
+| `set_max_lag_ms(int)` | `slack / fps` | How long to wait for a silent track first, in sender-clock ms. |
+| `set_track_on_stall(str, StallPolicy)` | — | Per-track override of `set_on_stall`. |
+| `set_track_max_lag_ms(str, int)` | — | Per-track override of `set_max_lag_ms`. |
+| `set_reuse_stale_frames(bool)` | `False` | Deprecated. Alias for `set_on_stall(FREEZE)` with `set_max_lag_ms(0)`. |
 | `set_action_subscription(bool)` | `False` | Operator-only. Receive executed actions. |
 | `set_e2ee_key(bytes)` | none | Shared-key encryption. See [E2EE](reference/e2ee.md). |
 
@@ -153,7 +157,7 @@ config you loaded from YAML instead of building by hand:
 | `tolerance` | `float` | `set_tolerance`. |
 | `state_reliable` / `action_reliable` | `bool` | The reliability flags. |
 | `ping_ms` | `int` | `set_ping_ms`. |
-| `reuse_stale_frames` | `bool` | `set_reuse_stale_frames`. |
+| `reuse_stale_frames` | `bool` | `set_reuse_stale_frames`. Deprecated. |
 | `action_subscription` | `bool` | `set_action_subscription`. |
 | `has_e2ee_key` | `bool` | Whether a key was set. The bytes are not readable back. |
 

--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -130,11 +130,11 @@ role-specific is a no-op on the wrong side.
 | `set_state_reliable(bool)` | `True` | Reliable delivery for state. |
 | `set_action_reliable(bool)` | `True` | Reliable delivery for actions. |
 | `set_ping_ms(int)` | 1000 | RTT probe cadence. `0` disables probing on this side. |
-| `set_on_stall(StallPolicy)` | `DROP` | What to do about a moment a silent track cannot cover: `DROP`, `FREEZE`, or `OMIT`. |
+| `set_stall_behavior(StallBehavior)` | `DROP` | What to do about a moment a silent track cannot cover: `DROP`, `FREEZE`, or `OMIT`. |
 | `set_max_lag_ms(int)` | `slack / fps` | How long to wait for a silent track first, in sender-clock ms. |
-| `set_track_on_stall(str, StallPolicy)` | — | Per-track override of `set_on_stall`. |
+| `set_track_stall_behavior(str, StallBehavior)` | — | Per-track override of `set_stall_behavior`. In Python, `add_video(..., stall_behavior=...)` is the shorter equivalent. |
 | `set_track_max_lag_ms(str, int)` | — | Per-track override of `set_max_lag_ms`. |
-| `set_reuse_stale_frames(bool)` | `False` | Deprecated. Alias for `set_on_stall(FREEZE)` with `set_max_lag_ms(0)`. |
+| `set_reuse_stale_frames(bool)` | `False` | Deprecated. Alias for `set_stall_behavior(FREEZE)` with `set_max_lag_ms(0)`. |
 | `set_action_subscription(bool)` | `False` | Operator-only. Receive executed actions. |
 | `set_e2ee_key(bytes)` | none | Shared-key encryption. See [E2EE](reference/e2ee.md). |
 

--- a/docs/04-tuning.md
+++ b/docs/04-tuning.md
@@ -17,7 +17,9 @@ cfg.set_tolerance(1.5)               # match window, in ticks
 cfg.set_state_reliable(True)
 cfg.set_action_reliable(True)
 cfg.set_ping_ms(1000)                # 0 disables RTT probing on this side
-cfg.set_reuse_stale_frames(False)
+
+cfg.set_on_stall(StallPolicy.DROP)   # what to do about a silent track
+cfg.set_max_lag_ms(166)              # how long to wait first; default slack/fps
 ```
 
 ## The three matching knobs
@@ -86,28 +88,65 @@ Under asymmetric rates the overall drop rate scales with
 `state_rate x video_loss_rate`, not with the video rate. Fewer states means
 fewer things that can fail to match.
 
-## Reusing stale frames
+## Stalled tracks
 
-Off by default. Turn it on when your application would rather see a frozen frame
-than lose a state entirely.
+When a camera stops sending, two knobs decide what happens to the moments it
+can no longer cover: how long to wait, then what to do.
 
 ```python
-cfg.set_reuse_stale_frames(True)
+cfg.set_max_lag_ms(150)                 # wait this long, in stream time
+cfg.set_on_stall(StallPolicy.OMIT)      # then resolve this way
 ```
 
-With it on, a state whose match window has elapsed falls back to the most recent
-frame that track already emitted. Video freezes on the last good frame while
-state keeps flowing. Every state becomes an observation, once every track has
-emitted at least once.
+`max_lag` is how far the fastest-advancing stream may run past a moment before
+that moment resolves without the silent track. It is **sender-clock time, not
+wall-clock** — a statement about stream position, evaluated when a packet
+arrives rather than on a timer. It defaults to `slack / fps`, which is where
+state-buffer capacity would have evicted the moment anyway.
 
-Before that first emission there is no fallback, so the strict drop rule still
-applies. That keeps the state buffer bounded if video never starts at all.
+`on_stall` picks the outcome:
+
+| | What the consumer sees |
+|---|---|
+| `DROP` (default) | No observation at all. The state still reaches the drop callback, but the healthy cameras in that moment go with it. |
+| `FREEZE` | The silent track's last good frame. Video freezes, state keeps flowing. |
+| `OMIT` | A magenta "NO SIGNAL" placeholder naming the track, so the healthy cameras stay visible. |
+
+Every frame carries a `FrameSource` saying which of the three it is:
+
+```python
+def on_observation(obs):
+    wrist = obs.frames["wrist"]          # always present, whatever happened
+    if wrist.source is not FrameSource.LIVE:
+        return                            # not a measurement of this moment
+```
+
+`OMIT` never removes the key, so turning it on cannot start raising `KeyError`
+in code written before it existed.
+
+### Per track
+
+Cameras differ in how load-bearing they are, so both knobs override per track:
+
+```python
+cfg.set_on_stall(StallPolicy.OMIT)              # default for every track
+cfg.set_track_on_stall("wrist", StallPolicy.DROP)
+cfg.set_track_max_lag_ms("wrist", 40)
+```
 
 | Your situation | Pick |
 |---|---|
-| Real-time inference or control | `False`. A stale frame silently misaligns the perception and action loop. |
-| Data collection or logging | `True`. A dropped state is lost data. A brief video freeze is recoverable. |
-| Teleop viewer | `True`. Continuity beats exact pairing. |
+| Real-time inference or control | `DROP` on the tracks the policy depends on. A substituted frame silently misaligns the perception and action loop, and no observation beats a confidently wrong one. |
+| Data collection or logging | `FREEZE`. A dropped state is lost data; a brief video freeze is recoverable, and `FrameSource.STALE` marks it in the recording. |
+| Teleop viewer | `OMIT`. One dead camera should not blank the other three, and the operator can see which one died. |
+
+Before a track's first frame, `FREEZE` has nothing to reuse and `OMIT` has no
+geometry to synthesize from, so both wait through that startup window and then
+fall back to `DROP`. That keeps the state buffer bounded if video never starts
+at all.
+
+`set_reuse_stale_frames(True)` still works, as a deprecated alias for
+`set_on_stall(StallPolicy.FREEZE)` with `set_max_lag_ms(0)`.
 
 **Watch `metrics.sync.stale_observations_emitted`.** That counter rising while
 `observations_emitted` holds steady is the signal that a track is silently

--- a/docs/04-tuning.md
+++ b/docs/04-tuning.md
@@ -93,6 +93,14 @@ fewer things that can fail to match.
 When a camera stops sending, two knobs decide what happens to the moments it
 can no longer cover: how long to wait, then what to do.
 
+**Set these on the side that consumes observations, normally the operator.**
+Observations are assembled where they are received, so a stall is detected and
+resolved locally by the subscriber; nothing about it crosses the wire. Setting
+them on a `RobotConfig` is a no-op. In particular, `OMIT` does not send a
+placeholder frame: a silent camera is by definition sending nothing, so the
+receiver synthesizes the stand-in itself, using the geometry of the last frame
+that track actually delivered.
+
 ```python
 cfg.set_max_lag_ms(150)                 # wait this long, in stream time
 cfg.set_on_stall(StallPolicy.OMIT)      # then resolve this way

--- a/docs/04-tuning.md
+++ b/docs/04-tuning.md
@@ -18,7 +18,7 @@ cfg.set_state_reliable(True)
 cfg.set_action_reliable(True)
 cfg.set_ping_ms(1000)                # 0 disables RTT probing on this side
 
-cfg.set_on_stall(StallPolicy.DROP)   # what to do about a silent track
+cfg.set_stall_behavior(StallBehavior.DROP)   # what to do about a silent track
 cfg.set_max_lag_ms(166)              # how long to wait first; default slack/fps
 ```
 
@@ -103,7 +103,7 @@ that track actually delivered.
 
 ```python
 cfg.set_max_lag_ms(150)                 # wait this long, in stream time
-cfg.set_on_stall(StallPolicy.OMIT)      # then resolve this way
+cfg.set_stall_behavior(StallBehavior.OMIT)      # then resolve this way
 ```
 
 `max_lag` is how far the fastest-advancing stream may run past a moment before
@@ -112,7 +112,7 @@ wall-clock** — a statement about stream position, evaluated when a packet
 arrives rather than on a timer. It defaults to `slack / fps`, which is where
 state-buffer capacity would have evicted the moment anyway.
 
-`on_stall` picks the outcome:
+`stall_behavior` picks the outcome:
 
 | | What the consumer sees |
 |---|---|
@@ -134,12 +134,34 @@ in code written before it existed.
 
 ### Per track
 
-Cameras differ in how load-bearing they are, so both knobs override per track:
+Cameras differ in how load-bearing they are, so both knobs override per track.
+In Python the override goes on the track declaration, alongside `codec` and the
+encoder settings, so everything about a track reads in one place:
 
 ```python
-cfg.set_on_stall(StallPolicy.OMIT)              # default for every track
-cfg.set_track_on_stall("wrist", StallPolicy.DROP)
+cfg.set_stall_behavior(StallBehavior.OMIT)      # defaults for every track
+cfg.set_max_lag_ms(150)
+
+cfg.add_video("wrist", stall_behavior=StallBehavior.DROP, max_lag_ms=40)
+cfg.add_video("scene")                          # inherits OMIT / 150ms
+```
+
+Both are keyword-only and `None` inherits, so a track can override the
+behavior, the budget, or both. Setters exist for the cases where the config is
+built elsewhere, such as after `from_yaml`:
+
+```python
+cfg.set_track_stall_behavior("wrist", StallBehavior.DROP)
 cfg.set_track_max_lag_ms("wrist", 40)
+```
+
+Rust uses the setters throughout, keeping `add_video` at its existing arity:
+
+```rust
+cfg.set_stall_behavior(StallBehavior::Omit);
+cfg.set_max_lag_ms(150);
+cfg.set_track_stall_behavior("wrist", StallBehavior::Drop);
+cfg.set_track_max_lag_ms("wrist", 40);
 ```
 
 | Your situation | Pick |
@@ -154,7 +176,7 @@ fall back to `DROP`. That keeps the state buffer bounded if video never starts
 at all.
 
 `set_reuse_stale_frames(True)` still works, as a deprecated alias for
-`set_on_stall(StallPolicy.FREEZE)` with `set_max_lag_ms(0)`.
+`set_stall_behavior(StallBehavior.FREEZE)` with `set_max_lag_ms(0)`.
 
 **Watch `metrics.sync.stale_observations_emitted`.** That counter rising while
 `observations_emitted` holds steady is the signal that a track is silently

--- a/docs/07-metrics.md
+++ b/docs/07-metrics.md
@@ -49,7 +49,8 @@ Operator side. Everything about turning separate streams into observations.
 | Field | Type | Meaning |
 |---|---|---|
 | `observations_emitted` | `int` | Total observations handed to your callback. |
-| `stale_observations_emitted` | `int` | Subset of the above where at least one track contributed a reused frame. Always `0` unless `reuse_stale_frames` is on. |
+| `stale_observations_emitted` | `int` | Subset of the above where at least one track contributed a reused frame. Always `0` unless some track uses `on_stall: freeze`. |
+| `frames_omitted` | `dict[str, int]` | Per track: synthesized placeholder frames emitted under `on_stall: omit`. Rising means that camera is silent and its moments are being kept alive with a stand-in. |
 | `states_dropped` | `int` | States that never found a matching frame. |
 | `match_delta_us_p50` | `int \| None` | Median worst-track alignment per observation. |
 | `match_delta_us_p95` | `int \| None` | 95th percentile of the same. |
@@ -65,14 +66,14 @@ of 8 000 means you are using a sixth of the window and could tighten
 jitter will start dropping.
 
 **`stale_observations_emitted` is your freeze detector.** With
-`reuse_stale_frames` on, a frozen camera produces observations exactly like a
+`on_stall: freeze`, a frozen camera produces observations exactly like a
 healthy one. This counter is the only thing that distinguishes them. Rising here
 while `observations_emitted` holds steady means video is frozen and state is
 still flowing.
 
 **`last_blocker_track` is sticky and startup-biased.** It updates when a new
 block occurs, which is useful for post-hoc diagnosis. Under
-`reuse_stale_frames`, it stops updating once every track has emitted once, so do
+`on_stall: freeze`, it stops updating once every track has emitted once, so do
 not use it to detect a freeze. Use `stale_observations_emitted`.
 
 ```python

--- a/docs/07-metrics.md
+++ b/docs/07-metrics.md
@@ -49,8 +49,8 @@ Operator side. Everything about turning separate streams into observations.
 | Field | Type | Meaning |
 |---|---|---|
 | `observations_emitted` | `int` | Total observations handed to your callback. |
-| `stale_observations_emitted` | `int` | Subset of the above where at least one track contributed a reused frame. Always `0` unless some track uses `on_stall: freeze`. |
-| `frames_omitted` | `dict[str, int]` | Per track: synthesized placeholder frames emitted under `on_stall: omit`. Rising means that camera is silent and its moments are being kept alive with a stand-in. |
+| `stale_observations_emitted` | `int` | Subset of the above where at least one track contributed a reused frame. Always `0` unless some track uses `stall_behavior: freeze`. |
+| `frames_omitted` | `dict[str, int]` | Per track: synthesized placeholder frames emitted under `stall_behavior: omit`. Rising means that camera is silent and its moments are being kept alive with a stand-in. |
 | `states_dropped` | `int` | States that never found a matching frame. |
 | `match_delta_us_p50` | `int \| None` | Median worst-track alignment per observation. |
 | `match_delta_us_p95` | `int \| None` | 95th percentile of the same. |
@@ -66,14 +66,14 @@ of 8 000 means you are using a sixth of the window and could tighten
 jitter will start dropping.
 
 **`stale_observations_emitted` is your freeze detector.** With
-`on_stall: freeze`, a frozen camera produces observations exactly like a
+`stall_behavior: freeze`, a frozen camera produces observations exactly like a
 healthy one. This counter is the only thing that distinguishes them. Rising here
 while `observations_emitted` holds steady means video is frozen and state is
 still flowing.
 
 **`last_blocker_track` is sticky and startup-biased.** It updates when a new
 block occurs, which is useful for post-hoc diagnosis. Under
-`on_stall: freeze`, it stops updating once every track has emitted once, so do
+`stall_behavior: freeze`, it stops updating once every track has emitted once, so do
 not use it to detect a freeze. Use `stale_observations_emitted`.
 
 ```python

--- a/docs/08-troubleshooting.md
+++ b/docs/08-troubleshooting.md
@@ -204,8 +204,10 @@ match window. State kept flowing while video did not.
 
 - Raise `tolerance` to widen the window. Keep it at 1 or above.
 - Raise `slack` to buffer through longer stalls.
-- Enable `reuse_stale_frames` to freeze on the last good frame instead of
-  dropping. Good for data collection. Wrong for real-time control.
+- Set `on_stall` to something other than `DROP` so the moment survives:
+  `FREEZE` holds the last good frame (good for data collection, wrong for
+  real-time control), `OMIT` substitutes a visible placeholder so the healthy
+  cameras stay on screen. Both can be set per track.
 - Check `metrics.sync.last_blocker_track` to see which camera is behind.
 
 See [Choosing `tolerance`](04-tuning.md#choosing-tolerance).
@@ -220,9 +222,10 @@ The state buffer hit its cap and shed its oldest entries. States piled up with n
 frame to match against, which usually means a video track stalled completely.
 Logs once per burst.
 
-**Fix.** Raise `slack` to tolerate longer stalls. Enable `reuse_stale_frames` if a
-frozen frame is acceptable. If video stopped entirely, the fix is at the robot,
-not in the buffer.
+**Fix.** Raise `slack` to tolerate longer stalls, or lower `max_lag` so stuck
+moments resolve before they pile up. Set `on_stall` to `FREEZE` or `OMIT` if a
+substituted frame is acceptable. If video stopped entirely, the fix is at the
+robot, not in the buffer.
 
 ### video-overflow
 

--- a/docs/08-troubleshooting.md
+++ b/docs/08-troubleshooting.md
@@ -204,7 +204,7 @@ match window. State kept flowing while video did not.
 
 - Raise `tolerance` to widen the window. Keep it at 1 or above.
 - Raise `slack` to buffer through longer stalls.
-- Set `on_stall` to something other than `DROP` so the moment survives:
+- Set `stall_behavior` to something other than `DROP` so the moment survives:
   `FREEZE` holds the last good frame (good for data collection, wrong for
   real-time control), `OMIT` substitutes a visible placeholder so the healthy
   cameras stay on screen. Both can be set per track.
@@ -223,7 +223,7 @@ frame to match against, which usually means a video track stalled completely.
 Logs once per burst.
 
 **Fix.** Raise `slack` to tolerate longer stalls, or lower `max_lag` so stuck
-moments resolve before they pile up. Set `on_stall` to `FREEZE` or `OMIT` if a
+moments resolve before they pile up. Set `stall_behavior` to `FREEZE` or `OMIT` if a
 substituted frame is acceptable. If video stopped entirely, the fix is at the
 robot, not in the buffer.
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -96,8 +96,9 @@ tolerance: 1.5               # match window, in ticks
 state_reliable: true
 action_reliable: true
 
-# Sync behavior
-reuse_stale_frames: false    # freeze video on loss instead of dropping state
+# Stalled-track handling. Both override per video track.
+on_stall: drop               # drop | freeze | omit
+max_lag_ms: 166              # wait this long first; default is slack / fps
 
 # Heartbeat
 ping_ms: 1000                # RTT probe cadence. 0 disables probing here.
@@ -142,7 +143,9 @@ action_chunks:
 | `tolerance` | float | `1.5` | Match window, in ticks. See [Tuning](../04-tuning.md). |
 | `state_reliable` | bool | `true` | Reliable transport for state packets. |
 | `action_reliable` | bool | `true` | Reliable transport for action packets. |
-| `reuse_stale_frames` | bool | `false` | Reuse a track's most recent frame when the current state has no in-range match. |
+| `on_stall` | string | `drop` | What to do with a moment a silent track cannot cover: `drop`, `freeze`, or `omit`. Overridable per video entry. |
+| `max_lag_ms` | int | `slack / fps` | How far the stream clock may run past a moment before it resolves without a silent track, in sender-clock ms. Overridable per video entry. |
+| `reuse_stale_frames` | bool | `false` | Deprecated. Alias for `on_stall: freeze` with `max_lag_ms: 0`. |
 | `ping_ms` | int | `1000` | RTT probe cadence in ms. `0` disables probing on this side. The echo path stays active. |
 | `action_subscription` | bool | `false` | Operator-side opt-in for receiving executed actions. No-op on the robot. |
 | `videos` | list | `[]` | Declared video tracks. |
@@ -171,6 +174,8 @@ videos:
 | `codec` | string | **Required.** One of `h264`, `vp8`, `vp9`, `av1`, `h265`, `mjpeg`, `png`, `raw`. Case-insensitive, and `hevc` is an alias for `h265`. |
 | `quality` | int | Optional. `1` to `100`, for `mjpeg` only. Defaults to `90`. Ignored for every other codec. |
 | `max_bitrate_kbps` | int | Optional. Encoder bitrate ceiling for the WebRTC codecs. Defaults to `10000`. Rejected on the byte-stream codecs. |
+| `on_stall` | string | Optional. Per-track override of the top-level `on_stall`. |
+| `max_lag_ms` | int | Optional. Per-track override of the top-level `max_lag_ms`. |
 | `simulcast` | bool | Optional. Publish several spatial layers. Defaults to `false`. Rejected on the byte-stream codecs. |
 | `screencast` | bool | Optional. Pin the resolution and drop frames under pressure instead of rescaling. Defaults to `false`. Rejected on the byte-stream codecs. |
 
@@ -295,7 +300,9 @@ The loader produces the same config you would build by hand.
 | `tolerance` | `cfg.set_tolerance(...)` |
 | `state_reliable` | `cfg.set_state_reliable(...)` |
 | `action_reliable` | `cfg.set_action_reliable(...)` |
-| `reuse_stale_frames` | `cfg.set_reuse_stale_frames(...)` |
+| `on_stall` | `cfg.set_on_stall(...)` / `cfg.set_track_on_stall(...)` |
+| `max_lag_ms` | `cfg.set_max_lag_ms(...)` / `cfg.set_track_max_lag_ms(...)` |
+| `reuse_stale_frames` | `cfg.set_reuse_stale_frames(...)` (deprecated) |
 | `ping_ms` | `cfg.set_ping_ms(...)` |
 | `action_subscription` | `cfg.set_action_subscription(...)` |
 | `videos[]` | `cfg.add_video(name, codec, quality, max_bitrate_kbps, simulcast=..., screencast=...)` |

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -97,7 +97,7 @@ state_reliable: true
 action_reliable: true
 
 # Stalled-track handling. Both override per video track.
-on_stall: drop               # drop | freeze | omit
+stall_behavior: drop               # drop | freeze | omit
 max_lag_ms: 166              # wait this long first; default is slack / fps
 
 # Heartbeat
@@ -143,9 +143,9 @@ action_chunks:
 | `tolerance` | float | `1.5` | Match window, in ticks. See [Tuning](../04-tuning.md). |
 | `state_reliable` | bool | `true` | Reliable transport for state packets. |
 | `action_reliable` | bool | `true` | Reliable transport for action packets. |
-| `on_stall` | string | `drop` | What to do with a moment a silent track cannot cover: `drop`, `freeze`, or `omit`. Overridable per video entry. |
+| `stall_behavior` | string | `drop` | What to do with a moment a silent track cannot cover: `drop`, `freeze`, or `omit`. Overridable per video entry. |
 | `max_lag_ms` | int | `slack / fps` | How far the stream clock may run past a moment before it resolves without a silent track, in sender-clock ms. Overridable per video entry. |
-| `reuse_stale_frames` | bool | `false` | Deprecated. Alias for `on_stall: freeze` with `max_lag_ms: 0`. |
+| `reuse_stale_frames` | bool | `false` | Deprecated. Alias for `stall_behavior: freeze` with `max_lag_ms: 0`. |
 | `ping_ms` | int | `1000` | RTT probe cadence in ms. `0` disables probing on this side. The echo path stays active. |
 | `action_subscription` | bool | `false` | Operator-side opt-in for receiving executed actions. No-op on the robot. |
 | `videos` | list | `[]` | Declared video tracks. |
@@ -174,7 +174,7 @@ videos:
 | `codec` | string | **Required.** One of `h264`, `vp8`, `vp9`, `av1`, `h265`, `mjpeg`, `png`, `raw`. Case-insensitive, and `hevc` is an alias for `h265`. |
 | `quality` | int | Optional. `1` to `100`, for `mjpeg` only. Defaults to `90`. Ignored for every other codec. |
 | `max_bitrate_kbps` | int | Optional. Encoder bitrate ceiling for the WebRTC codecs. Defaults to `10000`. Rejected on the byte-stream codecs. |
-| `on_stall` | string | Optional. Per-track override of the top-level `on_stall`. |
+| `stall_behavior` | string | Optional. Per-track override of the top-level `stall_behavior`. |
 | `max_lag_ms` | int | Optional. Per-track override of the top-level `max_lag_ms`. |
 | `simulcast` | bool | Optional. Publish several spatial layers. Defaults to `false`. Rejected on the byte-stream codecs. |
 | `screencast` | bool | Optional. Pin the resolution and drop frames under pressure instead of rescaling. Defaults to `false`. Rejected on the byte-stream codecs. |
@@ -300,7 +300,7 @@ The loader produces the same config you would build by hand.
 | `tolerance` | `cfg.set_tolerance(...)` |
 | `state_reliable` | `cfg.set_state_reliable(...)` |
 | `action_reliable` | `cfg.set_action_reliable(...)` |
-| `on_stall` | `cfg.set_on_stall(...)` / `cfg.set_track_on_stall(...)` |
+| `stall_behavior` | `cfg.set_stall_behavior(...)` / `cfg.set_track_stall_behavior(...)` |
 | `max_lag_ms` | `cfg.set_max_lag_ms(...)` / `cfg.set_track_max_lag_ms(...)` |
 | `reuse_stale_frames` | `cfg.set_reuse_stale_frames(...)` (deprecated) |
 | `ping_ms` | `cfg.set_ping_ms(...)` |

--- a/docs/reference/lerobot.md
+++ b/docs/reference/lerobot.md
@@ -252,7 +252,7 @@ Shared by both plugin configs:
 | `tolerance` | `None` | Passed to `set_tolerance(...)`. `1.5` widens to one frame either side, `0.5` drops on loss. |
 | `state_reliable` | `True` | Reliable delivery for state. |
 | `action_reliable` | `True` | Reliable delivery for actions. |
-| `reuse_stale_frames` | `False` | Re-emit the last matched frame instead of dropping the state. |
+| `on_stall` | `DROP` | What to do with a moment a silent camera cannot cover. `FREEZE` re-emits its last matched frame instead of dropping the state. |
 
 Operator-only, on `LiveKitRobotConfig`:
 

--- a/docs/reference/lerobot.md
+++ b/docs/reference/lerobot.md
@@ -252,7 +252,7 @@ Shared by both plugin configs:
 | `tolerance` | `None` | Passed to `set_tolerance(...)`. `1.5` widens to one frame either side, `0.5` drops on loss. |
 | `state_reliable` | `True` | Reliable delivery for state. |
 | `action_reliable` | `True` | Reliable delivery for actions. |
-| `on_stall` | `DROP` | What to do with a moment a silent camera cannot cover. `FREEZE` re-emits its last matched frame instead of dropping the state. |
+| `stall_behavior` | `DROP` | What to do with a moment a silent camera cannot cover. `FREEZE` re-emits its last matched frame instead of dropping the state. |
 
 Operator-only, on `LiveKitRobotConfig`:
 

--- a/docs/reference/synchronization.md
+++ b/docs/reference/synchronization.md
@@ -239,9 +239,9 @@ The test covering it is `fair_share_prevents_stealing` in `sync_buffer.rs`.
 
 ### Optional: stale-frame reuse
 
-Enabling `reuse_stale_frames` turns the drop outcome into a **reuse** outcome,
-once a track has emitted at least once. Video freezes on a recent frame while
-state keeps flowing.
+`on_stall: freeze` turns the drop outcome into a **reuse** outcome, once a track
+has emitted at least once. Video freezes on a recent frame while state keeps
+flowing.
 
 There are two distinct fallbacks, and Portal prefers the first.
 
@@ -304,15 +304,29 @@ loop:
             matched[track_i] = best
             continue
 
-        if reuse_stale_frames:
+        # Waiting cannot help once the newest buffered frame is past the
+        # horizon; otherwise wait until the stream clock passes max_lag.
+        unmatchable = buf and buf.back().ts >= S + R
+        lagged = logical_now() - S >= max_lag[track_i]
+        if not unmatchable and not lagged:
+            iter_blocker ??= track_i
+            continue
+
+        if on_stall[track_i] == freeze:
             if cursor frame is <= S and out of range:
-                matched[track_i] = (cursor, stale)      # drains
+                matched[track_i] = (cursor, Stale)       # drains
                 continue
             if last_emitted[track_i]:
-                matched[track_i] = (last_emitted, stale) # no drain
+                matched[track_i] = (last_emitted, Stale) # no drain
+                continue
+        elif on_stall[track_i] == omit:
+            if last_emitted[track_i]:                    # geometry source
+                matched[track_i] = (placeholder, Omitted)
                 continue
 
-        if buf.empty():
+        # freeze/omit reach here only before the track's first frame, with
+        # nothing to substitute. Keep waiting if a frame could still match.
+        if not unmatchable and on_stall[track_i] != drop:
             iter_blocker ??= track_i
             continue
 
@@ -382,20 +396,77 @@ in `[S - R, S + R]`, or dropped once any track's newest frame passes `S + R`.
 **Memory.** Bounded by `video_buffer_size × tracks + state_buffer_size`, plus one
 latest-wins observation slot and one last-emitted frame per track.
 
-## Design choices not made
+## Stalled tracks
 
-**No deadline-based drop.** A state waits indefinitely while an older frame sits
-in the buffer, because a newer matching frame could still arrive. If the track
-stalls permanently, the state blocks the head until capacity-driven eviction
-resolves it. A wall-clock deadline would be more aggressive. It is not
-implemented, because eviction plus the drop rule already covers the failure modes
-and a deadline would add a time-source dependency.
+A track that stops sending would otherwise strand the head state. Two per-track
+knobs decide what happens: `max_lag` is how long to wait, `on_stall` is what to
+do when the wait is over.
+
+**`max_lag`** is measured against the *stream clock* — the largest sender
+timestamp buffered across every stream, states and all video tracks. It advances
+whenever any stream is still flowing, which is how a silent track is detected
+through the clocks of the tracks that are not silent. It defaults to
+`slack / fps`, the point at which state-buffer capacity would have evicted the
+moment anyway, so the default timing matches earlier versions.
+
+The one case that genuinely changes: capacity eviction only runs on `push_state`,
+so if state output also paused, the head previously waited forever. It now
+resolves as soon as any other stream advances past the budget.
+
+**`on_stall`** picks the outcome. All three are terminal.
+
+| | result | frame tagged |
+|---|---|---|
+| `drop` | No observation. The state still reaches the drop callback, but the healthy tracks in that moment are discarded with it. | — |
+| `freeze` | That track's last good frame. Video freezes while state keeps flowing. | `Stale` |
+| `omit` | A synthesized placeholder — magenta diagonals with the track name — so the healthy tracks stay visible. | `Omitted` |
+
+`omit` does **not** remove the map key. `frames[name]` is still present for every
+declared track, which is why enabling it cannot start raising `KeyError` in code
+that was written before it existed.
+
+Before a track's first frame, `freeze` has nothing to reuse and `omit` has no
+geometry to synthesize from, so both wait through that startup window and then
+fall back to `drop`.
+
+**Tell the three apart at the frame.** Every frame in an observation carries a
+`FrameSource` of `Live`, `Stale`, or `Omitted`. Only `Live` is a measurement of
+the observation's timestamp; the other two are substitutes attached to it. Check
+it before feeding an observation to a policy or writing it to a dataset. `Stale`
+and `Omitted` frames keep the *real* frame's timestamp, so the true age is
+`observation.timestamp_us - frame.timestamp_us`.
+
+Per-track policies are the point: a wrist camera a policy depends on may warrant
+`drop`, since no observation beats a confidently wrong one, while a scene camera
+warrants `omit` so its failure does not take the rest of the frame set down with
+it.
+
+```yaml
+on_stall: omit          # default for every track
+max_lag_ms: 150
+videos:
+  - { name: wrist, codec: h264, on_stall: drop, max_lag_ms: 40 }
+  - { name: scene, codec: h264 }
+```
+
+`reuse_stale_frames` is retained as a deprecated alias for `on_stall: freeze`
+with `max_lag_ms: 0`.
+
+## Design choices not made
 
 **No interpolation.** For each head state, Portal picks the nearest frame per
 track rather than interpolating between the two frames that bracket it. Nearest
 neighbour is cheaper and matches what most policies expect. Interpolation, or its
-mirror of interpolating state to a frame timestamp, would be a separate opt-in
-mode.
+mirror of interpolating state to a frame timestamp, would be a further
+`on_stall` variant rather than a separate knob.
+
+**No wall clock.** `max_lag` is measured in sender-clock time, never wall-clock,
+so a given packet sequence always produces the same sync decisions regardless of
+machine or scheduling. The consequence is that it is not a watchdog: it is
+evaluated when a packet arrives, so a burst of buffered frames can cross the
+budget in far less real time than the number suggests, and if *every* stream goes
+silent nothing resolves at all. That last case is harmless — with no stream
+advancing there is nothing to emit either.
 
 **No coalescing of state callbacks.** Every state packet fires `on_state` even if
 the consumer cannot keep up. The observation path is where synced and paced data
@@ -415,7 +486,8 @@ user-facing knobs.
 | `video_buffer_size` | `slack` | 5 | Frames buffered per track. Larger tolerates more jitter and longer stalls, at the cost of staleness. |
 | `state_buffer_size` | `slack` | 5 | States buffered awaiting a match. Larger tolerates longer video stalls before eviction. |
 | `search_range_us` | `tolerance / fps` | 50 000 | Match window half-width. Wider means fewer drops under jitter and looser alignment. |
-| `reuse_stale_frames` | `reuse_stale_frames` | `false` | Whether the drop outcome becomes a reuse outcome. |
+| `default_stall.max_lag_us` | `slack / fps` | 166 666 | How far the stream clock may run past a moment before it resolves without a silent track. |
+| `default_stall.policy` | `on_stall` | `drop` | How that moment resolves: `drop`, `freeze`, or `omit`. |
 
 Keep `tolerance` at 1 or above so the window covers at least one inter-frame
 interval. Tighter than that and ordinary jitter starts producing drops.

--- a/docs/reference/synchronization.md
+++ b/docs/reference/synchronization.md
@@ -402,6 +402,11 @@ A track that stops sending would otherwise strand the head state. Two per-track
 knobs decide what happens: `max_lag` is how long to wait, `on_stall` is what to
 do when the wait is over.
 
+Both are read by the receiving side, since `SyncBuffer` lives there (it is built
+in `setup_operator` and fed from the receive paths). Nothing about a stall is
+transmitted: a silent track is sending nothing by definition, so `omit`
+synthesizes its stand-in locally rather than moving pixels over the wire.
+
 **`max_lag`** is measured against the *stream clock* — the largest sender
 timestamp buffered across every stream, states and all video tracks. It advances
 whenever any stream is still flowing, which is how a silent track is detected

--- a/docs/reference/synchronization.md
+++ b/docs/reference/synchronization.md
@@ -239,7 +239,7 @@ The test covering it is `fair_share_prevents_stealing` in `sync_buffer.rs`.
 
 ### Optional: stale-frame reuse
 
-`on_stall: freeze` turns the drop outcome into a **reuse** outcome, once a track
+`stall_behavior: freeze` turns the drop outcome into a **reuse** outcome, once a track
 has emitted at least once. Video freezes on a recent frame while state keeps
 flowing.
 
@@ -312,21 +312,21 @@ loop:
             iter_blocker ??= track_i
             continue
 
-        if on_stall[track_i] == freeze:
+        if stall_behavior[track_i] == freeze:
             if cursor frame is <= S and out of range:
                 matched[track_i] = (cursor, Stale)       # drains
                 continue
             if last_emitted[track_i]:
                 matched[track_i] = (last_emitted, Stale) # no drain
                 continue
-        elif on_stall[track_i] == omit:
+        elif stall_behavior[track_i] == omit:
             if last_emitted[track_i]:                    # geometry source
                 matched[track_i] = (placeholder, Omitted)
                 continue
 
         # freeze/omit reach here only before the track's first frame, with
         # nothing to substitute. Keep waiting if a frame could still match.
-        if not unmatchable and on_stall[track_i] != drop:
+        if not unmatchable and stall_behavior[track_i] != drop:
             iter_blocker ??= track_i
             continue
 
@@ -399,7 +399,7 @@ latest-wins observation slot and one last-emitted frame per track.
 ## Stalled tracks
 
 A track that stops sending would otherwise strand the head state. Two per-track
-knobs decide what happens: `max_lag` is how long to wait, `on_stall` is what to
+knobs decide what happens: `max_lag` is how long to wait, `stall_behavior` is what to
 do when the wait is over.
 
 Both are read by the receiving side, since `SyncBuffer` lives there (it is built
@@ -418,7 +418,7 @@ The one case that genuinely changes: capacity eviction only runs on `push_state`
 so if state output also paused, the head previously waited forever. It now
 resolves as soon as any other stream advances past the budget.
 
-**`on_stall`** picks the outcome. All three are terminal.
+**`stall_behavior`** picks the outcome. All three are terminal.
 
 | | result | frame tagged |
 |---|---|---|
@@ -447,14 +447,14 @@ warrants `omit` so its failure does not take the rest of the frame set down with
 it.
 
 ```yaml
-on_stall: omit          # default for every track
+stall_behavior: omit          # default for every track
 max_lag_ms: 150
 videos:
-  - { name: wrist, codec: h264, on_stall: drop, max_lag_ms: 40 }
+  - { name: wrist, codec: h264, stall_behavior: drop, max_lag_ms: 40 }
   - { name: scene, codec: h264 }
 ```
 
-`reuse_stale_frames` is retained as a deprecated alias for `on_stall: freeze`
+`reuse_stale_frames` is retained as a deprecated alias for `stall_behavior: freeze`
 with `max_lag_ms: 0`.
 
 ## Design choices not made
@@ -463,7 +463,7 @@ with `max_lag_ms: 0`.
 track rather than interpolating between the two frames that bracket it. Nearest
 neighbour is cheaper and matches what most policies expect. Interpolation, or its
 mirror of interpolating state to a frame timestamp, would be a further
-`on_stall` variant rather than a separate knob.
+`stall_behavior` variant rather than a separate knob.
 
 **No wall clock.** `max_lag` is measured in sender-clock time, never wall-clock,
 so a given packet sequence always produces the same sync decisions regardless of
@@ -492,7 +492,7 @@ user-facing knobs.
 | `state_buffer_size` | `slack` | 5 | States buffered awaiting a match. Larger tolerates longer video stalls before eviction. |
 | `search_range_us` | `tolerance / fps` | 50 000 | Match window half-width. Wider means fewer drops under jitter and looser alignment. |
 | `default_stall.max_lag_us` | `slack / fps` | 166 666 | How far the stream clock may run past a moment before it resolves without a silent track. |
-| `default_stall.policy` | `on_stall` | `drop` | How that moment resolves: `drop`, `freeze`, or `omit`. |
+| `default_stall.behavior` | `stall_behavior` | `drop` | How that moment resolves: `drop`, `freeze`, or `omit`. |
 
 Keep `tolerance` at 1 or above so the window covers at least one inter-frame
 interval. Tighter than that and ordinary jitter starts producing drops.

--- a/docs/reference/synchronization.md
+++ b/docs/reference/synchronization.md
@@ -462,8 +462,8 @@ with `max_lag_ms: 0`.
 **No interpolation.** For each head state, Portal picks the nearest frame per
 track rather than interpolating between the two frames that bracket it. Nearest
 neighbour is cheaper and matches what most policies expect. Interpolation, or its
-mirror of interpolating state to a frame timestamp, would be a further
-`stall_behavior` variant rather than a separate knob.
+mirror of interpolating state to a frame timestamp, would be a separate opt-in
+mode.
 
 **No wall clock.** `max_lag` is measured in sender-clock time, never wall-clock,
 so a given packet sequence always produces the same sync decisions regardless of

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -245,6 +245,70 @@ fn chunk_columns_to_core(data: HashMap<String, ChunkColumn>) -> HashMap<String, 
         .collect()
 }
 
+/// Where the pixels in a delivered frame came from. Mirrors
+/// `livekit_portal::FrameSource`.
+///
+/// Frames delivered on the raw video callbacks are always `Live`. The other
+/// variants appear only on frames inside an `Observation`, when the sync
+/// buffer had to resolve a track that went silent past its `max_lag`.
+/// Check it before feeding an observation to a policy or a dataset — `Stale`
+/// and `Omitted` frames are not measurements of the moment they hang off.
+///
+/// **Foreign binding casing**: UniFFI emits enum variants in the host
+/// language's idiomatic case. Python code uses `FrameSource.LIVE` /
+/// `FrameSource.STALE` / `FrameSource.OMITTED` (UPPER), not the Rust
+/// spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum FrameSource {
+    /// A real frame matched to this state within the tolerance window.
+    Live,
+    /// A real frame from an earlier moment, reused because nothing in range
+    /// arrived (`on_stall: freeze`). Age is
+    /// `observation.timestamp_us - frame.timestamp_us`.
+    Stale,
+    /// A synthesized placeholder standing in for a silent track
+    /// (`on_stall: omit`). Not camera output.
+    Omitted,
+}
+
+impl From<core::FrameSource> for FrameSource {
+    fn from(s: core::FrameSource) -> Self {
+        match s {
+            core::FrameSource::Live => FrameSource::Live,
+            core::FrameSource::Stale => FrameSource::Stale,
+            core::FrameSource::Omitted => FrameSource::Omitted,
+        }
+    }
+}
+
+/// How a moment is resolved when a video track goes silent past its
+/// `max_lag`. Mirrors `livekit_portal::StallPolicy`.
+///
+/// **Foreign binding casing**: UniFFI emits enum variants in the host
+/// language's idiomatic case. Python code uses `StallPolicy.DROP` /
+/// `StallPolicy.FREEZE` / `StallPolicy.OMIT` (UPPER).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum StallPolicy {
+    /// Emit no observation. The state still reaches the drop callback, but
+    /// the healthy tracks in that moment are discarded with it.
+    Drop,
+    /// Emit with the track's last good frame, tagged `FrameSource.STALE`.
+    Freeze,
+    /// Emit with a visible placeholder for the silent track, tagged
+    /// `FrameSource.OMITTED`. The map key is still present.
+    Omit,
+}
+
+impl From<StallPolicy> for core::StallPolicy {
+    fn from(p: StallPolicy) -> Self {
+        match p {
+            StallPolicy::Drop => core::StallPolicy::Drop,
+            StallPolicy::Freeze => core::StallPolicy::Freeze,
+            StallPolicy::Omit => core::StallPolicy::Omit,
+        }
+    }
+}
+
 /// Decoded video frame. `data` is packed RGB24 (R,G,B byte order, `W*H*3`
 /// bytes) on both sides — `send_video_frame` accepts RGB, and receive-side
 /// frames are color-converted from I420 (WebRTC) or codec-decoded (frame
@@ -255,6 +319,9 @@ pub struct VideoFrame {
     pub height: u32,
     pub data: Vec<u8>,
     pub timestamp_us: u64,
+    /// Whether these pixels are a live match, a reused earlier frame, or a
+    /// synthesized placeholder. Always `Live` outside of `Observation`.
+    pub source: FrameSource,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -671,8 +738,32 @@ impl PortalConfig {
         self.inner.lock().set_ping_ms(ms);
     }
 
+    #[allow(deprecated)]
     pub fn set_reuse_stale_frames(&self, enable: bool) {
         self.inner.lock().set_reuse_stale_frames(enable);
+    }
+
+    /// How a moment is resolved when a video track goes silent past its
+    /// `max_lag`. Applies to tracks without a per-track override.
+    pub fn set_on_stall(&self, policy: StallPolicy) {
+        self.inner.lock().set_on_stall(policy.into());
+    }
+
+    /// How far the fastest-advancing stream may run past a moment before it
+    /// resolves without a silent track, in milliseconds of sender-clock time
+    /// (not wall-clock). Defaults to `slack / fps`; `0` resolves immediately.
+    pub fn set_max_lag_ms(&self, ms: u32) {
+        self.inner.lock().set_max_lag_ms(ms);
+    }
+
+    /// Per-track override for `set_on_stall`.
+    pub fn set_track_on_stall(&self, track: String, policy: StallPolicy) {
+        self.inner.lock().set_track_on_stall(track, policy.into());
+    }
+
+    /// Per-track override for `set_max_lag_ms`.
+    pub fn set_track_max_lag_ms(&self, track: String, ms: u32) {
+        self.inner.lock().set_track_max_lag_ms(track, ms);
     }
 
     pub fn set_e2ee_key(&self, key: Vec<u8>) {
@@ -777,6 +868,7 @@ impl PortalConfig {
 
     /// Whether a state past its video match window reuses the last emitted
     /// frame instead of being dropped.
+    #[allow(deprecated)]
     pub fn reuse_stale_frames(&self) -> bool {
         self.inner.lock().reuse_stale_frames()
     }
@@ -1185,8 +1277,32 @@ impl RobotConfig {
         self.inner.set_e2ee_key(key);
     }
 
+    #[allow(deprecated)]
     pub fn set_reuse_stale_frames(&self, enable: bool) {
         self.inner.set_reuse_stale_frames(enable);
+    }
+
+    /// How a moment is resolved when a video track goes silent past its
+    /// `max_lag`. Applies to tracks without a per-track override.
+    pub fn set_on_stall(&self, policy: StallPolicy) {
+        self.inner.set_on_stall(policy);
+    }
+
+    /// How far the fastest-advancing stream may run past a moment before it
+    /// resolves without a silent track, in milliseconds of sender-clock time
+    /// (not wall-clock). Defaults to `slack / fps`; `0` resolves immediately.
+    pub fn set_max_lag_ms(&self, ms: u32) {
+        self.inner.set_max_lag_ms(ms);
+    }
+
+    /// Per-track override for `set_on_stall`.
+    pub fn set_track_on_stall(&self, track: String, policy: StallPolicy) {
+        self.inner.set_track_on_stall(track, policy);
+    }
+
+    /// Per-track override for `set_max_lag_ms`.
+    pub fn set_track_max_lag_ms(&self, track: String, ms: u32) {
+        self.inner.set_track_max_lag_ms(track, ms);
     }
 
     /// No-op on the Robot side — the robot always processes actions. Kept on
@@ -1247,6 +1363,7 @@ impl RobotConfig {
         self.inner.action_reliable()
     }
 
+    #[allow(deprecated)]
     pub fn reuse_stale_frames(&self) -> bool {
         self.inner.reuse_stale_frames()
     }
@@ -1338,8 +1455,32 @@ impl OperatorConfig {
         self.inner.set_e2ee_key(key);
     }
 
+    #[allow(deprecated)]
     pub fn set_reuse_stale_frames(&self, enable: bool) {
         self.inner.set_reuse_stale_frames(enable);
+    }
+
+    /// How a moment is resolved when a video track goes silent past its
+    /// `max_lag`. Applies to tracks without a per-track override.
+    pub fn set_on_stall(&self, policy: StallPolicy) {
+        self.inner.set_on_stall(policy);
+    }
+
+    /// How far the fastest-advancing stream may run past a moment before it
+    /// resolves without a silent track, in milliseconds of sender-clock time
+    /// (not wall-clock). Defaults to `slack / fps`; `0` resolves immediately.
+    pub fn set_max_lag_ms(&self, ms: u32) {
+        self.inner.set_max_lag_ms(ms);
+    }
+
+    /// Per-track override for `set_on_stall`.
+    pub fn set_track_on_stall(&self, track: String, policy: StallPolicy) {
+        self.inner.set_track_on_stall(track, policy);
+    }
+
+    /// Per-track override for `set_max_lag_ms`.
+    pub fn set_track_max_lag_ms(&self, track: String, ms: u32) {
+        self.inner.set_track_max_lag_ms(track, ms);
     }
 
     /// Operator-side opt-in to receiving executed actions ("HITL recording").
@@ -1401,6 +1542,7 @@ impl OperatorConfig {
         self.inner.action_reliable()
     }
 
+    #[allow(deprecated)]
     pub fn reuse_stale_frames(&self) -> bool {
         self.inner.reuse_stale_frames()
     }
@@ -1690,6 +1832,7 @@ fn frame_from_core(f: &core::VideoFrameData) -> VideoFrame {
         height: f.height,
         data: f.data.to_vec(),
         timestamp_us: f.timestamp_us,
+        source: f.source.into(),
     }
 }
 

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -371,6 +371,10 @@ pub struct SyncMetrics {
     pub observations_emitted: u64,
     pub stale_observations_emitted: u64,
     pub states_dropped: u64,
+    /// Per-track count of synthesized placeholder frames emitted under
+    /// `on_stall: omit` — that track is silent and its moments are being kept
+    /// alive with a stand-in. The frames carry `FrameSource.OMITTED`.
+    pub frames_omitted: HashMap<String, u64>,
     pub match_delta_us_p50: Option<u64>,
     pub match_delta_us_p95: Option<u64>,
     pub last_blocker_track: Option<String>,
@@ -1910,6 +1914,7 @@ fn metrics_from_core(m: core::PortalMetrics) -> PortalMetrics {
             observations_emitted: m.sync.observations_emitted,
             stale_observations_emitted: m.sync.stale_observations_emitted,
             states_dropped: m.sync.states_dropped,
+            frames_omitted: m.sync.frames_omitted.clone(),
             match_delta_us_p50: m.sync.match_delta_us_p50,
             match_delta_us_p95: m.sync.match_delta_us_p95,
             last_blocker_track: m.sync.last_blocker_track,

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -263,11 +263,11 @@ pub enum FrameSource {
     /// A real frame matched to this state within the tolerance window.
     Live,
     /// A real frame from an earlier moment, reused because nothing in range
-    /// arrived (`on_stall: freeze`). Age is
+    /// arrived (`stall_behavior: freeze`). Age is
     /// `observation.timestamp_us - frame.timestamp_us`.
     Stale,
     /// A synthesized placeholder standing in for a silent track
-    /// (`on_stall: omit`). Not camera output.
+    /// (`stall_behavior: omit`). Not camera output.
     Omitted,
 }
 
@@ -282,13 +282,13 @@ impl From<core::FrameSource> for FrameSource {
 }
 
 /// How a moment is resolved when a video track goes silent past its
-/// `max_lag`. Mirrors `livekit_portal::StallPolicy`.
+/// `max_lag`. Mirrors `livekit_portal::StallBehavior`.
 ///
 /// **Foreign binding casing**: UniFFI emits enum variants in the host
-/// language's idiomatic case. Python code uses `StallPolicy.DROP` /
-/// `StallPolicy.FREEZE` / `StallPolicy.OMIT` (UPPER).
+/// language's idiomatic case. Python code uses `StallBehavior.DROP` /
+/// `StallBehavior.FREEZE` / `StallBehavior.OMIT` (UPPER).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
-pub enum StallPolicy {
+pub enum StallBehavior {
     /// Emit no observation. The state still reaches the drop callback, but
     /// the healthy tracks in that moment are discarded with it.
     Drop,
@@ -299,12 +299,12 @@ pub enum StallPolicy {
     Omit,
 }
 
-impl From<StallPolicy> for core::StallPolicy {
-    fn from(p: StallPolicy) -> Self {
+impl From<StallBehavior> for core::StallBehavior {
+    fn from(p: StallBehavior) -> Self {
         match p {
-            StallPolicy::Drop => core::StallPolicy::Drop,
-            StallPolicy::Freeze => core::StallPolicy::Freeze,
-            StallPolicy::Omit => core::StallPolicy::Omit,
+            StallBehavior::Drop => core::StallBehavior::Drop,
+            StallBehavior::Freeze => core::StallBehavior::Freeze,
+            StallBehavior::Omit => core::StallBehavior::Omit,
         }
     }
 }
@@ -372,7 +372,7 @@ pub struct SyncMetrics {
     pub stale_observations_emitted: u64,
     pub states_dropped: u64,
     /// Per-track count of synthesized placeholder frames emitted under
-    /// `on_stall: omit` — that track is silent and its moments are being kept
+    /// `stall_behavior: omit` — that track is silent and its moments are being kept
     /// alive with a stand-in. The frames carry `FrameSource.OMITTED`.
     pub frames_omitted: HashMap<String, u64>,
     pub match_delta_us_p50: Option<u64>,
@@ -680,6 +680,12 @@ impl PortalConfig {
     /// source as screen content, which pins the resolution and drops frames
     /// under CPU or bandwidth pressure instead of rescaling the frame. Both
     /// apply to the WebRTC codecs only and default to `false`.
+    /// `stall_behavior` and `max_lag_ms` are per-track overrides of
+    /// [`set_stall_behavior`] / [`set_max_lag_ms`], applied at the declaration
+    /// site so a track's whole configuration reads in one place. `None` on
+    /// either inherits the config-wide default. Both are read on the receiving
+    /// side; see `set_stall_behavior`.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_video(
         &self,
         name: String,
@@ -688,15 +694,17 @@ impl PortalConfig {
         max_bitrate_kbps: Option<u32>,
         simulcast: Option<bool>,
         screencast: Option<bool>,
+        stall_behavior: Option<StallBehavior>,
+        max_lag_ms: Option<u32>,
     ) {
-        self.inner.lock().add_video(
-            name,
-            codec.into(),
-            quality,
-            max_bitrate_kbps,
-            simulcast,
-            screencast,
-        );
+        let mut cfg = self.inner.lock();
+        cfg.add_video(name.clone(), codec.into(), quality, max_bitrate_kbps, simulcast, screencast);
+        if let Some(b) = stall_behavior {
+            cfg.set_track_stall_behavior(name.clone(), b.into());
+        }
+        if let Some(ms) = max_lag_ms {
+            cfg.set_track_max_lag_ms(name, ms);
+        }
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {
@@ -749,8 +757,8 @@ impl PortalConfig {
 
     /// How a moment is resolved when a video track goes silent past its
     /// `max_lag`. Applies to tracks without a per-track override.
-    pub fn set_on_stall(&self, policy: StallPolicy) {
-        self.inner.lock().set_on_stall(policy.into());
+    pub fn set_stall_behavior(&self, behavior: StallBehavior) {
+        self.inner.lock().set_stall_behavior(behavior.into());
     }
 
     /// How far the fastest-advancing stream may run past a moment before it
@@ -760,9 +768,9 @@ impl PortalConfig {
         self.inner.lock().set_max_lag_ms(ms);
     }
 
-    /// Per-track override for `set_on_stall`.
-    pub fn set_track_on_stall(&self, track: String, policy: StallPolicy) {
-        self.inner.lock().set_track_on_stall(track, policy.into());
+    /// Per-track override for `set_stall_behavior`.
+    pub fn set_track_stall_behavior(&self, track: String, behavior: StallBehavior) {
+        self.inner.lock().set_track_stall_behavior(track, behavior.into());
     }
 
     /// Per-track override for `set_max_lag_ms`.
@@ -1229,6 +1237,7 @@ impl RobotConfig {
         Ok(Arc::new(Self { inner: PortalConfig::from_yaml_str(yaml, session, Role::Robot)? }))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_video(
         &self,
         name: String,
@@ -1237,8 +1246,19 @@ impl RobotConfig {
         max_bitrate_kbps: Option<u32>,
         simulcast: Option<bool>,
         screencast: Option<bool>,
+        stall_behavior: Option<StallBehavior>,
+        max_lag_ms: Option<u32>,
     ) {
-        self.inner.add_video(name, codec, quality, max_bitrate_kbps, simulcast, screencast);
+        self.inner.add_video(
+            name,
+            codec,
+            quality,
+            max_bitrate_kbps,
+            simulcast,
+            screencast,
+            stall_behavior,
+            max_lag_ms,
+        );
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {
@@ -1288,8 +1308,8 @@ impl RobotConfig {
 
     /// How a moment is resolved when a video track goes silent past its
     /// `max_lag`. Applies to tracks without a per-track override.
-    pub fn set_on_stall(&self, policy: StallPolicy) {
-        self.inner.set_on_stall(policy);
+    pub fn set_stall_behavior(&self, behavior: StallBehavior) {
+        self.inner.set_stall_behavior(behavior);
     }
 
     /// How far the fastest-advancing stream may run past a moment before it
@@ -1299,9 +1319,9 @@ impl RobotConfig {
         self.inner.set_max_lag_ms(ms);
     }
 
-    /// Per-track override for `set_on_stall`.
-    pub fn set_track_on_stall(&self, track: String, policy: StallPolicy) {
-        self.inner.set_track_on_stall(track, policy);
+    /// Per-track override for `set_stall_behavior`.
+    pub fn set_track_stall_behavior(&self, track: String, behavior: StallBehavior) {
+        self.inner.set_track_stall_behavior(track, behavior);
     }
 
     /// Per-track override for `set_max_lag_ms`.
@@ -1407,6 +1427,7 @@ impl OperatorConfig {
         Ok(Arc::new(Self { inner: PortalConfig::from_yaml_str(yaml, session, Role::Operator)? }))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_video(
         &self,
         name: String,
@@ -1415,8 +1436,19 @@ impl OperatorConfig {
         max_bitrate_kbps: Option<u32>,
         simulcast: Option<bool>,
         screencast: Option<bool>,
+        stall_behavior: Option<StallBehavior>,
+        max_lag_ms: Option<u32>,
     ) {
-        self.inner.add_video(name, codec, quality, max_bitrate_kbps, simulcast, screencast);
+        self.inner.add_video(
+            name,
+            codec,
+            quality,
+            max_bitrate_kbps,
+            simulcast,
+            screencast,
+            stall_behavior,
+            max_lag_ms,
+        );
     }
 
     pub fn add_state_typed(&self, schema: Vec<FieldSpec>) {
@@ -1466,8 +1498,8 @@ impl OperatorConfig {
 
     /// How a moment is resolved when a video track goes silent past its
     /// `max_lag`. Applies to tracks without a per-track override.
-    pub fn set_on_stall(&self, policy: StallPolicy) {
-        self.inner.set_on_stall(policy);
+    pub fn set_stall_behavior(&self, behavior: StallBehavior) {
+        self.inner.set_stall_behavior(behavior);
     }
 
     /// How far the fastest-advancing stream may run past a moment before it
@@ -1477,9 +1509,9 @@ impl OperatorConfig {
         self.inner.set_max_lag_ms(ms);
     }
 
-    /// Per-track override for `set_on_stall`.
-    pub fn set_track_on_stall(&self, track: String, policy: StallPolicy) {
-        self.inner.set_track_on_stall(track, policy);
+    /// Per-track override for `set_stall_behavior`.
+    pub fn set_track_stall_behavior(&self, track: String, behavior: StallBehavior) {
+        self.inner.set_track_stall_behavior(track, behavior);
     }
 
     /// Per-track override for `set_max_lag_ms`.

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -516,21 +516,37 @@ impl PortalConfig {
     /// Effective stall config for one track, after applying per-track
     /// overrides and the `reuse_stale_frames` alias over the defaults.
     pub fn stall_for(&self, track: &str) -> StallConfig {
-        let policy = self.track_on_stall.get(track).copied().unwrap_or_else(|| {
-            // The deprecated alias only takes effect when the modern knob is
-            // left at its default, so an explicit `set_on_stall` always wins.
-            if self.reuse_stale_frames && self.on_stall == StallPolicy::Drop {
-                StallPolicy::Freeze
-            } else {
-                self.on_stall
-            }
-        });
+        let base = self.default_stall();
+        StallConfig {
+            policy: self.track_on_stall.get(track).copied().unwrap_or(base.policy),
+            max_lag_us: self
+                .track_max_lag_ms
+                .get(track)
+                .map(|ms| Some(*ms as u64 * 1_000))
+                .unwrap_or(base.max_lag_us),
+        }
+    }
 
-        let max_lag_us = match self.track_max_lag_ms.get(track).copied().or(self.max_lag_ms) {
+    /// Stall config for a track with no override, after folding in the
+    /// deprecated `reuse_stale_frames` alias. Kept separate from
+    /// [`stall_for`](Self::stall_for) so the fallback never has to be spelled
+    /// as a lookup for a track name that cannot exist.
+    fn default_stall(&self) -> StallConfig {
+        // The alias only applies while the modern knob sits at its default,
+        // so an explicit `set_on_stall` always wins — a caller migrating one
+        // setting at a time is never silently overridden by a leftover.
+        let policy = if self.reuse_stale_frames && self.on_stall == StallPolicy::Drop {
+            StallPolicy::Freeze
+        } else {
+            self.on_stall
+        };
+
+        let max_lag_us = match self.max_lag_ms {
             Some(ms) => ms as u64 * 1_000,
-            // `reuse_stale_frames` resolved immediately, with no wait.
-            None if self.reuse_stale_frames && self.max_lag_ms.is_none() => 0,
-            // Default: the point capacity eviction would have reached anyway.
+            // `reuse_stale_frames` substituted immediately, with no wait.
+            None if self.reuse_stale_frames => 0,
+            // Otherwise: the point capacity eviction would have reached anyway,
+            // so the default timing matches earlier versions.
             None => self.slack as u64 * 1_000_000 / self.fps.max(1) as u64,
         };
 
@@ -651,7 +667,7 @@ impl PortalConfig {
             video_buffer_size: self.slack,
             state_buffer_size: self.slack,
             search_range_us,
-            default_stall: self.stall_for(""),
+            default_stall: self.default_stall(),
         }
     }
 }
@@ -740,6 +756,19 @@ mod tests {
         let other = c.stall_for("other");
         assert_eq!(other.policy, StallPolicy::Drop);
         assert_eq!(other.max_lag_us, Some(100_000));
+    }
+
+    /// A track literally named "" must resolve like any other track, not
+    /// collide with the fallback. Guards the empty-string lookup the earlier
+    /// implementation used to express "no override".
+    #[test]
+    fn empty_track_name_is_not_the_fallback() {
+        let mut c = cfg();
+        c.set_on_stall(StallPolicy::Drop);
+        c.set_track_on_stall("", StallPolicy::Omit);
+        assert_eq!(c.stall_for("").policy, StallPolicy::Omit);
+        assert_eq!(c.stall_for("cam1").policy, StallPolicy::Drop, "fallback unaffected");
+        assert_eq!(c.sync_config().default_stall.policy, StallPolicy::Drop);
     }
 
     /// `stall_configs` resolves in the order the sync buffer indexes tracks,

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -468,6 +468,12 @@ impl PortalConfig {
     /// `max_lag`. Applies to every track without a per-track override; see
     /// [`set_track_on_stall`](Self::set_track_on_stall).
     ///
+    /// **Receiving side only.** Observations are assembled where they are
+    /// consumed, so this is read on the `Operator` and is a no-op on a
+    /// `Robot` config. Nothing about a stall crosses the wire: a silent track
+    /// is, by definition, sending nothing, so the substitute frame is
+    /// synthesized locally by the subscriber that noticed the gap.
+    ///
     /// [`Drop`](StallPolicy::Drop) (the default) emits nothing for that
     /// moment — the state still reaches the drop callback, but the healthy
     /// tracks in it are discarded too, so an operator screen goes dark while
@@ -495,6 +501,8 @@ impl PortalConfig {
     /// Defaults to `slack / fps` — the point at which state-buffer capacity
     /// would have evicted the moment anyway — so the default timing matches
     /// the historical behavior. `0` resolves immediately, without waiting.
+    ///
+    /// **Receiving side only**, like [`set_on_stall`](Self::set_on_stall).
     pub fn set_max_lag_ms(&mut self, ms: u32) {
         self.max_lag_ms = Some(ms);
     }

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -14,7 +14,7 @@
 
 use crate::codec::Codec;
 use crate::dtype::DType;
-use crate::types::{Role, StallConfig, StallPolicy, SyncConfig};
+use crate::types::{Role, StallBehavior, StallConfig, SyncConfig};
 use std::collections::HashMap;
 
 /// Default JPEG quality for `add_video` when MJPEG is selected without an
@@ -168,16 +168,16 @@ pub struct PortalConfig {
     pub(crate) tolerance: f32,
     pub(crate) ping_ms: u64,
     /// Deprecated alias, retained so existing callers keep working. Folded
-    /// into the stall policy in `sync_config()`; see `set_reuse_stale_frames`.
+    /// into the stall behavior in `sync_config()`; see `set_reuse_stale_frames`.
     pub(crate) reuse_stale_frames: bool,
-    /// Default stall policy for tracks with no per-track override.
-    pub(crate) on_stall: StallPolicy,
+    /// Default stall behavior for tracks with no per-track override.
+    pub(crate) stall_behavior: StallBehavior,
     /// Default `max_lag` in milliseconds. `None` derives it from `slack` and
     /// `fps`, which reproduces the historical capacity-eviction timing.
     pub(crate) max_lag_ms: Option<u32>,
     /// Per-track overrides, keyed by track name. Each is independent: a
     /// track may override the policy, the lag budget, or both.
-    pub(crate) track_on_stall: HashMap<String, StallPolicy>,
+    pub(crate) track_stall_behavior: HashMap<String, StallBehavior>,
     pub(crate) track_max_lag_ms: HashMap<String, u32>,
     pub(crate) shared_key: Option<Vec<u8>>,
     /// Operator-side: subscribe to executed actions. Off by default —
@@ -212,9 +212,9 @@ impl PortalConfig {
             tolerance: 1.5,
             ping_ms: 1000,
             reuse_stale_frames: false,
-            on_stall: StallPolicy::Drop,
+            stall_behavior: StallBehavior::Drop,
             max_lag_ms: None,
-            track_on_stall: HashMap::new(),
+            track_stall_behavior: HashMap::new(),
             track_max_lag_ms: HashMap::new(),
             shared_key: None,
             action_subscription: false,
@@ -458,7 +458,7 @@ impl PortalConfig {
     /// perception/action loop.
     #[deprecated(
         since = "0.3.0",
-        note = "use set_on_stall(StallPolicy::Freeze) — equivalent to this plus set_max_lag_ms(0)"
+        note = "use set_stall_behavior(StallBehavior::Freeze) — equivalent to this plus set_max_lag_ms(0)"
     )]
     pub fn set_reuse_stale_frames(&mut self, enable: bool) {
         self.reuse_stale_frames = enable;
@@ -466,7 +466,7 @@ impl PortalConfig {
 
     /// How a moment is resolved when a video track goes silent past its
     /// `max_lag`. Applies to every track without a per-track override; see
-    /// [`set_track_on_stall`](Self::set_track_on_stall).
+    /// [`set_track_stall_behavior`](Self::set_track_stall_behavior).
     ///
     /// **Receiving side only.** Observations are assembled where they are
     /// consumed, so this is read on the `Operator` and is a no-op on a
@@ -474,18 +474,18 @@ impl PortalConfig {
     /// is, by definition, sending nothing, so the substitute frame is
     /// synthesized locally by the subscriber that noticed the gap.
     ///
-    /// [`Drop`](StallPolicy::Drop) (the default) emits nothing for that
+    /// [`Drop`](StallBehavior::Drop) (the default) emits nothing for that
     /// moment — the state still reaches the drop callback, but the healthy
     /// tracks in it are discarded too, so an operator screen goes dark while
-    /// one camera is down. [`Freeze`](StallPolicy::Freeze) keeps the last
-    /// good frame on the silent track. [`Omit`](StallPolicy::Omit) emits a
+    /// one camera is down. [`Freeze`](StallBehavior::Freeze) keeps the last
+    /// good frame on the silent track. [`Omit`](StallBehavior::Omit) emits a
     /// visible placeholder for it, so the healthy tracks keep flowing.
     ///
     /// Whatever the policy, the frame carries a [`FrameSource`] saying which
     /// of the three it was — check it before feeding an observation to a
     /// policy or writing it to a dataset.
-    pub fn set_on_stall(&mut self, policy: StallPolicy) {
-        self.on_stall = policy;
+    pub fn set_stall_behavior(&mut self, behavior: StallBehavior) {
+        self.stall_behavior = behavior;
     }
 
     /// How far the fastest-advancing stream may run past a moment before it
@@ -502,18 +502,18 @@ impl PortalConfig {
     /// would have evicted the moment anyway — so the default timing matches
     /// the historical behavior. `0` resolves immediately, without waiting.
     ///
-    /// **Receiving side only**, like [`set_on_stall`](Self::set_on_stall).
+    /// **Receiving side only**, like [`set_stall_behavior`](Self::set_stall_behavior).
     pub fn set_max_lag_ms(&mut self, ms: u32) {
         self.max_lag_ms = Some(ms);
     }
 
-    /// Per-track override for [`set_on_stall`](Self::set_on_stall). Use it
+    /// Per-track override for [`set_stall_behavior`](Self::set_stall_behavior). Use it
     /// when tracks differ in how load-bearing they are: a wrist camera a
     /// policy depends on may warrant `Drop` (no observation beats a wrong
     /// one), while a scene camera warrants `Omit` so its failure does not
     /// take the rest of the frame set down with it.
-    pub fn set_track_on_stall(&mut self, track: impl Into<String>, policy: StallPolicy) {
-        self.track_on_stall.insert(track.into(), policy);
+    pub fn set_track_stall_behavior(&mut self, track: impl Into<String>, behavior: StallBehavior) {
+        self.track_stall_behavior.insert(track.into(), behavior);
     }
 
     /// Per-track override for [`set_max_lag_ms`](Self::set_max_lag_ms).
@@ -526,7 +526,7 @@ impl PortalConfig {
     pub fn stall_for(&self, track: &str) -> StallConfig {
         let base = self.default_stall();
         StallConfig {
-            policy: self.track_on_stall.get(track).copied().unwrap_or(base.policy),
+            behavior: self.track_stall_behavior.get(track).copied().unwrap_or(base.behavior),
             max_lag_us: self
                 .track_max_lag_ms
                 .get(track)
@@ -541,12 +541,12 @@ impl PortalConfig {
     /// as a lookup for a track name that cannot exist.
     fn default_stall(&self) -> StallConfig {
         // The alias only applies while the modern knob sits at its default,
-        // so an explicit `set_on_stall` always wins — a caller migrating one
+        // so an explicit `set_stall_behavior` always wins — a caller migrating one
         // setting at a time is never silently overridden by a leftover.
-        let policy = if self.reuse_stale_frames && self.on_stall == StallPolicy::Drop {
-            StallPolicy::Freeze
+        let behavior = if self.reuse_stale_frames && self.stall_behavior == StallBehavior::Drop {
+            StallBehavior::Freeze
         } else {
-            self.on_stall
+            self.stall_behavior
         };
 
         let max_lag_us = match self.max_lag_ms {
@@ -558,7 +558,7 @@ impl PortalConfig {
             None => self.slack as u64 * 1_000_000 / self.fps.max(1) as u64,
         };
 
-        StallConfig { max_lag_us: Some(max_lag_us), policy }
+        StallConfig { max_lag_us: Some(max_lag_us), behavior }
     }
 
     /// Per-track stall config for every registered track, in the order the
@@ -695,7 +695,7 @@ mod tests {
     fn default_stall_is_drop_at_slack_over_fps() {
         let c = cfg(); // slack 5, fps 30
         let s = c.stall_for("cam1");
-        assert_eq!(s.policy, StallPolicy::Drop);
+        assert_eq!(s.behavior, StallBehavior::Drop);
         assert_eq!(s.max_lag_us, Some(5 * 1_000_000 / 30));
     }
 
@@ -715,7 +715,7 @@ mod tests {
         #[allow(deprecated)]
         c.set_reuse_stale_frames(true);
         let s = c.stall_for("cam1");
-        assert_eq!(s.policy, StallPolicy::Freeze);
+        assert_eq!(s.behavior, StallBehavior::Freeze);
         assert_eq!(s.max_lag_us, Some(0));
     }
 
@@ -727,10 +727,10 @@ mod tests {
         let mut c = cfg();
         #[allow(deprecated)]
         c.set_reuse_stale_frames(true);
-        c.set_on_stall(StallPolicy::Omit);
+        c.set_stall_behavior(StallBehavior::Omit);
         c.set_max_lag_ms(200);
         let s = c.stall_for("cam1");
-        assert_eq!(s.policy, StallPolicy::Omit);
+        assert_eq!(s.behavior, StallBehavior::Omit);
         assert_eq!(s.max_lag_us, Some(200_000));
     }
 
@@ -748,21 +748,21 @@ mod tests {
     #[test]
     fn per_track_overrides_apply_independently() {
         let mut c = cfg();
-        c.set_on_stall(StallPolicy::Drop);
+        c.set_stall_behavior(StallBehavior::Drop);
         c.set_max_lag_ms(100);
-        c.set_track_on_stall("scene", StallPolicy::Omit);
+        c.set_track_stall_behavior("scene", StallBehavior::Omit);
         c.set_track_max_lag_ms("wrist", 20);
 
         let scene = c.stall_for("scene");
-        assert_eq!(scene.policy, StallPolicy::Omit, "policy overridden");
+        assert_eq!(scene.behavior, StallBehavior::Omit, "behavior overridden");
         assert_eq!(scene.max_lag_us, Some(100_000), "budget inherited");
 
         let wrist = c.stall_for("wrist");
-        assert_eq!(wrist.policy, StallPolicy::Drop, "policy inherited");
+        assert_eq!(wrist.behavior, StallBehavior::Drop, "behavior inherited");
         assert_eq!(wrist.max_lag_us, Some(20_000), "budget overridden");
 
         let other = c.stall_for("other");
-        assert_eq!(other.policy, StallPolicy::Drop);
+        assert_eq!(other.behavior, StallBehavior::Drop);
         assert_eq!(other.max_lag_us, Some(100_000));
     }
 
@@ -772,11 +772,11 @@ mod tests {
     #[test]
     fn empty_track_name_is_not_the_fallback() {
         let mut c = cfg();
-        c.set_on_stall(StallPolicy::Drop);
-        c.set_track_on_stall("", StallPolicy::Omit);
-        assert_eq!(c.stall_for("").policy, StallPolicy::Omit);
-        assert_eq!(c.stall_for("cam1").policy, StallPolicy::Drop, "fallback unaffected");
-        assert_eq!(c.sync_config().default_stall.policy, StallPolicy::Drop);
+        c.set_stall_behavior(StallBehavior::Drop);
+        c.set_track_stall_behavior("", StallBehavior::Omit);
+        assert_eq!(c.stall_for("").behavior, StallBehavior::Omit);
+        assert_eq!(c.stall_for("cam1").behavior, StallBehavior::Drop, "fallback unaffected");
+        assert_eq!(c.sync_config().default_stall.behavior, StallBehavior::Drop);
     }
 
     /// `stall_configs` resolves in the order the sync buffer indexes tracks,
@@ -784,11 +784,11 @@ mod tests {
     #[test]
     fn stall_configs_follow_track_order() {
         let mut c = cfg();
-        c.set_track_on_stall("b", StallPolicy::Freeze);
+        c.set_track_stall_behavior("b", StallBehavior::Freeze);
         let names = vec!["a".to_string(), "b".to_string()];
         let got = c.stall_configs(&names);
         assert_eq!(got.len(), 2);
-        assert_eq!(got[0].policy, StallPolicy::Drop);
-        assert_eq!(got[1].policy, StallPolicy::Freeze);
+        assert_eq!(got[0].behavior, StallBehavior::Drop);
+        assert_eq!(got[1].behavior, StallBehavior::Freeze);
     }
 }

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -14,7 +14,8 @@
 
 use crate::codec::Codec;
 use crate::dtype::DType;
-use crate::types::{Role, SyncConfig};
+use crate::types::{Role, StallConfig, StallPolicy, SyncConfig};
+use std::collections::HashMap;
 
 /// Default JPEG quality for `add_video` when MJPEG is selected without an
 /// explicit value. Tuned for inference workloads: visually near-lossless on
@@ -166,7 +167,18 @@ pub struct PortalConfig {
     pub(crate) slack: u32,
     pub(crate) tolerance: f32,
     pub(crate) ping_ms: u64,
+    /// Deprecated alias, retained so existing callers keep working. Folded
+    /// into the stall policy in `sync_config()`; see `set_reuse_stale_frames`.
     pub(crate) reuse_stale_frames: bool,
+    /// Default stall policy for tracks with no per-track override.
+    pub(crate) on_stall: StallPolicy,
+    /// Default `max_lag` in milliseconds. `None` derives it from `slack` and
+    /// `fps`, which reproduces the historical capacity-eviction timing.
+    pub(crate) max_lag_ms: Option<u32>,
+    /// Per-track overrides, keyed by track name. Each is independent: a
+    /// track may override the policy, the lag budget, or both.
+    pub(crate) track_on_stall: HashMap<String, StallPolicy>,
+    pub(crate) track_max_lag_ms: HashMap<String, u32>,
     pub(crate) shared_key: Option<Vec<u8>>,
     /// Operator-side: subscribe to executed actions. Off by default —
     /// most operators are pure controllers and do not want the bandwidth
@@ -200,6 +212,10 @@ impl PortalConfig {
             tolerance: 1.5,
             ping_ms: 1000,
             reuse_stale_frames: false,
+            on_stall: StallPolicy::Drop,
+            max_lag_ms: None,
+            track_on_stall: HashMap::new(),
+            track_max_lag_ms: HashMap::new(),
             shared_key: None,
             action_subscription: false,
         }
@@ -440,8 +456,91 @@ impl PortalConfig {
     /// losing a state is worse than a transient video freeze; leave it
     /// off for real-time control where a stale frame would misalign the
     /// perception/action loop.
+    #[deprecated(
+        since = "0.3.0",
+        note = "use set_on_stall(StallPolicy::Freeze) — equivalent to this plus set_max_lag_ms(0)"
+    )]
     pub fn set_reuse_stale_frames(&mut self, enable: bool) {
         self.reuse_stale_frames = enable;
+    }
+
+    /// How a moment is resolved when a video track goes silent past its
+    /// `max_lag`. Applies to every track without a per-track override; see
+    /// [`set_track_on_stall`](Self::set_track_on_stall).
+    ///
+    /// [`Drop`](StallPolicy::Drop) (the default) emits nothing for that
+    /// moment — the state still reaches the drop callback, but the healthy
+    /// tracks in it are discarded too, so an operator screen goes dark while
+    /// one camera is down. [`Freeze`](StallPolicy::Freeze) keeps the last
+    /// good frame on the silent track. [`Omit`](StallPolicy::Omit) emits a
+    /// visible placeholder for it, so the healthy tracks keep flowing.
+    ///
+    /// Whatever the policy, the frame carries a [`FrameSource`] saying which
+    /// of the three it was — check it before feeding an observation to a
+    /// policy or writing it to a dataset.
+    pub fn set_on_stall(&mut self, policy: StallPolicy) {
+        self.on_stall = policy;
+    }
+
+    /// How far the fastest-advancing stream may run past a moment before it
+    /// is resolved without a silent track, in milliseconds of **sender-clock
+    /// time** — not wall-clock.
+    ///
+    /// This is a statement about stream position, not a stopwatch: it is
+    /// evaluated when a packet arrives, so a burst of buffered frames can
+    /// cross the threshold in far less real time, and if every stream goes
+    /// quiet nothing fires at all (nothing is being emitted either). Keeping
+    /// it on sender clocks is what makes sync decisions reproducible.
+    ///
+    /// Defaults to `slack / fps` — the point at which state-buffer capacity
+    /// would have evicted the moment anyway — so the default timing matches
+    /// the historical behavior. `0` resolves immediately, without waiting.
+    pub fn set_max_lag_ms(&mut self, ms: u32) {
+        self.max_lag_ms = Some(ms);
+    }
+
+    /// Per-track override for [`set_on_stall`](Self::set_on_stall). Use it
+    /// when tracks differ in how load-bearing they are: a wrist camera a
+    /// policy depends on may warrant `Drop` (no observation beats a wrong
+    /// one), while a scene camera warrants `Omit` so its failure does not
+    /// take the rest of the frame set down with it.
+    pub fn set_track_on_stall(&mut self, track: impl Into<String>, policy: StallPolicy) {
+        self.track_on_stall.insert(track.into(), policy);
+    }
+
+    /// Per-track override for [`set_max_lag_ms`](Self::set_max_lag_ms).
+    pub fn set_track_max_lag_ms(&mut self, track: impl Into<String>, ms: u32) {
+        self.track_max_lag_ms.insert(track.into(), ms);
+    }
+
+    /// Effective stall config for one track, after applying per-track
+    /// overrides and the `reuse_stale_frames` alias over the defaults.
+    pub fn stall_for(&self, track: &str) -> StallConfig {
+        let policy = self.track_on_stall.get(track).copied().unwrap_or_else(|| {
+            // The deprecated alias only takes effect when the modern knob is
+            // left at its default, so an explicit `set_on_stall` always wins.
+            if self.reuse_stale_frames && self.on_stall == StallPolicy::Drop {
+                StallPolicy::Freeze
+            } else {
+                self.on_stall
+            }
+        });
+
+        let max_lag_us = match self.track_max_lag_ms.get(track).copied().or(self.max_lag_ms) {
+            Some(ms) => ms as u64 * 1_000,
+            // `reuse_stale_frames` resolved immediately, with no wait.
+            None if self.reuse_stale_frames && self.max_lag_ms.is_none() => 0,
+            // Default: the point capacity eviction would have reached anyway.
+            None => self.slack as u64 * 1_000_000 / self.fps.max(1) as u64,
+        };
+
+        StallConfig { max_lag_us: Some(max_lag_us), policy }
+    }
+
+    /// Per-track stall config for every registered track, in the order the
+    /// sync buffer indexes them.
+    pub(crate) fn stall_configs(&self, track_names: &[String]) -> Vec<StallConfig> {
+        track_names.iter().map(|n| self.stall_for(n)).collect()
     }
 
     /// Declared WebRTC (H264) video tracks (name + optional bitrate cap), in
@@ -552,7 +651,107 @@ impl PortalConfig {
             video_buffer_size: self.slack,
             state_buffer_size: self.slack,
             search_range_us,
-            reuse_stale_frames: self.reuse_stale_frames,
+            default_stall: self.stall_for(""),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> PortalConfig {
+        PortalConfig::new("demo", Role::Robot)
+    }
+
+    /// The default budget is the point state-buffer capacity would have
+    /// evicted the moment anyway (`slack / fps`), so the default timing
+    /// matches the historical behavior rather than changing it.
+    #[test]
+    fn default_stall_is_drop_at_slack_over_fps() {
+        let c = cfg(); // slack 5, fps 30
+        let s = c.stall_for("cam1");
+        assert_eq!(s.policy, StallPolicy::Drop);
+        assert_eq!(s.max_lag_us, Some(5 * 1_000_000 / 30));
+    }
+
+    #[test]
+    fn default_budget_tracks_slack_and_fps() {
+        let mut c = cfg();
+        c.set_slack(10);
+        c.set_fps(50);
+        assert_eq!(c.stall_for("cam1").max_lag_us, Some(200_000));
+    }
+
+    /// `reuse_stale_frames` is exactly `Freeze` with a zero budget: resolve
+    /// immediately, substituting the last good frame.
+    #[test]
+    fn reuse_stale_frames_aliases_to_freeze_with_zero_budget() {
+        let mut c = cfg();
+        #[allow(deprecated)]
+        c.set_reuse_stale_frames(true);
+        let s = c.stall_for("cam1");
+        assert_eq!(s.policy, StallPolicy::Freeze);
+        assert_eq!(s.max_lag_us, Some(0));
+    }
+
+    /// An explicit modern knob always beats the deprecated alias, in both
+    /// directions, so a caller migrating one setting at a time is never
+    /// silently overridden by a leftover `reuse_stale_frames`.
+    #[test]
+    fn explicit_knobs_win_over_the_alias() {
+        let mut c = cfg();
+        #[allow(deprecated)]
+        c.set_reuse_stale_frames(true);
+        c.set_on_stall(StallPolicy::Omit);
+        c.set_max_lag_ms(200);
+        let s = c.stall_for("cam1");
+        assert_eq!(s.policy, StallPolicy::Omit);
+        assert_eq!(s.max_lag_us, Some(200_000));
+    }
+
+    #[test]
+    fn max_lag_ms_converts_to_micros() {
+        let mut c = cfg();
+        c.set_max_lag_ms(200);
+        assert_eq!(c.stall_for("cam1").max_lag_us, Some(200_000));
+        c.set_max_lag_ms(0);
+        assert_eq!(c.stall_for("cam1").max_lag_us, Some(0), "0 resolves immediately");
+    }
+
+    /// Per-track overrides are independent: a track may override the policy,
+    /// the budget, or both, and untouched tracks keep the defaults.
+    #[test]
+    fn per_track_overrides_apply_independently() {
+        let mut c = cfg();
+        c.set_on_stall(StallPolicy::Drop);
+        c.set_max_lag_ms(100);
+        c.set_track_on_stall("scene", StallPolicy::Omit);
+        c.set_track_max_lag_ms("wrist", 20);
+
+        let scene = c.stall_for("scene");
+        assert_eq!(scene.policy, StallPolicy::Omit, "policy overridden");
+        assert_eq!(scene.max_lag_us, Some(100_000), "budget inherited");
+
+        let wrist = c.stall_for("wrist");
+        assert_eq!(wrist.policy, StallPolicy::Drop, "policy inherited");
+        assert_eq!(wrist.max_lag_us, Some(20_000), "budget overridden");
+
+        let other = c.stall_for("other");
+        assert_eq!(other.policy, StallPolicy::Drop);
+        assert_eq!(other.max_lag_us, Some(100_000));
+    }
+
+    /// `stall_configs` resolves in the order the sync buffer indexes tracks,
+    /// since the buffer addresses them positionally.
+    #[test]
+    fn stall_configs_follow_track_order() {
+        let mut c = cfg();
+        c.set_track_on_stall("b", StallPolicy::Freeze);
+        let names = vec!["a".to_string(), "b".to_string()];
+        let got = c.stall_configs(&names);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].policy, StallPolicy::Drop);
+        assert_eq!(got[1].policy, StallPolicy::Freeze);
     }
 }

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -35,7 +35,7 @@ use serde::Deserialize;
 use crate::codec::Codec;
 use crate::config::{DEFAULT_MJPEG_QUALITY, PortalConfig};
 use crate::dtype::DType;
-use crate::types::Role;
+use crate::types::{Role, StallPolicy};
 
 /// Errors raised by `PortalConfig::from_yaml_*`.
 #[derive(Debug, thiserror::Error)]
@@ -57,6 +57,19 @@ pub enum ConfigFileError {
 /// lands.
 const SUPPORTED_VERSION: u32 = 1;
 
+/// Parse an `on_stall` value. Spelled in lowercase in YAML to match the rest
+/// of the file's vocabulary; `context` names the key for the error message.
+fn parse_stall_policy(s: &str, context: &str) -> Result<StallPolicy, ConfigFileError> {
+    match s {
+        "drop" => Ok(StallPolicy::Drop),
+        "freeze" => Ok(StallPolicy::Freeze),
+        "omit" => Ok(StallPolicy::Omit),
+        other => Err(ConfigFileError::Invalid(format!(
+            "{context}: expected one of drop, freeze, omit — got '{other}'"
+        ))),
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ConfigFileV1 {
@@ -74,6 +87,13 @@ struct ConfigFileV1 {
     action_reliable: Option<bool>,
     #[serde(default)]
     reuse_stale_frames: Option<bool>,
+    /// Default stall policy: `drop` (default), `freeze`, or `omit`.
+    #[serde(default)]
+    on_stall: Option<String>,
+    /// Default lag budget in milliseconds of sender-clock time. Omit to
+    /// derive it from `slack` and `fps`.
+    #[serde(default)]
+    max_lag_ms: Option<u32>,
     #[serde(default)]
     ping_ms: Option<u64>,
     #[serde(default)]
@@ -102,6 +122,12 @@ struct VideoEntry {
     /// codecs. Omit to use the default ceiling.
     #[serde(default)]
     max_bitrate_kbps: Option<u32>,
+    /// Per-track override of the top-level `on_stall`.
+    #[serde(default)]
+    on_stall: Option<String>,
+    /// Per-track override of the top-level `max_lag_ms`.
+    #[serde(default)]
+    max_lag_ms: Option<u32>,
     /// Publish multiple spatial layers. WebRTC codecs only. Defaults to
     /// `false`.
     #[serde(default)]
@@ -233,7 +259,23 @@ impl PortalConfig {
             cfg.set_action_reliable(v);
         }
         if let Some(v) = parsed.reuse_stale_frames {
-            cfg.set_reuse_stale_frames(v);
+            // Deprecated alias; `stall_for` folds it into the stall policy.
+            cfg.reuse_stale_frames = v;
+        }
+        if let Some(v) = &parsed.on_stall {
+            cfg.set_on_stall(parse_stall_policy(v, "on_stall")?);
+        }
+        if let Some(v) = parsed.max_lag_ms {
+            cfg.set_max_lag_ms(v);
+        }
+        for v in &parsed.videos {
+            if let Some(p) = &v.on_stall {
+                let ctx = format!("video '{}': on_stall", v.name);
+                cfg.set_track_on_stall(v.name.clone(), parse_stall_policy(p, &ctx)?);
+            }
+            if let Some(ms) = v.max_lag_ms {
+                cfg.set_track_max_lag_ms(v.name.clone(), ms);
+            }
         }
         if let Some(v) = parsed.ping_ms {
             cfg.set_ping_ms(v);
@@ -678,5 +720,63 @@ state:
         let operator = PortalConfig::from_yaml_str(yaml_full(), "demo", Role::Operator).unwrap();
         assert_eq!(robot.state_schema(), operator.state_schema());
         assert_eq!(robot.action_schema(), operator.action_schema());
+    }
+
+    /// Stall knobs parse at both levels, with per-track overriding the
+    /// default and untouched tracks inheriting it.
+    #[test]
+    fn stall_policy_parses_per_track() {
+        let yaml = r#"
+version: 1
+on_stall: freeze
+max_lag_ms: 120
+videos:
+  - { name: front, codec: h264 }
+  - { name: wrist, codec: h264, on_stall: drop, max_lag_ms: 20 }
+  - { name: scene, codec: h264, on_stall: omit }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+
+        let front = cfg.stall_for("front");
+        assert_eq!(front.policy, StallPolicy::Freeze, "inherits the default");
+        assert_eq!(front.max_lag_us, Some(120_000));
+
+        let wrist = cfg.stall_for("wrist");
+        assert_eq!(wrist.policy, StallPolicy::Drop);
+        assert_eq!(wrist.max_lag_us, Some(20_000));
+
+        let scene = cfg.stall_for("scene");
+        assert_eq!(scene.policy, StallPolicy::Omit);
+        assert_eq!(scene.max_lag_us, Some(120_000), "budget still inherited");
+    }
+
+    /// An unknown policy is rejected by name rather than silently ignored,
+    /// and the message says which key was wrong.
+    #[test]
+    fn unknown_stall_policy_is_rejected() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: front, codec: h264, on_stall: nope }
+"#;
+        let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("front"), "names the offending track: {msg}");
+        assert!(msg.contains("on_stall"), "names the key: {msg}");
+        assert!(msg.contains("nope"), "quotes the bad value: {msg}");
+    }
+
+    /// Omitting both keys leaves the derived default in place.
+    #[test]
+    fn stall_defaults_when_absent() {
+        let yaml = r#"
+version: 1
+videos:
+  - { name: front, codec: h264 }
+"#;
+        let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
+        let s = cfg.stall_for("front");
+        assert_eq!(s.policy, StallPolicy::Drop);
+        assert_eq!(s.max_lag_us, Some(5 * 1_000_000 / 30), "slack / fps");
     }
 }

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -35,7 +35,7 @@ use serde::Deserialize;
 use crate::codec::Codec;
 use crate::config::{DEFAULT_MJPEG_QUALITY, PortalConfig};
 use crate::dtype::DType;
-use crate::types::{Role, StallPolicy};
+use crate::types::{Role, StallBehavior};
 
 /// Errors raised by `PortalConfig::from_yaml_*`.
 #[derive(Debug, thiserror::Error)]
@@ -57,13 +57,13 @@ pub enum ConfigFileError {
 /// lands.
 const SUPPORTED_VERSION: u32 = 1;
 
-/// Parse an `on_stall` value. Spelled in lowercase in YAML to match the rest
+/// Parse an `stall_behavior` value. Spelled in lowercase in YAML to match the rest
 /// of the file's vocabulary; `context` names the key for the error message.
-fn parse_stall_policy(s: &str, context: &str) -> Result<StallPolicy, ConfigFileError> {
+fn parse_stall_behavior(s: &str, context: &str) -> Result<StallBehavior, ConfigFileError> {
     match s {
-        "drop" => Ok(StallPolicy::Drop),
-        "freeze" => Ok(StallPolicy::Freeze),
-        "omit" => Ok(StallPolicy::Omit),
+        "drop" => Ok(StallBehavior::Drop),
+        "freeze" => Ok(StallBehavior::Freeze),
+        "omit" => Ok(StallBehavior::Omit),
         other => Err(ConfigFileError::Invalid(format!(
             "{context}: expected one of drop, freeze, omit — got '{other}'"
         ))),
@@ -87,9 +87,9 @@ struct ConfigFileV1 {
     action_reliable: Option<bool>,
     #[serde(default)]
     reuse_stale_frames: Option<bool>,
-    /// Default stall policy: `drop` (default), `freeze`, or `omit`.
+    /// Default stall behavior: `drop` (default), `freeze`, or `omit`.
     #[serde(default)]
-    on_stall: Option<String>,
+    stall_behavior: Option<String>,
     /// Default lag budget in milliseconds of sender-clock time. Omit to
     /// derive it from `slack` and `fps`.
     #[serde(default)]
@@ -122,9 +122,9 @@ struct VideoEntry {
     /// codecs. Omit to use the default ceiling.
     #[serde(default)]
     max_bitrate_kbps: Option<u32>,
-    /// Per-track override of the top-level `on_stall`.
+    /// Per-track override of the top-level `stall_behavior`.
     #[serde(default)]
-    on_stall: Option<String>,
+    stall_behavior: Option<String>,
     /// Per-track override of the top-level `max_lag_ms`.
     #[serde(default)]
     max_lag_ms: Option<u32>,
@@ -259,19 +259,19 @@ impl PortalConfig {
             cfg.set_action_reliable(v);
         }
         if let Some(v) = parsed.reuse_stale_frames {
-            // Deprecated alias; `stall_for` folds it into the stall policy.
+            // Deprecated alias; `stall_for` folds it into the stall behavior.
             cfg.reuse_stale_frames = v;
         }
-        if let Some(v) = &parsed.on_stall {
-            cfg.set_on_stall(parse_stall_policy(v, "on_stall")?);
+        if let Some(v) = &parsed.stall_behavior {
+            cfg.set_stall_behavior(parse_stall_behavior(v, "stall_behavior")?);
         }
         if let Some(v) = parsed.max_lag_ms {
             cfg.set_max_lag_ms(v);
         }
         for v in &parsed.videos {
-            if let Some(p) = &v.on_stall {
-                let ctx = format!("video '{}': on_stall", v.name);
-                cfg.set_track_on_stall(v.name.clone(), parse_stall_policy(p, &ctx)?);
+            if let Some(p) = &v.stall_behavior {
+                let ctx = format!("video '{}': stall_behavior", v.name);
+                cfg.set_track_stall_behavior(v.name.clone(), parse_stall_behavior(p, &ctx)?);
             }
             if let Some(ms) = v.max_lag_ms {
                 cfg.set_track_max_lag_ms(v.name.clone(), ms);
@@ -728,25 +728,25 @@ state:
     fn stall_policy_parses_per_track() {
         let yaml = r#"
 version: 1
-on_stall: freeze
+stall_behavior: freeze
 max_lag_ms: 120
 videos:
   - { name: front, codec: h264 }
-  - { name: wrist, codec: h264, on_stall: drop, max_lag_ms: 20 }
-  - { name: scene, codec: h264, on_stall: omit }
+  - { name: wrist, codec: h264, stall_behavior: drop, max_lag_ms: 20 }
+  - { name: scene, codec: h264, stall_behavior: omit }
 "#;
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
 
         let front = cfg.stall_for("front");
-        assert_eq!(front.policy, StallPolicy::Freeze, "inherits the default");
+        assert_eq!(front.behavior, StallBehavior::Freeze, "inherits the default");
         assert_eq!(front.max_lag_us, Some(120_000));
 
         let wrist = cfg.stall_for("wrist");
-        assert_eq!(wrist.policy, StallPolicy::Drop);
+        assert_eq!(wrist.behavior, StallBehavior::Drop);
         assert_eq!(wrist.max_lag_us, Some(20_000));
 
         let scene = cfg.stall_for("scene");
-        assert_eq!(scene.policy, StallPolicy::Omit);
+        assert_eq!(scene.behavior, StallBehavior::Omit);
         assert_eq!(scene.max_lag_us, Some(120_000), "budget still inherited");
     }
 
@@ -757,12 +757,12 @@ videos:
         let yaml = r#"
 version: 1
 videos:
-  - { name: front, codec: h264, on_stall: nope }
+  - { name: front, codec: h264, stall_behavior: nope }
 "#;
         let err = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("front"), "names the offending track: {msg}");
-        assert!(msg.contains("on_stall"), "names the key: {msg}");
+        assert!(msg.contains("stall_behavior"), "names the key: {msg}");
         assert!(msg.contains("nope"), "quotes the bad value: {msg}");
     }
 
@@ -776,7 +776,7 @@ videos:
 "#;
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
         let s = cfg.stall_for("front");
-        assert_eq!(s.policy, StallPolicy::Drop);
+        assert_eq!(s.behavior, StallBehavior::Drop);
         assert_eq!(s.max_lag_us, Some(5 * 1_000_000 / 30), "slack / fps");
     }
 }

--- a/livekit-portal/src/frame_video.rs
+++ b/livekit-portal/src/frame_video.rs
@@ -81,7 +81,7 @@ use crate::error::{PortalError, PortalResult};
 use crate::metrics::TrackMetrics;
 use crate::portal::ObservationSink;
 use crate::sync_buffer::SyncBuffer;
-use crate::types::VideoFrameData;
+use crate::types::{FrameSource, VideoFrameData};
 use crate::video::{VideoTrackSlots, now_us};
 
 /// Reserved Portal topic for frame-video byte streams. A single topic
@@ -402,6 +402,7 @@ pub(crate) fn dispatch_frame_payload(
         height: decoded.height,
         data: decoded.rgb,
         timestamp_us,
+        source: FrameSource::Live,
     });
 
     let track_name_for_dispatch = entry.spec.name.as_str();

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -20,6 +20,7 @@ pub mod dtype;
 pub mod error;
 mod frame_video;
 pub mod metrics;
+mod placeholder;
 mod portal;
 pub mod rpc;
 mod rtt;

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -43,6 +43,6 @@ pub use metrics::{
 pub use portal::{ACTIVE_OPERATOR_ATTR_KEY, Portal, ROLE_ATTR_KEY, SET_ACTIVE_OPERATOR_RPC};
 pub use rpc::{RpcError, RpcHandler, RpcInvocationData};
 pub use types::{
-    Action, ActionChunk, ChunkColumn, Observation, Role, State, SyncConfig, TypedValue,
-    VideoFrameData,
+    Action, ActionChunk, ChunkColumn, FrameSource, Observation, Role, StallConfig, StallPolicy,
+    State, SyncConfig, TypedValue, VideoFrameData,
 };

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -44,6 +44,6 @@ pub use metrics::{
 pub use portal::{ACTIVE_OPERATOR_ATTR_KEY, Portal, ROLE_ATTR_KEY, SET_ACTIVE_OPERATOR_RPC};
 pub use rpc::{RpcError, RpcHandler, RpcInvocationData};
 pub use types::{
-    Action, ActionChunk, ChunkColumn, FrameSource, Observation, Role, StallConfig, StallPolicy,
+    Action, ActionChunk, ChunkColumn, FrameSource, Observation, Role, StallBehavior, StallConfig,
     State, SyncConfig, TypedValue, VideoFrameData,
 };

--- a/livekit-portal/src/metrics.rs
+++ b/livekit-portal/src/metrics.rs
@@ -38,6 +38,11 @@ pub struct SyncMetrics {
     /// rate signals a silently frozen video track.
     pub stale_observations_emitted: u64,
     pub states_dropped: u64,
+    /// Per-track count of synthesized placeholder frames emitted under
+    /// `on_stall: omit`. A rising counter means that track is silent and its
+    /// moments are being kept alive with a stand-in rather than discarded;
+    /// the matching frames carry `FrameSource::Omitted`.
+    pub frames_omitted: HashMap<String, u64>,
     /// Worst per-track alignment `max_t |state_ts − frame_ts|` across the
     /// tracks in each emitted observation, over a rolling 256-sample window.
     pub match_delta_us_p50: Option<u64>,
@@ -262,6 +267,7 @@ impl MetricsRegistry {
         let mut frames_received = HashMap::with_capacity(n);
         let mut frame_jitter_us = HashMap::with_capacity(n);
         let mut evictions = HashMap::with_capacity(n);
+        let mut frames_omitted = HashMap::with_capacity(n);
         let mut frames_dropped_publisher_full = HashMap::with_capacity(n);
         let mut bytes_sent = HashMap::with_capacity(n);
         let mut bytes_received = HashMap::with_capacity(n);
@@ -271,6 +277,7 @@ impl MetricsRegistry {
                 frames_received.insert(name.clone(), t.frames_received.load(Ordering::Relaxed));
                 frame_jitter_us.insert(name.clone(), t.jitter.lock().jitter_us);
                 evictions.insert(name.clone(), t.evictions.load(Ordering::Relaxed));
+                frames_omitted.insert(name.clone(), t.frames_omitted.load(Ordering::Relaxed));
                 frames_dropped_publisher_full
                     .insert(name.clone(), t.frames_dropped_publisher_full.load(Ordering::Relaxed));
                 bytes_sent.insert(name.clone(), t.bytes_sent.load(Ordering::Relaxed));
@@ -304,6 +311,7 @@ impl MetricsRegistry {
                 observations_emitted: self.observations_emitted.load(Ordering::Relaxed),
                 stale_observations_emitted: self.stale_observations_emitted.load(Ordering::Relaxed),
                 states_dropped: self.states_dropped.load(Ordering::Relaxed),
+                frames_omitted,
                 match_delta_us_p50: match_p50,
                 match_delta_us_p95: match_p95,
                 last_blocker_track,
@@ -372,6 +380,7 @@ pub(crate) struct TrackMetrics {
     pub frames_sent: AtomicU64,
     pub frames_received: AtomicU64,
     pub evictions: AtomicU64,
+    pub frames_omitted: AtomicU64,
     pub frames_dropped_publisher_full: AtomicU64,
     pub bytes_sent: AtomicU64,
     pub bytes_received: AtomicU64,
@@ -384,6 +393,7 @@ impl TrackMetrics {
             frames_sent: AtomicU64::new(0),
             frames_received: AtomicU64::new(0),
             evictions: AtomicU64::new(0),
+            frames_omitted: AtomicU64::new(0),
             frames_dropped_publisher_full: AtomicU64::new(0),
             bytes_sent: AtomicU64::new(0),
             bytes_received: AtomicU64::new(0),
@@ -420,6 +430,10 @@ impl TrackMetrics {
         self.evictions.fetch_add(n, Ordering::Relaxed);
     }
 
+    pub fn record_frame_omitted(&self) {
+        self.frames_omitted.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn record_dropped_publisher_full(&self) {
         self.frames_dropped_publisher_full.fetch_add(1, Ordering::Relaxed);
     }
@@ -428,6 +442,7 @@ impl TrackMetrics {
         self.frames_sent.store(0, Ordering::Relaxed);
         self.frames_received.store(0, Ordering::Relaxed);
         self.evictions.store(0, Ordering::Relaxed);
+        self.frames_omitted.store(0, Ordering::Relaxed);
         self.frames_dropped_publisher_full.store(0, Ordering::Relaxed);
         self.bytes_sent.store(0, Ordering::Relaxed);
         self.bytes_received.store(0, Ordering::Relaxed);

--- a/livekit-portal/src/placeholder.rs
+++ b/livekit-portal/src/placeholder.rs
@@ -1,0 +1,274 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Synthesized stand-in frames for `StallPolicy::Omit`.
+//!
+//! When a track goes silent past its lag budget, `Omit` keeps the moment
+//! alive by substituting a frame that is obviously not camera output: magenta
+//! diagonals with the track's name written across it. The alternative —
+//! plain black — is indistinguishable from a dark room or a capped lens, so a
+//! recording made through a camera failure could never be told apart from one
+//! made in the dark.
+//!
+//! The pixels are only half the signal. Every synthesized frame is also
+//! tagged [`FrameSource::Omitted`](crate::FrameSource::Omitted), which is
+//! what a policy or a dataset writer should branch on; the pattern is for
+//! whoever is watching the screen.
+//!
+//! Rendering is deliberately dependency-free — a 5x7 bitmap font rather than
+//! a font rasterizer crate, which would be a real dependency taken on for a
+//! failure path. Callers are expected to cache the result per track and
+//! geometry (see `SyncBuffer::placeholder_pixels`); nothing here memoizes.
+
+use bytes::Bytes;
+
+/// Stripe colors. Magenta essentially never occurs in a robot scene, and is
+/// the established "invalid" convention in video and graphics tooling.
+const MAGENTA: [u8; 3] = [0xC0, 0x00, 0xC0];
+const DARK: [u8; 3] = [0x20, 0x00, 0x28];
+/// Backing band behind the text, so the label stays legible over stripes.
+const BAND: [u8; 3] = [0x0A, 0x00, 0x0C];
+const TEXT: [u8; 3] = [0xFF, 0xFF, 0xFF];
+
+/// Diagonal stripe half-period, in unscaled pixels.
+const STRIPE: usize = 8;
+
+const GLYPH_W: usize = 5;
+const GLYPH_H: usize = 7;
+/// One blank column between glyphs.
+const ADVANCE: usize = GLYPH_W + 1;
+
+/// Rows of a 5x7 glyph, most significant of the low 5 bits leftmost.
+type Glyph = [u8; GLYPH_H];
+
+const UNKNOWN: Glyph = [0x0E, 0x11, 0x01, 0x02, 0x04, 0x00, 0x04];
+
+/// 5x7 bitmap font, uppercase-only. Track names are upcased before drawing,
+/// so lowercase never needs its own glyphs.
+fn glyph(c: char) -> Glyph {
+    match c {
+        'A' => [0x0E, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11],
+        'B' => [0x1E, 0x11, 0x11, 0x1E, 0x11, 0x11, 0x1E],
+        'C' => [0x0E, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0E],
+        'D' => [0x1E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1E],
+        'E' => [0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x1F],
+        'F' => [0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x10],
+        'G' => [0x0E, 0x11, 0x10, 0x17, 0x11, 0x11, 0x0F],
+        'H' => [0x11, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11],
+        'I' => [0x0E, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0E],
+        'J' => [0x07, 0x02, 0x02, 0x02, 0x02, 0x12, 0x0C],
+        'K' => [0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11],
+        'L' => [0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1F],
+        'M' => [0x11, 0x1B, 0x15, 0x15, 0x11, 0x11, 0x11],
+        'N' => [0x11, 0x11, 0x19, 0x15, 0x13, 0x11, 0x11],
+        'O' => [0x0E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E],
+        'P' => [0x1E, 0x11, 0x11, 0x1E, 0x10, 0x10, 0x10],
+        'Q' => [0x0E, 0x11, 0x11, 0x11, 0x15, 0x12, 0x0D],
+        'R' => [0x1E, 0x11, 0x11, 0x1E, 0x14, 0x12, 0x11],
+        'S' => [0x0F, 0x10, 0x10, 0x0E, 0x01, 0x01, 0x1E],
+        'T' => [0x1F, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04],
+        'U' => [0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E],
+        'V' => [0x11, 0x11, 0x11, 0x11, 0x11, 0x0A, 0x04],
+        'W' => [0x11, 0x11, 0x11, 0x15, 0x15, 0x1B, 0x11],
+        'X' => [0x11, 0x11, 0x0A, 0x04, 0x0A, 0x11, 0x11],
+        'Y' => [0x11, 0x11, 0x0A, 0x04, 0x04, 0x04, 0x04],
+        'Z' => [0x1F, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1F],
+        '0' => [0x0E, 0x11, 0x13, 0x15, 0x19, 0x11, 0x0E],
+        '1' => [0x04, 0x0C, 0x04, 0x04, 0x04, 0x04, 0x0E],
+        '2' => [0x0E, 0x11, 0x01, 0x02, 0x04, 0x08, 0x1F],
+        '3' => [0x1F, 0x02, 0x04, 0x02, 0x01, 0x11, 0x0E],
+        '4' => [0x02, 0x06, 0x0A, 0x12, 0x1F, 0x02, 0x02],
+        '5' => [0x1F, 0x10, 0x1E, 0x01, 0x01, 0x11, 0x0E],
+        '6' => [0x06, 0x08, 0x10, 0x1E, 0x11, 0x11, 0x0E],
+        '7' => [0x1F, 0x01, 0x02, 0x04, 0x08, 0x08, 0x08],
+        '8' => [0x0E, 0x11, 0x11, 0x0E, 0x11, 0x11, 0x0E],
+        '9' => [0x0E, 0x11, 0x11, 0x0F, 0x01, 0x02, 0x0C],
+        ' ' => [0x00; GLYPH_H],
+        '-' => [0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00],
+        '_' => [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F],
+        '.' => [0x00, 0x00, 0x00, 0x00, 0x00, 0x0C, 0x0C],
+        ':' => [0x00, 0x0C, 0x0C, 0x00, 0x0C, 0x0C, 0x00],
+        '/' => [0x01, 0x02, 0x02, 0x04, 0x08, 0x08, 0x10],
+        _ => UNKNOWN,
+    }
+}
+
+/// Longest track name drawn. Longer names are truncated with an ellipsis so
+/// one pathological name cannot push the label off both edges.
+const MAX_NAME: usize = 20;
+
+/// Render an RGB24 placeholder of `width` x `height` for `track_name`.
+///
+/// Always returns exactly `width * height * 3` bytes, including for degenerate
+/// sizes: text that does not fit is skipped rather than clipped mid-glyph, so
+/// a tiny frame comes back as bare stripes.
+pub(crate) fn render(width: u32, height: u32, track_name: &str) -> Bytes {
+    let w = width as usize;
+    let h = height as usize;
+    let mut buf = vec![0u8; w * h * 3];
+    if w == 0 || h == 0 {
+        return Bytes::from(buf);
+    }
+
+    for y in 0..h {
+        for x in 0..w {
+            let c = if ((x + y) / STRIPE).is_multiple_of(2) { MAGENTA } else { DARK };
+            let i = (y * w + x) * 3;
+            buf[i..i + 3].copy_from_slice(&c);
+        }
+    }
+
+    // Integer scale keeps glyph edges crisp. ~120px of width per 20 columns
+    // of text is the smallest that stays readable on a teleop grid tile.
+    let scale = (w / 120).max(1);
+    let mut name: String = track_name.to_uppercase();
+    if name.chars().count() > MAX_NAME {
+        name = name.chars().take(MAX_NAME - 1).collect::<String>() + ".";
+    }
+    let lines = ["NO SIGNAL", name.as_str()];
+
+    let line_h = GLYPH_H * scale;
+    let gap = scale * 3;
+    let text_h = line_h * lines.len() + gap;
+    let pad = scale * 4;
+    if text_h + pad * 2 > h {
+        // No room for a legible label; the stripes alone still read as
+        // "synthetic", which is the property that matters most.
+        return Bytes::from(buf);
+    }
+
+    let band_top = (h - (text_h + pad * 2)) / 2;
+    let band_bot = band_top + text_h + pad * 2;
+    for y in band_top..band_bot {
+        for x in 0..w {
+            let i = (y * w + x) * 3;
+            buf[i..i + 3].copy_from_slice(&BAND);
+        }
+    }
+
+    let mut y = band_top + pad;
+    for line in lines {
+        let text_w = line.chars().count() * ADVANCE * scale;
+        if text_w <= w {
+            draw_text(&mut buf, w, (w - text_w) / 2, y, line, scale);
+        }
+        y += line_h + gap;
+    }
+
+    Bytes::from(buf)
+}
+
+/// Blit `text` at `(ox, oy)`, `scale`x nearest-neighbour. Glyph pixels that
+/// would fall outside the buffer are skipped, so callers need not pre-check
+/// the exact right edge.
+fn draw_text(buf: &mut [u8], w: usize, ox: usize, oy: usize, text: &str, scale: usize) {
+    let h = buf.len() / (w * 3);
+    for (n, ch) in text.chars().enumerate() {
+        let g = glyph(ch);
+        let gx = ox + n * ADVANCE * scale;
+        for (row, bits) in g.iter().enumerate() {
+            for col in 0..GLYPH_W {
+                // Bit 4 is the leftmost column of the glyph.
+                if bits & (1 << (GLYPH_W - 1 - col)) == 0 {
+                    continue;
+                }
+                for sy in 0..scale {
+                    for sx in 0..scale {
+                        let px = gx + col * scale + sx;
+                        let py = oy + row * scale + sy;
+                        if px >= w || py >= h {
+                            continue;
+                        }
+                        let i = (py * w + px) * 3;
+                        buf[i..i + 3].copy_from_slice(&TEXT);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn px(buf: &[u8], w: usize, x: usize, y: usize) -> [u8; 3] {
+        let i = (y * w + x) * 3;
+        [buf[i], buf[i + 1], buf[i + 2]]
+    }
+
+    /// The buffer is always exactly RGB24-sized for the requested geometry —
+    /// consumers reshape it as `(h, w, 3)` and a short buffer would be a
+    /// downstream panic rather than a visible defect.
+    #[test]
+    fn output_is_always_rgb24_sized() {
+        for (w, h) in [(640u32, 480u32), (1, 1), (2, 2), (17, 33), (320, 240)] {
+            let b = render(w, h, "cam1");
+            assert_eq!(b.len(), (w as usize) * (h as usize) * 3, "{w}x{h}");
+        }
+    }
+
+    /// Zero-sized geometry is degenerate but must not panic.
+    #[test]
+    fn zero_geometry_is_empty_not_a_panic() {
+        assert!(render(0, 0, "cam1").is_empty());
+        assert!(render(0, 10, "cam1").is_empty());
+    }
+
+    /// A placeholder must never be mistakable for a dark scene: the stripes
+    /// guarantee saturated magenta somewhere in the frame.
+    #[test]
+    fn is_visibly_not_a_dark_frame() {
+        let w = 320usize;
+        let b = render(320, 240, "cam1");
+        let has_magenta = (0..240).any(|y| (0..w).any(|x| px(&b, w, x, y) == MAGENTA));
+        assert!(has_magenta, "placeholder must be obviously synthetic");
+        assert!(b.iter().any(|&v| v > 0x80), "must not read as near-black");
+    }
+
+    /// Text is drawn for a normal-sized frame — the band and white pixels are
+    /// what tell an operator *which* camera died.
+    #[test]
+    fn draws_a_label_when_there_is_room() {
+        let w = 640usize;
+        let b = render(640, 480, "wrist");
+        let white = (0..480).any(|y| (0..w).any(|x| px(&b, w, x, y) == TEXT));
+        assert!(white, "expected label pixels");
+    }
+
+    /// Frames too small for a legible label degrade to bare stripes rather
+    /// than clipping glyphs into noise.
+    #[test]
+    fn tiny_frames_skip_the_label() {
+        let w = 2usize;
+        let b = render(2, 2, "cam1");
+        let white = (0..2).any(|y| (0..w).any(|x| px(&b, w, x, y) == TEXT));
+        assert!(!white, "no label should be attempted at 2x2");
+    }
+
+    /// Rendering is deterministic, which is what makes caching per (track,
+    /// geometry) safe.
+    #[test]
+    fn render_is_deterministic() {
+        assert_eq!(render(64, 64, "cam1"), render(64, 64, "cam1"));
+        assert_ne!(render(64, 64, "cam1"), render(64, 64, "cam2"));
+    }
+
+    /// A pathological track name must not panic or overrun the buffer.
+    #[test]
+    fn long_and_odd_names_are_contained() {
+        let b = render(320, 240, "a-very-long-track-name-that-keeps-going/…");
+        assert_eq!(b.len(), 320 * 240 * 3);
+    }
+}

--- a/livekit-portal/src/placeholder.rs
+++ b/livekit-portal/src/placeholder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Synthesized stand-in frames for `StallPolicy::Omit`.
+//! Synthesized stand-in frames for `StallBehavior::Omit`.
 //!
 //! When a track goes silent past its lag budget, `Omit` keeps the moment
 //! alive by substituting a frame that is obviously not camera output: magenta

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -415,8 +415,7 @@ impl Portal {
             return Err(PortalError::AlreadyConnected);
         }
 
-        static OTHER_SDKS_VALUE: &str =
-            concat!("portal:", env!("CARGO_PKG_VERSION"));
+        static OTHER_SDKS_VALUE: &str = concat!("portal:", env!("CARGO_PKG_VERSION"));
 
         let mut options = RoomOptions::default();
         options.sdk_options.other_sdks = Some(OTHER_SDKS_VALUE.to_string());
@@ -1297,6 +1296,7 @@ impl Portal {
             &self.all_track_names,
             self.config.state_schema.clone(),
             self.config.sync_config(),
+            self.config.stall_configs(&self.all_track_names),
             self.metrics.clone(),
         )));
         *self.sync_buffer.lock() = Some(sync_buffer);

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -82,9 +82,11 @@ struct MatchSlot {
     // set `last_emitted_frames[track] = frame`. If `None`, the frame is
     // the stored last-emitted fallback — buffer and pointer stay put.
     drain_to: Option<usize>,
-    // True iff the frame's |delta| from state_ts exceeds `search_range_us`
-    // (pure reuse, or a below-horizon drain-match).
-    stale: bool,
+    // How the frame relates to the state it is being attached to. `Live`
+    // for an in-range match; `Stale` for either reuse path (pure reuse or a
+    // below-horizon drain-match). Stamped onto the emitted frame so
+    // consumers can tell a measurement from a substitute.
+    source: FrameSource,
 }
 
 pub(crate) struct SyncBuffer {
@@ -97,6 +99,14 @@ pub(crate) struct SyncBuffer {
     /// reconstruct typed values into each `Observation` emitted.
     state_schema: Vec<FieldSpec>,
     config: SyncConfig,
+
+    // Per-track stall handling, parallel to `track_names`: how long to wait
+    // for a silent track and how to resolve the moment when the wait ends.
+    stall: Vec<StallConfig>,
+
+    // True iff any track has a finite `max_lag_us`. Lets the hot path skip
+    // computing `logical_now` entirely under the default config.
+    any_max_lag: bool,
 
     // Per-track cursor: the largest index whose frame ts is <= head state ts
     // (or 0 if all frames are > head ts). Advances monotonically with state_ts
@@ -132,10 +142,15 @@ pub(crate) struct SyncBuffer {
 }
 
 impl SyncBuffer {
+    /// `stall` is the per-track stall configuration, parallel to
+    /// `video_track_names`. A length mismatch (or an empty vec) falls back to
+    /// `config.default_stall` for every track, so test and embedding callers
+    /// that do not care can pass `Vec::new()`.
     pub fn new(
         video_track_names: &[String],
         state_schema: Vec<FieldSpec>,
         config: SyncConfig,
+        stall: Vec<StallConfig>,
         metrics: Arc<MetricsRegistry>,
     ) -> Self {
         let track_names: Vec<String> = video_track_names.to_vec();
@@ -146,6 +161,12 @@ impl SyncBuffer {
         let matched_scratch: Vec<Option<MatchSlot>> =
             (0..track_names.len()).map(|_| None).collect();
         let last_emitted_frames = vec![None; track_names.len()];
+        let stall = if stall.len() == track_names.len() {
+            stall
+        } else {
+            vec![config.default_stall; track_names.len()]
+        };
+        let any_max_lag = stall.iter().any(|s| s.max_lag_us.is_some());
         Self {
             track_names,
             track_index,
@@ -153,6 +174,8 @@ impl SyncBuffer {
             state_buffer: VecDeque::new(),
             state_schema,
             config,
+            stall,
+            any_max_lag,
             cursors,
             blocker: None,
             matched_scratch,
@@ -205,6 +228,31 @@ impl SyncBuffer {
         self.drop_warn.worst_ahead_us = 0;
     }
 
+    /// Largest sender timestamp currently buffered across every stream — the
+    /// newest state plus each track's newest frame. This is the "stream
+    /// clock" `max_lag` is measured against: it advances whenever *any*
+    /// stream is still flowing, so a track that has gone silent is detected
+    /// through the clocks of the tracks that have not.
+    ///
+    /// Reads only sender timestamps, never a wall clock, so stall decisions
+    /// stay reproducible and testable — the reason a wall-clock deadline was
+    /// rejected in the first place. The corollary is that this is not a
+    /// watchdog: if every stream goes silent the clock stops and nothing
+    /// resolves, which is harmless because nothing is being emitted either.
+    ///
+    /// Always `>= state_buffer[0]`, since the head is the front of
+    /// `state_buffer` and its back is `>=` its front. O(tracks), and only
+    /// called when at least one track has a finite `max_lag`.
+    fn logical_now(&self) -> u64 {
+        let mut now = self.state_buffer.back().map(|(ts, _)| *ts).unwrap_or(0);
+        for buf in &self.video_buffers {
+            if let Some(frame) = buf.back() {
+                now = now.max(frame.timestamp_us);
+            }
+        }
+        now
+    }
+
     /// Build the typed state map once per emission. Separate so the two
     /// call sites (overflow drop and sync emit) stay in lockstep, and
     /// distinctly named to avoid shadowing the conceptual "typed state"
@@ -240,11 +288,20 @@ impl SyncBuffer {
         // Skip try_sync when this push cannot have changed head-state matchability:
         //   - another track is blocking (a push to a non-blocker doesn't unblock it), AND
         //   - no eviction happened on this track (eviction can newly-transition a track
-        //     from matching → unmatchable, which must be checked).
+        //     from matching → unmatchable, which must be checked), AND
+        //   - no track has a finite `max_lag`.
+        //
+        // That last clause is what makes a stall resolve when a healthy track
+        // is the only thing still moving: a push to a *non-blocking* track
+        // advances the stream clock, which can carry the head past its lag
+        // budget even though this track was never the blocker. Skipping here
+        // would strand the head exactly in the case the budget exists to fix.
+        // It costs the blocker short-circuit whenever a budget is set, which
+        // is an O(tracks) early-return per frame — cheap next to decoding one.
         let should_run = match self.blocker {
             None => true,
             Some(b) if b == idx => true,
-            Some(_) => evicted > 0,
+            Some(_) => evicted > 0 || self.any_max_lag,
         };
 
         if should_run { self.try_sync() } else { SyncOutput::empty() }
@@ -328,18 +385,24 @@ impl SyncBuffer {
                 *slot = None;
             }
 
+            // Stream clock for `max_lag`, computed once per candidate state
+            // rather than per track. Skipped entirely when no track has a
+            // finite `max_lag`, which is the default.
+            let logical_now = if self.any_max_lag { self.logical_now() } else { 0 };
+
             // Per-iteration status. Priority: drop > wait > emit. We scan every
             // track (even after a wait-on-earlier-track) so that a drop-eligible
             // track later in the list can override the wait — otherwise a state
             // could stall forever waiting on cam1 while cam2 has already moved
             // beyond the match horizon.
             //
-            // When `reuse_stale_frames` is enabled, any track with a
-            // last-emitted frame short-circuits to stale reuse instead of
-            // waiting or dropping. The remaining wait/drop branches cover the
-            // startup window before a track has emitted for the first time,
-            // plus state-buffer overflow (handled in `push_state`) as the
-            // hard safety net against a fully halted video stream.
+            // A track that cannot match waits until either no future frame
+            // could match it or its `max_lag` elapses, then resolves per its
+            // `on_stall` policy. `Freeze` and `Omit` still wait through the
+            // startup window before the track's first frame, when they have
+            // nothing to substitute. State-buffer overflow (handled in
+            // `push_state`) remains the hard safety net against a fully
+            // halted video stream.
             let mut should_drop = false;
             // How far the video stream had moved past `state_ts` when the drop
             // fired (`newest_frame_ts - state_ts`). Captured for the warning so
@@ -401,71 +464,101 @@ impl SyncBuffer {
                     self.matched_scratch[track_i] = Some(MatchSlot {
                         frame: self.video_buffers[track_i][idx].clone(),
                         drain_to: Some(idx),
-                        stale: false,
+                        source: FrameSource::Live,
                     });
                     continue;
                 }
 
-                // No fresh in-range match. Under reuse, prefer the newest
-                // below-horizon buffered frame (ts ≤ state_ts, |Δ| ≥ range)
-                // over the stored last-emitted fallback: it tracks forward
-                // with state_ts so match_delta stays bounded, and draining
-                // it keeps the buffer from wedging at cap while a track is
-                // systematically behind. Since state_ts advances monotonically,
-                // no future state could fresh-match a frame with ts ≤ current
-                // state_ts − range, so consuming it now is safe.
+                // No fresh in-range match on this track. Two questions, in
+                // order: can waiting still help, and — if not, or if we have
+                // already waited long enough — how does this track's policy
+                // resolve the moment?
                 //
-                // Past-horizon frames (ts > state_ts) fall through to pure
-                // reuse so a later state can still claim them.
-                if self.config.reuse_stale_frames {
-                    if !frame_buf.is_empty() {
-                        let c = self.cursors[track_i];
-                        let cand = &frame_buf[c];
-                        if cand.timestamp_us <= state_ts && state_ts - cand.timestamp_us >= range {
-                            self.matched_scratch[track_i] = Some(MatchSlot {
-                                frame: cand.clone(),
-                                drain_to: Some(c),
-                                stale: true,
-                            });
-                            continue;
-                        }
-                    }
-                    if let Some(stale) = self.last_emitted_frames[track_i].clone() {
-                        self.matched_scratch[track_i] =
-                            Some(MatchSlot { frame: stale, drain_to: None, stale: true });
-                        continue;
-                    }
-                }
+                // Waiting cannot help once the newest buffered frame is
+                // already past the horizon: frame timestamps are monotonic,
+                // so every future frame is at least that new and none of them
+                // can match. (Testing the newest rather than the front
+                // detects this immediately, instead of only after eviction
+                // drags the tail past the horizon — a latency bug of up to
+                // `video_buffer_size` frames.) `>=` matches the strict
+                // `d < range` match rule: a frame at exactly `state_ts +
+                // range` is not a match, so the state cannot match it either.
+                let newest_ts = frame_buf.back().map(|f| f.timestamp_us);
+                let unmatchable = newest_ts.is_some_and(|n| n >= state_ts.saturating_add(range));
 
-                // Startup fallback: no reuse available. Empty buffer or below
-                // the horizon → wait (future frames may still match). Newest
-                // past the horizon → permanently unmatchable, drop. The drop
-                // path here only fires before the track's first emission;
-                // after that, reuse above handles it.
-                if frame_buf.is_empty() {
+                // Otherwise a future frame could still land in range, so we
+                // wait — but only until the fastest-advancing stream's sender
+                // clock has run `max_lag` past this moment. `None` keeps the
+                // historical behavior of waiting until state-buffer capacity
+                // evicts the moment (or forever, if state output has stopped
+                // too). See `logical_now`.
+                let stall = self.stall[track_i];
+                let lagged =
+                    stall.max_lag_us.is_some_and(|max| logical_now.saturating_sub(state_ts) >= max);
+
+                if !unmatchable && !lagged {
                     if iter_blocker.is_none() {
                         iter_blocker = Some(track_i);
                     }
                     continue;
                 }
 
-                // Unmatched, buffer non-empty. The real question is whether
-                // any *future* frame could match; since frame timestamps are
-                // monotonic, future ts ≥ back_ts, so the state is permanently
-                // unmatchable iff back_ts >= state_ts + range. (Checking the
-                // front would only detect the drop after eviction has dragged
-                // the old tail past the horizon — a latency bug of up to
-                // video_buffer_size frames.) `>=` matches the strict
-                // `d < range` match rule: a frame at exactly state_ts + range
-                // is not a match, so the state can't match it either.
-                let newest_ts = frame_buf.back().unwrap().timestamp_us;
-                if newest_ts >= state_ts.saturating_add(range) {
-                    should_drop = true;
-                    drop_ahead_us = newest_ts.saturating_sub(state_ts);
-                    break;
-                } else if iter_blocker.is_none() {
-                    iter_blocker = Some(track_i);
+                // Resolve without this track.
+                match stall.policy {
+                    // Prefer the newest below-horizon buffered frame
+                    // (ts ≤ state_ts, |Δ| ≥ range) over the stored
+                    // last-emitted fallback: it tracks forward with state_ts
+                    // so match_delta stays bounded, and draining it keeps the
+                    // buffer from wedging at cap while a track is
+                    // systematically behind. Since state_ts advances
+                    // monotonically, no future state could fresh-match a
+                    // frame with ts ≤ state_ts − range, so consuming it now is
+                    // safe. Past-horizon frames (ts > state_ts) are left for a
+                    // later state to claim, and we fall back to pure reuse.
+                    StallPolicy::Freeze => {
+                        if !frame_buf.is_empty() {
+                            let c = self.cursors[track_i];
+                            let cand = &frame_buf[c];
+                            if cand.timestamp_us <= state_ts
+                                && state_ts - cand.timestamp_us >= range
+                            {
+                                self.matched_scratch[track_i] = Some(MatchSlot {
+                                    frame: cand.clone(),
+                                    drain_to: Some(c),
+                                    source: FrameSource::Stale,
+                                });
+                                continue;
+                            }
+                        }
+                        if let Some(stale) = self.last_emitted_frames[track_i].clone() {
+                            self.matched_scratch[track_i] = Some(MatchSlot {
+                                frame: stale,
+                                drain_to: None,
+                                source: FrameSource::Stale,
+                            });
+                            continue;
+                        }
+                    }
+                    StallPolicy::Omit => {}
+                    StallPolicy::Drop => {}
                 }
+
+                // `Freeze` and `Omit` land here only before the track's first
+                // frame, with nothing to stand in with and no geometry to
+                // synthesize from. If a future frame could still match, keep
+                // waiting rather than discarding a moment we may yet be able
+                // to satisfy; that startup window is exactly the historical
+                // `reuse_stale_frames` behavior. Otherwise drop.
+                if !unmatchable && stall.policy != StallPolicy::Drop {
+                    if iter_blocker.is_none() {
+                        iter_blocker = Some(track_i);
+                    }
+                    continue;
+                }
+
+                should_drop = true;
+                drop_ahead_us = newest_ts.unwrap_or(logical_now).saturating_sub(state_ts);
+                break;
             }
 
             if should_drop {
@@ -494,7 +587,7 @@ impl SyncBuffer {
             for slot in &self.matched_scratch {
                 if let Some(s) = slot.as_ref() {
                     worst_delta = worst_delta.max(state_ts.abs_diff(s.frame.timestamp_us));
-                    if s.stale {
+                    if s.source == FrameSource::Stale {
                         any_stale = true;
                     }
                 }
@@ -526,8 +619,12 @@ impl SyncBuffer {
                     // last-emitted untouched so a future in-range frame can
                     // still be claimed by a later state.
                     //
-                    // Cheap clone: VideoFrameData carries Arc<[u8]>.
-                    frames_map.insert(self.track_names[track_i].clone(), (*slot.frame).clone());
+                    // Cheap clone: VideoFrameData carries Arc<[u8]>. The
+                    // buffered frame is always stored as `Live`; stamp how it
+                    // was actually used on the copy handed to the consumer.
+                    let mut frame = (*slot.frame).clone();
+                    frame.source = slot.source;
+                    frames_map.insert(self.track_names[track_i].clone(), frame);
                 }
             }
 
@@ -566,6 +663,7 @@ mod tests {
                 height: 2,
                 data: bytes::Bytes::from(vec![0u8; 12]),
                 timestamp_us: ts,
+                source: FrameSource::Live,
             }),
         )
     }
@@ -581,7 +679,7 @@ mod tests {
         // so the internal observation builder has a dtype per position.
         let schema: Vec<FieldSpec> =
             fields.into_iter().map(|n| FieldSpec::new(n, DType::F64)).collect();
-        SyncBuffer::new(names, schema, config, metrics)
+        SyncBuffer::new(names, schema, config, Vec::new(), metrics)
     }
 
     #[test]
@@ -966,7 +1064,7 @@ mod tests {
             video_buffer_size: 5,
             state_buffer_size: 5,
             search_range_us: 500,
-            reuse_stale_frames: true,
+            default_stall: StallConfig { max_lag_us: Some(0), policy: StallPolicy::Freeze },
         }
     }
 
@@ -1170,7 +1268,7 @@ mod tests {
             video_buffer_size: 5,
             state_buffer_size: 5,
             search_range_us: 100,
-            reuse_stale_frames: true,
+            default_stall: StallConfig { max_lag_us: Some(0), policy: StallPolicy::Freeze },
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -1209,7 +1307,7 @@ mod tests {
         let metrics = Arc::new(MetricsRegistry::new(&tracks));
         let schema: Vec<FieldSpec> =
             fields.into_iter().map(|n| FieldSpec::new(n, DType::F64)).collect();
-        let mut buf = SyncBuffer::new(&tracks, schema, reuse_config(), metrics.clone());
+        let mut buf = SyncBuffer::new(&tracks, schema, reuse_config(), Vec::new(), metrics.clone());
 
         // Fresh emission #1.
         let _ = buf.push_frame(
@@ -1219,6 +1317,7 @@ mod tests {
                 height: 2,
                 data: bytes::Bytes::from(vec![0u8; 12]),
                 timestamp_us: 1_000,
+                source: FrameSource::Live,
             }),
         );
         let _ = buf.push_state(1_050, vec![1.0]);
@@ -1231,6 +1330,7 @@ mod tests {
                 height: 2,
                 data: bytes::Bytes::from(vec![0u8; 12]),
                 timestamp_us: 2_000,
+                source: FrameSource::Live,
             }),
         );
         let _ = buf.push_state(2_050, vec![2.0]);
@@ -1325,5 +1425,247 @@ mod tests {
             total_obs += out3.observations.len();
         }
         assert_eq!(total_obs, 100);
+    }
+
+    // --- FrameSource tagging -------------------------------------------
+    //     Every frame handed to a consumer records how it was actually
+    //     used, so a single observation is self-describing: a policy can
+    //     tell a measurement from a substitute without consulting a
+    //     process-wide metric.
+
+    /// A frame matched inside the tolerance window is tagged `Live`.
+    #[test]
+    fn fresh_match_tagged_live() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, SyncConfig::default());
+
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let out = buf.push_state(1_000, vec![1.0]);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam1"].source, FrameSource::Live);
+    }
+
+    /// Reusing the last-emitted frame tags it `Stale`, and the frame keeps
+    /// its own timestamp so the consumer can compute the age itself.
+    #[test]
+    fn reused_last_frame_tagged_stale() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let out = buf.push_state(1_100, vec![1.0]);
+        assert_eq!(out.observations[0].frames["cam1"].source, FrameSource::Live);
+
+        // No new frame arrives; the next state reuses the 1_000 frame.
+        let out = buf.push_state(2_000, vec![2.0]);
+        assert_eq!(out.observations.len(), 1);
+        let f = &out.observations[0].frames["cam1"];
+        assert_eq!(f.source, FrameSource::Stale);
+        assert_eq!(f.timestamp_us, 1_000, "stale frame keeps its own ts");
+        assert_eq!(out.observations[0].timestamp_us, 2_000);
+    }
+
+    /// The buffered below-horizon reuse path is tagged `Stale` too, not just
+    /// the stored last-emitted fallback.
+    #[test]
+    fn below_horizon_reuse_tagged_stale() {
+        let tracks = vec!["cam1".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        // Establish a last-emitted frame.
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let _ = buf.push_state(1_100, vec![1.0]);
+
+        // A frame lands far below the next state's horizon: drained and
+        // reused rather than matched.
+        let _ = push_f(&mut buf, "cam1", 2_000);
+        let out = buf.push_state(9_000, vec![2.0]);
+        assert_eq!(out.observations.len(), 1);
+        let f = &out.observations[0].frames["cam1"];
+        assert_eq!(f.source, FrameSource::Stale);
+        assert_eq!(f.timestamp_us, 2_000, "drained the below-horizon frame");
+    }
+
+    /// Tagging is per-track: a live track stays `Live` in the same
+    /// observation where another track is reusing.
+    #[test]
+    fn source_is_per_track() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, reuse_config());
+
+        let _ = push_f(&mut buf, "cam1", 1_000);
+        let _ = push_f(&mut buf, "cam2", 1_000);
+        let out = buf.push_state(1_100, vec![1.0]);
+        assert_eq!(out.observations.len(), 1);
+
+        // cam1 keeps sending, cam2 goes silent.
+        let _ = push_f(&mut buf, "cam1", 2_000);
+        let out = buf.push_state(2_050, vec![2.0]);
+        assert_eq!(out.observations.len(), 1);
+        let frames = &out.observations[0].frames;
+        assert_eq!(frames["cam1"].source, FrameSource::Live);
+        assert_eq!(frames["cam2"].source, FrameSource::Stale);
+    }
+
+    // --- max_lag / on_stall ---------------------------------------------
+
+    fn stall_config(max_lag_us: Option<u64>, policy: StallPolicy) -> SyncConfig {
+        SyncConfig {
+            // Large buffers, so capacity eviction is never what resolves a
+            // moment in these tests — the lag budget is.
+            video_buffer_size: 100,
+            state_buffer_size: 100,
+            search_range_us: 1_000,
+            default_stall: StallConfig { max_lag_us, policy },
+        }
+    }
+
+    /// With no budget (the historical default), a head blocked by a silent
+    /// track waits however far the other streams run ahead. Guards the
+    /// backward-compatible path.
+    #[test]
+    fn no_max_lag_waits_indefinitely() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(None, StallPolicy::Drop));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        assert!(buf.push_state(10_000, vec![1.0]).is_empty(), "waits on cam2");
+
+        let out = buf.push_state(500_000, vec![2.0]);
+        assert!(out.observations.is_empty());
+        assert!(out.drops.is_empty(), "no budget → the head waits, never resolves");
+    }
+
+    /// The stream clock advances on *any* stream, so a head blocked by a
+    /// silent track resolves even when state output has stopped. Capacity
+    /// eviction can never reach this case: it only runs on `push_state`.
+    ///
+    /// Regression guard for the blocker short-circuit in `push_frame` — if
+    /// pushes to a non-blocking track skip `try_sync`, the budget never gets
+    /// evaluated and the head strands forever.
+    #[test]
+    fn max_lag_resolves_when_only_video_advances() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Drop));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        assert!(buf.push_state(10_000, vec![1.0]).is_empty(), "waits on cam2");
+
+        // No further states at all. cam1 keeps sending; the stream clock
+        // crosses the 50ms budget and the head resolves on a frame push.
+        let out = push_f(&mut buf, "cam1", 70_000);
+        assert_eq!(out.drops.len(), 1, "budget resolved the stranded head");
+        assert!(out.observations.is_empty());
+        assert_eq!(buf.metrics.snapshot(HashMap::new(), 0).sync.states_dropped, 1);
+    }
+
+    /// A budget never resolves a moment that still has an in-range match on
+    /// every track — no spurious drops during normal operation.
+    #[test]
+    fn max_lag_does_not_touch_matched_states() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(1), StallPolicy::Drop));
+
+        for i in 0..20u64 {
+            let ts = 10_000 + i * 10_000;
+            let _ = push_f(&mut buf, "cam1", ts);
+            let _ = push_f(&mut buf, "cam2", ts);
+            let out = buf.push_state(ts, vec![i as f64]);
+            assert_eq!(out.observations.len(), 1, "tick {i} must emit");
+            assert!(out.drops.is_empty(), "tick {i} must not drop");
+        }
+    }
+
+    /// `Freeze` resolves a stalled track with its last good frame, so the
+    /// healthy tracks and the state keep flowing.
+    #[test]
+    fn freeze_keeps_observations_flowing() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Freeze));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let _ = push_f(&mut buf, "cam2", 10_000);
+        assert_eq!(buf.push_state(10_000, vec![1.0]).observations.len(), 1);
+
+        // cam2 goes silent. The next moment is still inside its budget — it
+        // has only just arrived — so it waits rather than resolving early.
+        let _ = push_f(&mut buf, "cam1", 70_000);
+        let out = buf.push_state(70_000, vec![2.0]);
+        assert!(out.observations.is_empty(), "still inside the budget");
+
+        // cam1 carries the stream clock 60ms past that moment, over the 50ms
+        // budget. It now resolves with cam2 frozen rather than discarded.
+        let out = push_f(&mut buf, "cam1", 130_000);
+        assert_eq!(out.observations.len(), 1, "freeze keeps the moment");
+        let frames = &out.observations[0].frames;
+        assert_eq!(frames["cam1"].source, FrameSource::Live);
+        assert_eq!(frames["cam1"].timestamp_us, 70_000);
+        assert_eq!(frames["cam2"].source, FrameSource::Stale);
+        assert_eq!(frames["cam2"].timestamp_us, 10_000, "cam2's last good frame");
+    }
+
+    /// Policies are per track: a `Drop` track and a `Freeze` track in the
+    /// same buffer resolve independently.
+    #[test]
+    fn stall_policy_is_per_track() {
+        let tracks = vec!["wrist".to_string(), "scene".to_string()];
+        let config = stall_config(Some(50_000), StallPolicy::Drop);
+        let metrics = Arc::new(MetricsRegistry::new(&tracks));
+        let schema = vec![FieldSpec::new("j1".to_string(), DType::F64)];
+        // wrist is load-bearing: no observation beats a wrong one. scene is
+        // not: freeze it rather than losing the moment.
+        let stall = vec![
+            StallConfig { max_lag_us: Some(50_000), policy: StallPolicy::Drop },
+            StallConfig { max_lag_us: Some(50_000), policy: StallPolicy::Freeze },
+        ];
+        let mut buf = SyncBuffer::new(&tracks, schema, config, stall, metrics);
+
+        let _ = push_f(&mut buf, "wrist", 10_000);
+        let _ = push_f(&mut buf, "scene", 10_000);
+        assert_eq!(buf.push_state(10_000, vec![1.0]).observations.len(), 1);
+
+        // scene stalls. wrist carries the clock past the budget, and scene's
+        // Freeze policy keeps the moment alive.
+        let _ = push_f(&mut buf, "wrist", 70_000);
+        assert!(buf.push_state(70_000, vec![2.0]).observations.is_empty());
+        let out = push_f(&mut buf, "wrist", 130_000);
+        assert_eq!(out.observations.len(), 1, "scene freezes, moment survives");
+        assert_eq!(out.observations[0].frames["scene"].source, FrameSource::Stale);
+
+        // Now the reverse: wrist stalls while scene carries the clock. Its
+        // Drop policy discards the moment rather than substituting.
+        let _ = push_f(&mut buf, "scene", 200_000);
+        assert!(buf.push_state(200_000, vec![3.0]).observations.is_empty());
+        let out = push_f(&mut buf, "scene", 260_000);
+        assert!(out.observations.is_empty(), "wrist is load-bearing");
+        assert_eq!(out.drops.len(), 1, "moment discarded rather than faked");
+    }
+
+    /// `Freeze` still waits through the startup window: before a track's
+    /// first frame there is nothing to substitute, and a future frame could
+    /// still match, so the moment is held rather than discarded.
+    #[test]
+    fn freeze_waits_before_first_frame() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallPolicy::Freeze));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let out = buf.push_state(10_000, vec![1.0]);
+        assert!(out.observations.is_empty(), "cam2 has never sent");
+        assert!(out.drops.is_empty(), "and nothing is discarded yet");
+
+        // cam2's first frame arrives in range: the held moment now emits.
+        let out = push_f(&mut buf, "cam2", 10_000);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam2"].source, FrameSource::Live);
     }
 }

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -16,8 +16,11 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
+
 use crate::config::FieldSpec;
 use crate::metrics::MetricsRegistry;
+use crate::placeholder;
 use crate::types::*;
 
 #[cfg(test)]
@@ -100,6 +103,13 @@ pub(crate) struct SyncBuffer {
     state_schema: Vec<FieldSpec>,
     config: SyncConfig,
 
+    // Per-track cached placeholder pixels for `on_stall: omit`, with the
+    // geometry they were rendered for. Rebuilt only when a track's frame
+    // size changes, so a silent track costs one render rather than one per
+    // observation — the buffer is `W*H*3` and would otherwise be re-synthesized
+    // at the state rate for as long as the track stays down.
+    placeholders: Vec<Option<(u32, u32, Bytes)>>,
+
     // Per-track stall handling, parallel to `track_names`: how long to wait
     // for a silent track and how to resolve the moment when the wait ends.
     stall: Vec<StallConfig>,
@@ -167,6 +177,7 @@ impl SyncBuffer {
             vec![config.default_stall; track_names.len()]
         };
         let any_max_lag = stall.iter().any(|s| s.max_lag_us.is_some());
+        let placeholders = vec![None; track_names.len()];
         Self {
             track_names,
             track_index,
@@ -174,6 +185,7 @@ impl SyncBuffer {
             state_buffer: VecDeque::new(),
             state_schema,
             config,
+            placeholders,
             stall,
             any_max_lag,
             cursors,
@@ -251,6 +263,29 @@ impl SyncBuffer {
             }
         }
         now
+    }
+
+    /// Cached placeholder pixels for one track at one geometry.
+    ///
+    /// Free function over the cache slot rather than a `&mut self` method so
+    /// it can be called while the track's frame buffer is borrowed. Rendering
+    /// is deterministic, so caching on `(width, height)` is sound; a track
+    /// that renegotiates resolution simply re-renders once.
+    fn placeholder_pixels(
+        slot: &mut Option<(u32, u32, Bytes)>,
+        track_name: &str,
+        width: u32,
+        height: u32,
+    ) -> Bytes {
+        if let Some((w, h, data)) = slot
+            && *w == width
+            && *h == height
+        {
+            return data.clone();
+        }
+        let data = placeholder::render(width, height, track_name);
+        *slot = Some((width, height, data.clone()));
+        data
     }
 
     /// Build the typed state map once per emission. Separate so the two
@@ -358,6 +393,9 @@ impl SyncBuffer {
             *c = 0;
         }
         for slot in &mut self.last_emitted_frames {
+            *slot = None;
+        }
+        for slot in &mut self.placeholders {
             *slot = None;
         }
         self.blocker = None;
@@ -539,7 +577,38 @@ impl SyncBuffer {
                             continue;
                         }
                     }
-                    StallPolicy::Omit => {}
+                    // Keep the moment alive with a stand-in, so the healthy
+                    // tracks and the state still reach the consumer. Geometry
+                    // and recency both come from the track's last real frame:
+                    // without one there is nothing to size a placeholder
+                    // from, and reusing its timestamp keeps `match_delta`
+                    // reporting the true age of the newest real pixels rather
+                    // than a flattering zero.
+                    StallPolicy::Omit => {
+                        if let Some(last) = self.last_emitted_frames[track_i].clone() {
+                            let data = Self::placeholder_pixels(
+                                &mut self.placeholders[track_i],
+                                &self.track_names[track_i],
+                                last.width,
+                                last.height,
+                            );
+                            self.matched_scratch[track_i] = Some(MatchSlot {
+                                frame: Arc::new(VideoFrameData {
+                                    width: last.width,
+                                    height: last.height,
+                                    data,
+                                    timestamp_us: last.timestamp_us,
+                                    source: FrameSource::Omitted,
+                                }),
+                                drain_to: None,
+                                source: FrameSource::Omitted,
+                            });
+                            if let Some(tm) = self.metrics.track(&self.track_names[track_i]) {
+                                tm.record_frame_omitted();
+                            }
+                            continue;
+                        }
+                    }
                     StallPolicy::Drop => {}
                 }
 
@@ -1665,6 +1734,142 @@ mod tests {
 
         // cam2's first frame arrives in range: the held moment now emits.
         let out = push_f(&mut buf, "cam2", 10_000);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam2"].source, FrameSource::Live);
+    }
+
+    // --- on_stall: omit --------------------------------------------------
+
+    /// The point of `Omit`: one silent camera must not blank the others.
+    /// Under `Drop` this same sequence yields no observation at all, so the
+    /// operator loses every camera because one died.
+    #[test]
+    fn omit_keeps_healthy_tracks_visible() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let _ = push_f(&mut buf, "cam2", 10_000);
+        assert_eq!(buf.push_state(10_000, vec![1.0]).observations.len(), 1);
+
+        // cam2 dies. cam1 carries the clock past the budget.
+        let _ = push_f(&mut buf, "cam1", 70_000);
+        assert!(buf.push_state(70_000, vec![2.0]).observations.is_empty());
+        let out = push_f(&mut buf, "cam1", 130_000);
+
+        assert_eq!(out.observations.len(), 1, "the moment survives");
+        let frames = &out.observations[0].frames;
+        assert_eq!(frames["cam1"].source, FrameSource::Live, "healthy camera still live");
+        assert_eq!(frames["cam2"].source, FrameSource::Omitted);
+        assert_eq!(frames.len(), 2, "every declared track still has a key");
+    }
+
+    /// The key is never removed, so `frames[name]` cannot start failing when
+    /// a camera dies — the reason a placeholder is substituted rather than
+    /// the entry dropped.
+    #[test]
+    fn omit_never_removes_the_key() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallPolicy::Omit));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let _ = push_f(&mut buf, "cam2", 10_000);
+        assert_eq!(buf.push_state(10_000, vec![1.0]).observations.len(), 1);
+
+        for i in 1..5u64 {
+            let ts = 10_000 + i * 60_000;
+            let _ = push_f(&mut buf, "cam1", ts);
+            let _ = buf.push_state(ts, vec![i as f64]);
+            let out = push_f(&mut buf, "cam1", ts + 60_000);
+            for obs in &out.observations {
+                assert!(obs.frames.contains_key("cam2"), "cam2 key present at tick {i}");
+            }
+        }
+    }
+
+    /// A placeholder carries the last real frame's timestamp, not the
+    /// state's: `match_delta` must report how stale the newest real pixels
+    /// are, not a flattering zero.
+    #[test]
+    fn omit_frame_reports_real_recency() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let _ = push_f(&mut buf, "cam2", 10_000);
+        let _ = buf.push_state(10_000, vec![1.0]);
+
+        let _ = push_f(&mut buf, "cam1", 70_000);
+        assert!(buf.push_state(70_000, vec![2.0]).observations.is_empty());
+        let out = push_f(&mut buf, "cam1", 130_000);
+        let f = &out.observations[0].frames["cam2"];
+        assert_eq!(f.timestamp_us, 10_000, "last real frame's ts, not the state's");
+        assert_eq!(f.width, 2, "geometry inherited from the real frame");
+        assert_eq!(f.height, 2);
+    }
+
+    /// Omission is counted per track, so ops can tell which camera is down
+    /// without diffing key sets.
+    #[test]
+    fn omit_is_counted_per_track() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let _ = push_f(&mut buf, "cam2", 10_000);
+        let _ = buf.push_state(10_000, vec![1.0]);
+        let _ = push_f(&mut buf, "cam1", 70_000);
+        let _ = buf.push_state(70_000, vec![2.0]);
+        let _ = push_f(&mut buf, "cam1", 130_000);
+
+        let snap = buf.metrics.snapshot(HashMap::new(), 0);
+        assert_eq!(snap.sync.frames_omitted.get("cam2"), Some(&1));
+        assert_eq!(snap.sync.frames_omitted.get("cam1"), Some(&0), "healthy track untouched");
+    }
+
+    /// Before a track's first frame there is no geometry to synthesize from,
+    /// so `Omit` waits like the others rather than inventing a size.
+    #[test]
+    fn omit_waits_before_first_frame() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallPolicy::Omit));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let out = buf.push_state(10_000, vec![1.0]);
+        assert!(out.observations.is_empty(), "cam2 has never sent");
+        assert!(out.drops.is_empty(), "and nothing is discarded yet");
+
+        let out = push_f(&mut buf, "cam2", 10_000);
+        assert_eq!(out.observations.len(), 1);
+        assert_eq!(out.observations[0].frames["cam2"].source, FrameSource::Live);
+    }
+
+    /// A recovering track goes straight back to `Live` — the placeholder is
+    /// not sticky.
+    #[test]
+    fn omit_recovers_when_the_track_returns() {
+        let tracks = vec!["cam1".to_string(), "cam2".to_string()];
+        let fields = vec!["j1".to_string()];
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+
+        let _ = push_f(&mut buf, "cam1", 10_000);
+        let _ = push_f(&mut buf, "cam2", 10_000);
+        let _ = buf.push_state(10_000, vec![1.0]);
+
+        let _ = push_f(&mut buf, "cam1", 70_000);
+        assert!(buf.push_state(70_000, vec![2.0]).observations.is_empty());
+        let out = push_f(&mut buf, "cam1", 130_000);
+        assert_eq!(out.observations[0].frames["cam2"].source, FrameSource::Omitted);
+
+        // cam2 comes back in range of the next moment.
+        let _ = push_f(&mut buf, "cam1", 200_000);
+        let _ = push_f(&mut buf, "cam2", 200_000);
+        let out = buf.push_state(200_000, vec![3.0]);
         assert_eq!(out.observations.len(), 1);
         assert_eq!(out.observations[0].frames["cam2"].source, FrameSource::Live);
     }

--- a/livekit-portal/src/sync_buffer.rs
+++ b/livekit-portal/src/sync_buffer.rs
@@ -103,7 +103,7 @@ pub(crate) struct SyncBuffer {
     state_schema: Vec<FieldSpec>,
     config: SyncConfig,
 
-    // Per-track cached placeholder pixels for `on_stall: omit`, with the
+    // Per-track cached placeholder pixels for `stall_behavior: omit`, with the
     // geometry they were rendered for. Rebuilt only when a track's frame
     // size changes, so a silent track costs one render rather than one per
     // observation — the buffer is `W*H*3` and would otherwise be re-synthesized
@@ -436,7 +436,7 @@ impl SyncBuffer {
             //
             // A track that cannot match waits until either no future frame
             // could match it or its `max_lag` elapses, then resolves per its
-            // `on_stall` policy. `Freeze` and `Omit` still wait through the
+            // `stall_behavior` policy. `Freeze` and `Omit` still wait through the
             // startup window before the track's first frame, when they have
             // nothing to substitute. State-buffer overflow (handled in
             // `push_state`) remains the hard safety net against a fully
@@ -542,7 +542,7 @@ impl SyncBuffer {
                 }
 
                 // Resolve without this track.
-                match stall.policy {
+                match stall.behavior {
                     // Prefer the newest below-horizon buffered frame
                     // (ts ≤ state_ts, |Δ| ≥ range) over the stored
                     // last-emitted fallback: it tracks forward with state_ts
@@ -553,7 +553,7 @@ impl SyncBuffer {
                     // frame with ts ≤ state_ts − range, so consuming it now is
                     // safe. Past-horizon frames (ts > state_ts) are left for a
                     // later state to claim, and we fall back to pure reuse.
-                    StallPolicy::Freeze => {
+                    StallBehavior::Freeze => {
                         if !frame_buf.is_empty() {
                             let c = self.cursors[track_i];
                             let cand = &frame_buf[c];
@@ -584,7 +584,7 @@ impl SyncBuffer {
                     // from, and reusing its timestamp keeps `match_delta`
                     // reporting the true age of the newest real pixels rather
                     // than a flattering zero.
-                    StallPolicy::Omit => {
+                    StallBehavior::Omit => {
                         if let Some(last) = self.last_emitted_frames[track_i].clone() {
                             let data = Self::placeholder_pixels(
                                 &mut self.placeholders[track_i],
@@ -609,7 +609,7 @@ impl SyncBuffer {
                             continue;
                         }
                     }
-                    StallPolicy::Drop => {}
+                    StallBehavior::Drop => {}
                 }
 
                 // `Freeze` and `Omit` land here only before the track's first
@@ -618,7 +618,7 @@ impl SyncBuffer {
                 // waiting rather than discarding a moment we may yet be able
                 // to satisfy; that startup window is exactly the historical
                 // `reuse_stale_frames` behavior. Otherwise drop.
-                if !unmatchable && stall.policy != StallPolicy::Drop {
+                if !unmatchable && stall.behavior != StallBehavior::Drop {
                     if iter_blocker.is_none() {
                         iter_blocker = Some(track_i);
                     }
@@ -1133,7 +1133,7 @@ mod tests {
             video_buffer_size: 5,
             state_buffer_size: 5,
             search_range_us: 500,
-            default_stall: StallConfig { max_lag_us: Some(0), policy: StallPolicy::Freeze },
+            default_stall: StallConfig { max_lag_us: Some(0), behavior: StallBehavior::Freeze },
         }
     }
 
@@ -1337,7 +1337,7 @@ mod tests {
             video_buffer_size: 5,
             state_buffer_size: 5,
             search_range_us: 100,
-            default_stall: StallConfig { max_lag_us: Some(0), policy: StallPolicy::Freeze },
+            default_stall: StallConfig { max_lag_us: Some(0), behavior: StallBehavior::Freeze },
         };
         let mut buf = mk(&tracks, fields, config);
 
@@ -1582,14 +1582,14 @@ mod tests {
 
     // --- max_lag / on_stall ---------------------------------------------
 
-    fn stall_config(max_lag_us: Option<u64>, policy: StallPolicy) -> SyncConfig {
+    fn stall_config(max_lag_us: Option<u64>, behavior: StallBehavior) -> SyncConfig {
         SyncConfig {
             // Large buffers, so capacity eviction is never what resolves a
             // moment in these tests — the lag budget is.
             video_buffer_size: 100,
             state_buffer_size: 100,
             search_range_us: 1_000,
-            default_stall: StallConfig { max_lag_us, policy },
+            default_stall: StallConfig { max_lag_us, behavior },
         }
     }
 
@@ -1600,7 +1600,7 @@ mod tests {
     fn no_max_lag_waits_indefinitely() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(None, StallPolicy::Drop));
+        let mut buf = mk(&tracks, fields, stall_config(None, StallBehavior::Drop));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         assert!(buf.push_state(10_000, vec![1.0]).is_empty(), "waits on cam2");
@@ -1621,7 +1621,7 @@ mod tests {
     fn max_lag_resolves_when_only_video_advances() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Drop));
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallBehavior::Drop));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         assert!(buf.push_state(10_000, vec![1.0]).is_empty(), "waits on cam2");
@@ -1640,7 +1640,7 @@ mod tests {
     fn max_lag_does_not_touch_matched_states() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(1), StallPolicy::Drop));
+        let mut buf = mk(&tracks, fields, stall_config(Some(1), StallBehavior::Drop));
 
         for i in 0..20u64 {
             let ts = 10_000 + i * 10_000;
@@ -1658,7 +1658,7 @@ mod tests {
     fn freeze_keeps_observations_flowing() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Freeze));
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallBehavior::Freeze));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let _ = push_f(&mut buf, "cam2", 10_000);
@@ -1684,16 +1684,16 @@ mod tests {
     /// Policies are per track: a `Drop` track and a `Freeze` track in the
     /// same buffer resolve independently.
     #[test]
-    fn stall_policy_is_per_track() {
+    fn stall_behavior_is_per_track() {
         let tracks = vec!["wrist".to_string(), "scene".to_string()];
-        let config = stall_config(Some(50_000), StallPolicy::Drop);
+        let config = stall_config(Some(50_000), StallBehavior::Drop);
         let metrics = Arc::new(MetricsRegistry::new(&tracks));
         let schema = vec![FieldSpec::new("j1".to_string(), DType::F64)];
         // wrist is load-bearing: no observation beats a wrong one. scene is
         // not: freeze it rather than losing the moment.
         let stall = vec![
-            StallConfig { max_lag_us: Some(50_000), policy: StallPolicy::Drop },
-            StallConfig { max_lag_us: Some(50_000), policy: StallPolicy::Freeze },
+            StallConfig { max_lag_us: Some(50_000), behavior: StallBehavior::Drop },
+            StallConfig { max_lag_us: Some(50_000), behavior: StallBehavior::Freeze },
         ];
         let mut buf = SyncBuffer::new(&tracks, schema, config, stall, metrics);
 
@@ -1725,7 +1725,7 @@ mod tests {
     fn freeze_waits_before_first_frame() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallPolicy::Freeze));
+        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallBehavior::Freeze));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let out = buf.push_state(10_000, vec![1.0]);
@@ -1738,7 +1738,7 @@ mod tests {
         assert_eq!(out.observations[0].frames["cam2"].source, FrameSource::Live);
     }
 
-    // --- on_stall: omit --------------------------------------------------
+    // --- stall_behavior: omit --------------------------------------------------
 
     /// The point of `Omit`: one silent camera must not blank the others.
     /// Under `Drop` this same sequence yields no observation at all, so the
@@ -1747,7 +1747,7 @@ mod tests {
     fn omit_keeps_healthy_tracks_visible() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallBehavior::Omit));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let _ = push_f(&mut buf, "cam2", 10_000);
@@ -1772,7 +1772,7 @@ mod tests {
     fn omit_never_removes_the_key() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallPolicy::Omit));
+        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallBehavior::Omit));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let _ = push_f(&mut buf, "cam2", 10_000);
@@ -1796,7 +1796,7 @@ mod tests {
     fn omit_frame_reports_real_recency() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallBehavior::Omit));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let _ = push_f(&mut buf, "cam2", 10_000);
@@ -1817,7 +1817,7 @@ mod tests {
     fn omit_is_counted_per_track() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallBehavior::Omit));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let _ = push_f(&mut buf, "cam2", 10_000);
@@ -1837,7 +1837,7 @@ mod tests {
     fn omit_waits_before_first_frame() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallPolicy::Omit));
+        let mut buf = mk(&tracks, fields, stall_config(Some(0), StallBehavior::Omit));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let out = buf.push_state(10_000, vec![1.0]);
@@ -1855,7 +1855,7 @@ mod tests {
     fn omit_recovers_when_the_track_returns() {
         let tracks = vec!["cam1".to_string(), "cam2".to_string()];
         let fields = vec!["j1".to_string()];
-        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallPolicy::Omit));
+        let mut buf = mk(&tracks, fields, stall_config(Some(50_000), StallBehavior::Omit));
 
         let _ = push_f(&mut buf, "cam1", 10_000);
         let _ = push_f(&mut buf, "cam2", 10_000);

--- a/livekit-portal/src/types.rs
+++ b/livekit-portal/src/types.rs
@@ -248,6 +248,30 @@ pub struct Observation {
     pub timestamp_us: u64,
 }
 
+/// Where the pixels in a delivered frame came from. Frames arriving on the
+/// raw video callbacks are always `Live`; the other two variants only ever
+/// appear on frames inside an [`Observation`], where the sync buffer had to
+/// resolve a track that could not be matched within its `max_lag` (see
+/// `on_stall` in [`PortalConfig`](crate::PortalConfig)).
+///
+/// Check this before feeding an observation to a policy or writing it to a
+/// dataset: `Stale` and `Omitted` frames are not measurements of the moment
+/// they are attached to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameSource {
+    /// A real frame matched to this state within the tolerance window.
+    Live,
+    /// A real frame, but from an earlier moment — the track's last good
+    /// frame, reused because nothing in range arrived (`on_stall: freeze`).
+    /// `timestamp_us` is the frame's own, so the age is
+    /// `observation.timestamp_us - frame.timestamp_us`.
+    Stale,
+    /// Not a camera frame at all: a synthesized placeholder standing in for
+    /// a track that went silent (`on_stall: omit`). The key is still present
+    /// so `frames[name]` never fails; the pixels carry a visible pattern.
+    Omitted,
+}
+
 /// Decoded video frame. `data` is packed RGB24 (R,G,B byte order, `W*H*3`
 /// bytes) regardless of transport — WebRTC frames are color-converted from
 /// I420 on receive, frame-video frames are decoded back to RGB by the
@@ -263,6 +287,53 @@ pub struct VideoFrameData {
     pub height: u32,
     pub data: Bytes,
     pub timestamp_us: u64,
+    /// Whether these pixels are a live match, a reused earlier frame, or a
+    /// synthesized placeholder. Always `Live` outside of `Observation`.
+    pub source: FrameSource,
+}
+
+/// What to do with a moment whose video track has gone silent past its
+/// `max_lag`. Set per track via
+/// [`set_on_stall`](crate::PortalConfig::set_on_stall).
+///
+/// All three are terminal: they describe how the moment is resolved once
+/// the wait is over, not something that happens during it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StallPolicy {
+    /// Emit no observation. The state is still delivered, on the drop
+    /// callback. Nothing is fabricated — but the healthy tracks in that
+    /// moment are discarded along with the silent one.
+    #[default]
+    Drop,
+    /// Emit with the track's last good frame, tagged
+    /// [`FrameSource::Stale`]. Video freezes on that track while state
+    /// keeps flowing. Falls back to `Drop` before the track's first frame,
+    /// when there is nothing to reuse.
+    Freeze,
+    /// Emit with a synthesized placeholder for the silent track, tagged
+    /// [`FrameSource::Omitted`]. The map key is still present, so
+    /// `frames[name]` never fails. Falls back to `Drop` before the track's
+    /// first frame, when its frame geometry is not yet known.
+    Omit,
+}
+
+/// Per-track stall handling: how long to wait for a silent track, and how
+/// to resolve the moment when the wait is over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct StallConfig {
+    /// How far the fastest-advancing stream may run past a moment — in
+    /// sender-clock microseconds, never wall-clock — before that moment is
+    /// resolved without this track.
+    ///
+    /// Evaluated when a packet arrives, not on a timer: if every stream
+    /// goes silent nothing fires, because nothing is being emitted anyway.
+    /// `None` (the default here) keeps the historical behavior of waiting
+    /// until state-buffer capacity evicts the moment;
+    /// [`PortalConfig`](crate::PortalConfig) derives a concrete value from
+    /// `slack` and `fps` instead. `Some(0)` resolves immediately, without
+    /// ever waiting.
+    pub max_lag_us: Option<u64>,
+    pub policy: StallPolicy,
 }
 
 /// Internal sync configuration, derived from `PortalConfig` knobs.
@@ -271,13 +342,9 @@ pub struct SyncConfig {
     pub video_buffer_size: u32,
     pub state_buffer_size: u32,
     pub search_range_us: u64,
-    /// When true, a state whose video match window has elapsed reuses the
-    /// most recently emitted frame on that track instead of being dropped.
-    /// Video effectively "freezes" during frame loss while state keeps
-    /// flowing — every state becomes an observation once every track has
-    /// emitted at least once. Default is `false`, preserving the strict
-    /// drop-on-horizon behavior.
-    pub reuse_stale_frames: bool,
+    /// Stall handling for tracks with no per-track override. Defaults to
+    /// the historical strict behavior: wait for capacity, then drop.
+    pub default_stall: StallConfig,
 }
 
 impl Default for SyncConfig {
@@ -286,7 +353,7 @@ impl Default for SyncConfig {
             video_buffer_size: 5,    // ~83ms at 60fps
             state_buffer_size: 5,    // ~83ms at 60fps
             search_range_us: 10_000, // 10ms — half a frame interval at 60fps
-            reuse_stale_frames: false,
+            default_stall: StallConfig { max_lag_us: None, policy: StallPolicy::Drop },
         }
     }
 }

--- a/livekit-portal/src/types.rs
+++ b/livekit-portal/src/types.rs
@@ -252,7 +252,7 @@ pub struct Observation {
 /// raw video callbacks are always `Live`; the other two variants only ever
 /// appear on frames inside an [`Observation`], where the sync buffer had to
 /// resolve a track that could not be matched within its `max_lag` (see
-/// `on_stall` in [`PortalConfig`](crate::PortalConfig)).
+/// `stall_behavior` in [`PortalConfig`](crate::PortalConfig)).
 ///
 /// Check this before feeding an observation to a policy or writing it to a
 /// dataset: `Stale` and `Omitted` frames are not measurements of the moment
@@ -262,12 +262,12 @@ pub enum FrameSource {
     /// A real frame matched to this state within the tolerance window.
     Live,
     /// A real frame, but from an earlier moment — the track's last good
-    /// frame, reused because nothing in range arrived (`on_stall: freeze`).
+    /// frame, reused because nothing in range arrived (`stall_behavior: freeze`).
     /// `timestamp_us` is the frame's own, so the age is
     /// `observation.timestamp_us - frame.timestamp_us`.
     Stale,
     /// Not a camera frame at all: a synthesized placeholder standing in for
-    /// a track that went silent (`on_stall: omit`). The key is still present
+    /// a track that went silent (`stall_behavior: omit`). The key is still present
     /// so `frames[name]` never fails; the pixels carry a visible pattern.
     Omitted,
 }
@@ -294,12 +294,12 @@ pub struct VideoFrameData {
 
 /// What to do with a moment whose video track has gone silent past its
 /// `max_lag`. Set per track via
-/// [`set_on_stall`](crate::PortalConfig::set_on_stall).
+/// [`set_stall_behavior`](crate::PortalConfig::set_stall_behavior).
 ///
 /// All three are terminal: they describe how the moment is resolved once
 /// the wait is over, not something that happens during it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum StallPolicy {
+pub enum StallBehavior {
     /// Emit no observation. The state is still delivered, on the drop
     /// callback. Nothing is fabricated — but the healthy tracks in that
     /// moment are discarded along with the silent one.
@@ -333,7 +333,7 @@ pub struct StallConfig {
     /// `slack` and `fps` instead. `Some(0)` resolves immediately, without
     /// ever waiting.
     pub max_lag_us: Option<u64>,
-    pub policy: StallPolicy,
+    pub behavior: StallBehavior,
 }
 
 /// Internal sync configuration, derived from `PortalConfig` knobs.
@@ -353,7 +353,7 @@ impl Default for SyncConfig {
             video_buffer_size: 5,    // ~83ms at 60fps
             state_buffer_size: 5,    // ~83ms at 60fps
             search_range_us: 10_000, // 10ms — half a frame interval at 60fps
-            default_stall: StallConfig { max_lag_us: None, policy: StallPolicy::Drop },
+            default_stall: StallConfig { max_lag_us: None, behavior: StallBehavior::Drop },
         }
     }
 }

--- a/livekit-portal/src/video.rs
+++ b/livekit-portal/src/video.rs
@@ -37,7 +37,7 @@ use crate::error::{PortalError, PortalResult};
 use crate::metrics::TrackMetrics;
 use crate::portal::ObservationSink;
 use crate::sync_buffer::SyncBuffer;
-use crate::types::VideoFrameData;
+use crate::types::{FrameSource, VideoFrameData};
 
 const DEFAULT_WIDTH: u32 = 640;
 const DEFAULT_HEIGHT: u32 = 480;
@@ -157,7 +157,8 @@ impl VideoPublisher {
         let mut buffer = I420Buffer::new(width, height);
         rgb_to_i420(rgb_data, width, height, &mut buffer);
         let mut frame = VideoFrame::new(VideoRotation::VideoRotation0, buffer);
-        frame.frame_metadata = Some(FrameMetadata { user_timestamp: Some(ts), frame_id: None, user_data: None });
+        frame.frame_metadata =
+            Some(FrameMetadata { user_timestamp: Some(ts), frame_id: None, user_data: None });
         self.source.capture_frame(&frame);
         self.metrics.record_sent();
         Ok(())
@@ -415,7 +416,13 @@ fn convert_frame<T: AsRef<dyn VideoBuffer>>(
         );
         buf.set_len(total);
     }
-    VideoFrameData { width, height, data: Bytes::from(buf), timestamp_us }
+    VideoFrameData {
+        width,
+        height,
+        data: Bytes::from(buf),
+        timestamp_us,
+        source: FrameSource::Live,
+    }
 }
 
 // RGB24 (R,G,B byte order) -> I420 via libyuv. libyuv's `RAW` format is R,G,B;
@@ -456,6 +463,7 @@ mod tests {
             height: 2,
             data: Bytes::from_static(&[0u8; 12]),
             timestamp_us: ts,
+            source: FrameSource::Live,
         })
     }
 

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -58,6 +58,8 @@ from ._frame import frame_bytes_to_numpy_rgb
 Role = _ffi.Role
 DType = _ffi.DType
 VideoCodec = _ffi.VideoCodec
+FrameSource = _ffi.FrameSource
+StallPolicy = _ffi.StallPolicy
 FieldSpec = _ffi.FieldSpec
 FrameVideoSpec = _ffi.FrameVideoSpec
 ChunkSpec = _ffi.ChunkSpec
@@ -289,6 +291,12 @@ class Observation:
     `state` holds Python-native types per the declared state schema;
     `raw_state` keeps the f64 dict. `frames` is unchanged from the FFI
     layer — one entry per registered video track.
+
+    Every registered track always has an entry, even when it went silent:
+    check `frames[name].source` to tell a real match (`FrameSource.LIVE`)
+    from a reused earlier frame (`FrameSource.STALE`) or a synthesized
+    placeholder (`FrameSource.OMITTED`). Only `LIVE` frames are
+    measurements of `timestamp_us`.
     """
 
     state: Dict[str, TypedScalar]
@@ -1035,8 +1043,61 @@ class PortalConfig:
         or logging where losing state is worse than a transient video freeze.
         Leave off for real-time control where a stale frame would misalign
         the perception/action loop.
+
+        .. deprecated::
+            Use ``set_on_stall(StallPolicy.FREEZE)``, which is this plus
+            ``set_max_lag_ms(0)``.
         """
         self._inner.set_reuse_stale_frames(enable)
+
+    def set_on_stall(self, policy: "StallPolicy") -> None:
+        """How a moment is resolved when a video track goes silent for longer
+        than its `max_lag`. Applies to every track without a per-track
+        override; see `set_track_on_stall`.
+
+        `StallPolicy.DROP` (the default) emits no observation — the state
+        still reaches the drop callback, but the healthy tracks in that
+        moment go with it, so an operator screen stays dark while one camera
+        is down. `StallPolicy.FREEZE` holds the silent track's last good
+        frame. `StallPolicy.OMIT` substitutes a visible placeholder, so the
+        healthy tracks keep flowing.
+
+        Whichever fires, the frame carries a `FrameSource` saying which it
+        was. Check `frames[name].source` before feeding an observation to a
+        policy or writing it to a dataset.
+        """
+        self._inner.set_on_stall(policy)
+
+    def set_max_lag_ms(self, ms: int) -> None:
+        """How far the fastest-advancing stream may run past a moment before
+        that moment resolves without a silent track — in milliseconds of
+        **sender-clock time**, not wall-clock.
+
+        This is a statement about stream position, not a stopwatch. It is
+        evaluated when a packet arrives, so a burst of buffered frames can
+        cross it in far less real time, and if every stream goes quiet
+        nothing fires at all (nothing is being emitted either). Staying on
+        sender clocks is what keeps sync decisions reproducible.
+
+        Defaults to `slack / fps` — where state-buffer capacity would have
+        evicted the moment anyway — so the default timing is unchanged from
+        earlier versions. `0` resolves immediately, without waiting.
+        """
+        self._inner.set_max_lag_ms(ms)
+
+    def set_track_on_stall(self, track: str, policy: "StallPolicy") -> None:
+        """Per-track override for `set_on_stall`.
+
+        Use it when tracks differ in how load-bearing they are: a wrist
+        camera a policy depends on may warrant `DROP` (no observation beats
+        a wrong one), while a scene camera warrants `OMIT` so its failure
+        does not take the rest of the frame set down with it.
+        """
+        self._inner.set_track_on_stall(track, policy)
+
+    def set_track_max_lag_ms(self, track: str, ms: int) -> None:
+        """Per-track override for `set_max_lag_ms`."""
+        self._inner.set_track_max_lag_ms(track, ms)
 
     def set_action_subscription(self, enable: bool) -> None:
         """Operator-side opt-in to receiving executed actions.
@@ -1570,6 +1631,18 @@ class _RoleConfigBase:
     def set_reuse_stale_frames(self, enable: bool) -> None:
         self._inner.set_reuse_stale_frames(enable)
 
+    def set_on_stall(self, policy: "StallPolicy") -> None:
+        self._inner.set_on_stall(policy)
+
+    def set_max_lag_ms(self, ms: int) -> None:
+        self._inner.set_max_lag_ms(ms)
+
+    def set_track_on_stall(self, track: str, policy: "StallPolicy") -> None:
+        self._inner.set_track_on_stall(track, policy)
+
+    def set_track_max_lag_ms(self, track: str, ms: int) -> None:
+        self._inner.set_track_max_lag_ms(track, ms)
+
     def set_action_subscription(self, enable: bool) -> None:
         """Operator-side opt-in to receiving executed actions ("HITL
         recording"). Off by default. See `PortalConfig.set_action_subscription`
@@ -1953,6 +2026,8 @@ __all__ = [
     "Role",
     "DType",
     "VideoCodec",
+    "FrameSource",
+    "StallPolicy",
     "FieldSpec",
     "FrameVideoSpec",
     "ChunkSpec",

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -1055,6 +1055,12 @@ class PortalConfig:
         than its `max_lag`. Applies to every track without a per-track
         override; see `set_track_on_stall`.
 
+        **Receiving side only.** Observations are assembled where they are
+        consumed, so this is read on the `Operator` and is a no-op on
+        `RobotConfig`. Nothing about a stall crosses the wire: a silent track
+        is by definition sending nothing, so the substitute frame is
+        synthesized locally by the subscriber that noticed the gap.
+
         `StallPolicy.DROP` (the default) emits no observation — the state
         still reaches the drop callback, but the healthy tracks in that
         moment go with it, so an operator screen stays dark while one camera
@@ -1082,6 +1088,8 @@ class PortalConfig:
         Defaults to `slack / fps` — where state-buffer capacity would have
         evicted the moment anyway — so the default timing is unchanged from
         earlier versions. `0` resolves immediately, without waiting.
+
+        **Receiving side only**, like `set_on_stall`.
         """
         self._inner.set_max_lag_ms(ms)
 

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -59,7 +59,7 @@ Role = _ffi.Role
 DType = _ffi.DType
 VideoCodec = _ffi.VideoCodec
 FrameSource = _ffi.FrameSource
-StallPolicy = _ffi.StallPolicy
+StallBehavior = _ffi.StallBehavior
 FieldSpec = _ffi.FieldSpec
 FrameVideoSpec = _ffi.FrameVideoSpec
 ChunkSpec = _ffi.ChunkSpec
@@ -900,6 +900,8 @@ class PortalConfig:
         *,
         simulcast: Optional[bool] = None,
         screencast: Optional[bool] = None,
+        stall_behavior: Optional["StallBehavior"] = None,
+        max_lag_ms: Optional[int] = None,
     ) -> None:
         """Declare a video track.
 
@@ -932,6 +934,12 @@ class PortalConfig:
         `simulcast` and `screencast` are keyword-only, apply to the WebRTC
         codecs only, and both default to `False`.
 
+        `stall_behavior` and `max_lag_ms` are keyword-only per-track overrides
+        of `set_stall_behavior` / `set_max_lag_ms`, given here so a track's
+        whole configuration reads in one place. `None` on either inherits the
+        config-wide default. Both are read on the receiving side, so they have
+        no effect in a `RobotConfig`.
+
           * `simulcast=True` publishes several spatial layers at once so the
             SFU can hand each subscriber the layer their link can carry. Costs
             encode CPU per extra layer. Worth it only when several operators
@@ -956,7 +964,14 @@ class PortalConfig:
         usually does.
         """
         self._inner.add_video(
-            name, codec, quality, max_bitrate_kbps, simulcast, screencast
+            name,
+            codec,
+            quality,
+            max_bitrate_kbps,
+            simulcast,
+            screencast,
+            stall_behavior,
+            max_lag_ms,
         )
         if codec in _WEBRTC_CODECS:
             self._video_tracks.append(name)
@@ -1045,15 +1060,15 @@ class PortalConfig:
         the perception/action loop.
 
         .. deprecated::
-            Use ``set_on_stall(StallPolicy.FREEZE)``, which is this plus
+            Use ``set_stall_behavior(StallBehavior.FREEZE)``, which is this plus
             ``set_max_lag_ms(0)``.
         """
         self._inner.set_reuse_stale_frames(enable)
 
-    def set_on_stall(self, policy: "StallPolicy") -> None:
+    def set_stall_behavior(self, policy: "StallBehavior") -> None:
         """How a moment is resolved when a video track goes silent for longer
         than its `max_lag`. Applies to every track without a per-track
-        override; see `set_track_on_stall`.
+        override; see `set_track_stall_behavior`.
 
         **Receiving side only.** Observations are assembled where they are
         consumed, so this is read on the `Operator` and is a no-op on
@@ -1061,18 +1076,18 @@ class PortalConfig:
         is by definition sending nothing, so the substitute frame is
         synthesized locally by the subscriber that noticed the gap.
 
-        `StallPolicy.DROP` (the default) emits no observation — the state
+        `StallBehavior.DROP` (the default) emits no observation — the state
         still reaches the drop callback, but the healthy tracks in that
         moment go with it, so an operator screen stays dark while one camera
-        is down. `StallPolicy.FREEZE` holds the silent track's last good
-        frame. `StallPolicy.OMIT` substitutes a visible placeholder, so the
+        is down. `StallBehavior.FREEZE` holds the silent track's last good
+        frame. `StallBehavior.OMIT` substitutes a visible placeholder, so the
         healthy tracks keep flowing.
 
         Whichever fires, the frame carries a `FrameSource` saying which it
         was. Check `frames[name].source` before feeding an observation to a
         policy or writing it to a dataset.
         """
-        self._inner.set_on_stall(policy)
+        self._inner.set_stall_behavior(policy)
 
     def set_max_lag_ms(self, ms: int) -> None:
         """How far the fastest-advancing stream may run past a moment before
@@ -1089,19 +1104,19 @@ class PortalConfig:
         evicted the moment anyway — so the default timing is unchanged from
         earlier versions. `0` resolves immediately, without waiting.
 
-        **Receiving side only**, like `set_on_stall`.
+        **Receiving side only**, like `set_stall_behavior`.
         """
         self._inner.set_max_lag_ms(ms)
 
-    def set_track_on_stall(self, track: str, policy: "StallPolicy") -> None:
-        """Per-track override for `set_on_stall`.
+    def set_track_stall_behavior(self, track: str, policy: "StallBehavior") -> None:
+        """Per-track override for `set_stall_behavior`.
 
         Use it when tracks differ in how load-bearing they are: a wrist
         camera a policy depends on may warrant `DROP` (no observation beats
         a wrong one), while a scene camera warrants `OMIT` so its failure
         does not take the rest of the frame set down with it.
         """
-        self._inner.set_track_on_stall(track, policy)
+        self._inner.set_track_stall_behavior(track, policy)
 
     def set_track_max_lag_ms(self, track: str, ms: int) -> None:
         """Per-track override for `set_max_lag_ms`."""
@@ -1596,9 +1611,18 @@ class _RoleConfigBase:
         *,
         simulcast: Optional[bool] = None,
         screencast: Optional[bool] = None,
+        stall_behavior: Optional["StallBehavior"] = None,
+        max_lag_ms: Optional[int] = None,
     ) -> None:
         self._inner.add_video(
-            name, codec, quality, max_bitrate_kbps, simulcast, screencast
+            name,
+            codec,
+            quality,
+            max_bitrate_kbps,
+            simulcast,
+            screencast,
+            stall_behavior,
+            max_lag_ms,
         )
 
     def add_state_typed(self, schema: Iterable[SchemaEntry]) -> None:
@@ -1639,14 +1663,14 @@ class _RoleConfigBase:
     def set_reuse_stale_frames(self, enable: bool) -> None:
         self._inner.set_reuse_stale_frames(enable)
 
-    def set_on_stall(self, policy: "StallPolicy") -> None:
-        self._inner.set_on_stall(policy)
+    def set_stall_behavior(self, policy: "StallBehavior") -> None:
+        self._inner.set_stall_behavior(policy)
 
     def set_max_lag_ms(self, ms: int) -> None:
         self._inner.set_max_lag_ms(ms)
 
-    def set_track_on_stall(self, track: str, policy: "StallPolicy") -> None:
-        self._inner.set_track_on_stall(track, policy)
+    def set_track_stall_behavior(self, track: str, policy: "StallBehavior") -> None:
+        self._inner.set_track_stall_behavior(track, policy)
 
     def set_track_max_lag_ms(self, track: str, ms: int) -> None:
         self._inner.set_track_max_lag_ms(track, ms)
@@ -2035,7 +2059,7 @@ __all__ = [
     "DType",
     "VideoCodec",
     "FrameSource",
-    "StallPolicy",
+    "StallBehavior",
     "FieldSpec",
     "FrameVideoSpec",
     "ChunkSpec",

--- a/python/packages/livekit-portal/tests/integration/conftest.py
+++ b/python/packages/livekit-portal/tests/integration/conftest.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import pathlib
 import time
 from typing import Optional
 
@@ -47,20 +48,13 @@ API_KEY = os.environ.get("LIVEKIT_API_KEY", "devkey")
 API_SECRET = os.environ.get("LIVEKIT_API_SECRET", "secret")
 
 
+# Derived rather than enumerated: every module in this directory needs a
+# server, and a hand-maintained list silently un-skips any file someone
+# forgets to add. That surfaces as a confusing `NoneType` deep inside the FFI
+# rather than as a skip, and only in an environment without `LIVEKIT_URL` —
+# so it passes locally for whoever wrote the file and fails in CI.
 collect_ignore = (
-    []
-    if URL
-    else [
-        "test_chunks.py",
-        "test_frame_video.py",
-        "test_frame_video_stress.py",
-        "test_e2ee.py",
-        "test_multi_operator.py",
-        "test_action_subscription.py",
-        "test_webrtc_codecs.py",
-        "test_ffi_role_split.py",
-        "test_rpc.py",
-    ]
+    [] if URL else sorted(p.name for p in pathlib.Path(__file__).parent.glob("test_*.py"))
 )
 
 

--- a/python/packages/livekit-portal/tests/integration/test_stall_behavior.py
+++ b/python/packages/livekit-portal/tests/integration/test_stall_behavior.py
@@ -35,7 +35,7 @@ import pytest
 from livekit.portal import (
     FrameSource,
     Observation,
-    StallPolicy,
+    StallBehavior,
     VideoCodec,
 )
 
@@ -61,7 +61,7 @@ def _frame(width: int = 32, height: int = 24, seed: int = 0) -> np.ndarray:
     return np.stack([r, g, b], axis=-1)
 
 
-def _declare(pair, policy: StallPolicy | None = None) -> None:
+def _declare(pair, policy: StallBehavior | None = None) -> None:
     """Two cameras on the byte-stream path, so frames arrive deterministically
     rather than through libwebrtc's rate-adapting encoder.
 
@@ -75,7 +75,7 @@ def _declare(pair, policy: StallPolicy | None = None) -> None:
         cfg.add_video("cam2", codec=VideoCodec.RAW)
     pair.operator_cfg.set_max_lag_ms(MAX_LAG_MS)
     if policy is not None:
-        pair.operator_cfg.set_on_stall(policy)
+        pair.operator_cfg.set_stall_behavior(policy)
 
 
 async def _run_cam2_dies(pair, obs: list[Observation], base: int) -> None:
@@ -104,7 +104,7 @@ async def test_omit_keeps_healthy_camera_visible(pair):
     placeholder — and the `cam2` key is still present, so consumer code
     indexing it does not start raising.
     """
-    _declare(pair, StallPolicy.OMIT)
+    _declare(pair, StallBehavior.OMIT)
     obs: list[Observation] = []
     await pair.start()
     pair.operator.on_observation(lambda o: obs.append(o))
@@ -131,7 +131,7 @@ async def test_drop_loses_the_healthy_camera_too(pair):
     the operator loses every camera because one died. Asserting it here keeps
     the two policies honest about how they differ.
     """
-    _declare(pair, StallPolicy.DROP)
+    _declare(pair, StallBehavior.DROP)
     obs: list[Observation] = []
     await pair.start()
     pair.operator.on_observation(lambda o: obs.append(o))
@@ -146,7 +146,7 @@ async def test_drop_loses_the_healthy_camera_too(pair):
 async def test_freeze_substitutes_the_last_good_frame(pair):
     """`FREEZE` keeps the moment too, but with real (older) pixels rather than
     a placeholder — tagged `STALE` so a consumer can tell the difference."""
-    _declare(pair, StallPolicy.FREEZE)
+    _declare(pair, StallBehavior.FREEZE)
     obs: list[Observation] = []
     await pair.start()
     pair.operator.on_observation(lambda o: obs.append(o))
@@ -163,9 +163,17 @@ async def test_freeze_substitutes_the_last_good_frame(pair):
 async def test_policy_is_per_track_over_the_wire(pair):
     """Per-track policy is the reason the knob exists: a load-bearing camera
     can stay strict while a secondary one degrades gracefully."""
-    _declare(pair)
-    pair.operator_cfg.set_on_stall(StallPolicy.DROP)
-    pair.operator_cfg.set_track_on_stall("cam2", StallPolicy.OMIT)
+    # Declared inline rather than through the setters: this is the form the
+    # Python docs lead with, so it needs to survive the round trip through the
+    # FFI and reach the sync buffer's per-track resolution.
+    pair.robot_cfg.add_video("cam1", codec=VideoCodec.RAW)
+    pair.robot_cfg.add_video("cam2", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video("cam1", codec=VideoCodec.RAW)
+    pair.operator_cfg.add_video(
+        "cam2", codec=VideoCodec.RAW, stall_behavior=StallBehavior.OMIT
+    )
+    pair.operator_cfg.set_stall_behavior(StallBehavior.DROP)
+    pair.operator_cfg.set_max_lag_ms(MAX_LAG_MS)
 
     obs: list[Observation] = []
     await pair.start()
@@ -179,7 +187,7 @@ async def test_policy_is_per_track_over_the_wire(pair):
 
 async def test_omission_is_counted_per_track(pair):
     """Ops need to know *which* camera is down without diffing key sets."""
-    _declare(pair, StallPolicy.OMIT)
+    _declare(pair, StallBehavior.OMIT)
     obs: list[Observation] = []
     await pair.start()
     pair.operator.on_observation(lambda o: obs.append(o))
@@ -194,7 +202,7 @@ async def test_omission_is_counted_per_track(pair):
 async def test_recovery_returns_to_live(pair):
     """A camera coming back must go straight to `LIVE`; the placeholder is not
     sticky, or a recovered session would look permanently broken."""
-    _declare(pair, StallPolicy.OMIT)
+    _declare(pair, StallBehavior.OMIT)
     obs: list[Observation] = []
     await pair.start()
     pair.operator.on_observation(lambda o: obs.append(o))
@@ -231,7 +239,7 @@ async def test_policy_is_read_on_the_receiving_side(pair):
         cfg.add_video("cam2", codec=VideoCodec.RAW)
     # Deliberately the wrong side.
     pair.robot_cfg.set_max_lag_ms(MAX_LAG_MS)
-    pair.robot_cfg.set_on_stall(StallPolicy.OMIT)
+    pair.robot_cfg.set_stall_behavior(StallBehavior.OMIT)
 
     obs: list[Observation] = []
     await pair.start()

--- a/python/packages/livekit-portal/tests/integration/test_stall_policy.py
+++ b/python/packages/livekit-portal/tests/integration/test_stall_policy.py
@@ -63,16 +63,19 @@ def _frame(width: int = 32, height: int = 24, seed: int = 0) -> np.ndarray:
 
 def _declare(pair, policy: StallPolicy | None = None) -> None:
     """Two cameras on the byte-stream path, so frames arrive deterministically
-    rather than through libwebrtc's rate-adapting encoder."""
+    rather than through libwebrtc's rate-adapting encoder.
+
+    The stall knobs go on the **operator only**. Observations are assembled
+    where they are received, so that is the side that reads them; leaving the
+    robot at its defaults keeps every test below an implicit check that the
+    receiver alone is in charge.
+    """
     for cfg in (pair.robot_cfg, pair.operator_cfg):
         cfg.add_video("cam1", codec=VideoCodec.RAW)
         cfg.add_video("cam2", codec=VideoCodec.RAW)
-    # Only the receiving side runs a sync buffer, but configuring both keeps
-    # the declaration symmetric the way real deployments write it.
-    for cfg in (pair.robot_cfg, pair.operator_cfg):
-        cfg.set_max_lag_ms(MAX_LAG_MS)
-        if policy is not None:
-            cfg.set_on_stall(policy)
+    pair.operator_cfg.set_max_lag_ms(MAX_LAG_MS)
+    if policy is not None:
+        pair.operator_cfg.set_on_stall(policy)
 
 
 async def _run_cam2_dies(pair, obs: list[Observation], base: int) -> None:
@@ -161,9 +164,8 @@ async def test_policy_is_per_track_over_the_wire(pair):
     """Per-track policy is the reason the knob exists: a load-bearing camera
     can stay strict while a secondary one degrades gracefully."""
     _declare(pair)
-    for cfg in (pair.robot_cfg, pair.operator_cfg):
-        cfg.set_on_stall(StallPolicy.DROP)
-        cfg.set_track_on_stall("cam2", StallPolicy.OMIT)
+    pair.operator_cfg.set_on_stall(StallPolicy.DROP)
+    pair.operator_cfg.set_track_on_stall("cam2", StallPolicy.OMIT)
 
     obs: list[Observation] = []
     await pair.start()
@@ -210,3 +212,32 @@ async def test_recovery_returns_to_live(pair):
 
     assert obs[-1].frames["cam2"].source is FrameSource.LIVE
     assert obs[-1].frames["cam1"].source is FrameSource.LIVE
+
+
+async def test_policy_is_read_on_the_receiving_side(pair):
+    """Setting the policy on the publisher must do nothing.
+
+    Nothing about a stall crosses the wire: a silent camera is by definition
+    sending nothing, so `OMIT` cannot be a message. The substitute is
+    synthesized by whoever is assembling observations, which is the operator.
+    Configuring only the robot therefore leaves the operator on its default
+    `DROP`, and the moment is discarded.
+
+    This is the mirror of `test_omit_keeps_healthy_camera_visible`: identical
+    traffic, policy on the other side, opposite outcome.
+    """
+    for cfg in (pair.robot_cfg, pair.operator_cfg):
+        cfg.add_video("cam1", codec=VideoCodec.RAW)
+        cfg.add_video("cam2", codec=VideoCodec.RAW)
+    # Deliberately the wrong side.
+    pair.robot_cfg.set_max_lag_ms(MAX_LAG_MS)
+    pair.robot_cfg.set_on_stall(StallPolicy.OMIT)
+
+    obs: list[Observation] = []
+    await pair.start()
+    pair.operator.on_observation(lambda o: obs.append(o))
+
+    await _run_cam2_dies(pair, obs, base=7_000_000)
+
+    assert len(obs) == 1, "the robot-side policy must have no effect"
+    assert all(f.source is FrameSource.LIVE for f in obs[0].frames.values())

--- a/python/packages/livekit-portal/tests/integration/test_stall_policy.py
+++ b/python/packages/livekit-portal/tests/integration/test_stall_policy.py
@@ -1,0 +1,212 @@
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stalled-track handling against a live LiveKit server.
+
+The unit tests drive `SyncBuffer` directly. These drive the whole path —
+publish, SFU, receive, decode, sync — because the thing being fixed is an
+operational failure (a camera dies mid-session), and the interesting question
+is what the *consumer* sees when it happens.
+
+Timestamps are supplied explicitly so the stream clock is deterministic:
+`max_lag` is measured in sender-clock time, so a test that relied on wall-clock
+arrival would be racing the network for no reason.
+
+Skipped automatically when `LIVEKIT_URL` isn't set (see conftest).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from livekit.portal import (
+    FrameSource,
+    Observation,
+    StallPolicy,
+    VideoCodec,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# Byte-stream receive races a few hops (stream open → read → decode → sync →
+# callback hop to the asyncio loop). Generous on localhost.
+SETTLE_S = 0.6
+
+# Sender-clock spacing between moments, in microseconds. Comfortably wider
+# than the default match window (tolerance/fps = 50ms) so nothing matches by
+# accident, and wider than MAX_LAG so one silent step trips the budget.
+STEP_US = 100_000
+MAX_LAG_MS = 50
+
+
+def _frame(width: int = 32, height: int = 24, seed: int = 0) -> np.ndarray:
+    x = np.arange(width, dtype=np.int32)
+    y = np.arange(height, dtype=np.int32)[:, None]
+    r = np.broadcast_to(((x + seed) % 256).astype(np.uint8), (height, width))
+    g = np.broadcast_to(((y + seed) % 256).astype(np.uint8), (height, width))
+    b = ((x + y + seed) % 256).astype(np.uint8)
+    return np.stack([r, g, b], axis=-1)
+
+
+def _declare(pair, policy: StallPolicy | None = None) -> None:
+    """Two cameras on the byte-stream path, so frames arrive deterministically
+    rather than through libwebrtc's rate-adapting encoder."""
+    for cfg in (pair.robot_cfg, pair.operator_cfg):
+        cfg.add_video("cam1", codec=VideoCodec.RAW)
+        cfg.add_video("cam2", codec=VideoCodec.RAW)
+    # Only the receiving side runs a sync buffer, but configuring both keeps
+    # the declaration symmetric the way real deployments write it.
+    for cfg in (pair.robot_cfg, pair.operator_cfg):
+        cfg.set_max_lag_ms(MAX_LAG_MS)
+        if policy is not None:
+            cfg.set_on_stall(policy)
+
+
+async def _run_cam2_dies(pair, obs: list[Observation], base: int) -> None:
+    """Three moments: both cameras healthy, then cam2 goes silent while cam1
+    keeps carrying the stream clock forward past the lag budget."""
+    pair.robot.send_video_frame("cam1", _frame(seed=1), timestamp_us=base)
+    pair.robot.send_video_frame("cam2", _frame(seed=2), timestamp_us=base)
+    pair.robot.send_state({"j": 0.0}, timestamp_us=base)
+    await asyncio.sleep(SETTLE_S)
+
+    # cam2 is now dead. This moment is still inside its budget, so it waits.
+    pair.robot.send_video_frame("cam1", _frame(seed=3), timestamp_us=base + STEP_US)
+    pair.robot.send_state({"j": 1.0}, timestamp_us=base + STEP_US)
+    await asyncio.sleep(SETTLE_S)
+
+    # cam1 alone carries the clock past the budget, which is the case
+    # capacity eviction could never reach — no further state is sent.
+    pair.robot.send_video_frame("cam1", _frame(seed=4), timestamp_us=base + 2 * STEP_US)
+    await asyncio.sleep(SETTLE_S)
+
+
+async def test_omit_keeps_healthy_camera_visible(pair):
+    """The headline case: one camera dying must not blank the other.
+
+    Under `OMIT` the moment survives with cam1 live and cam2 carrying a
+    placeholder — and the `cam2` key is still present, so consumer code
+    indexing it does not start raising.
+    """
+    _declare(pair, StallPolicy.OMIT)
+    obs: list[Observation] = []
+    await pair.start()
+    pair.operator.on_observation(lambda o: obs.append(o))
+
+    await _run_cam2_dies(pair, obs, base=1_000_000)
+
+    assert len(obs) >= 2, f"expected the stalled moment to resolve, got {len(obs)}"
+    last = obs[-1]
+    assert set(last.frames) == {"cam1", "cam2"}, "every declared track keeps its key"
+    assert last.frames["cam1"].source is FrameSource.LIVE
+    assert last.frames["cam2"].source is FrameSource.OMITTED
+
+    # The placeholder inherits the dead camera's geometry and the timestamp of
+    # its last real frame, so staleness stays measurable.
+    assert last.frames["cam2"].width == 32
+    assert last.frames["cam2"].height == 24
+    assert last.frames["cam2"].timestamp_us == 1_000_000
+
+
+async def test_drop_loses_the_healthy_camera_too(pair):
+    """The contrast that makes `OMIT` worth having.
+
+    With the default policy the same failure yields no observation at all, so
+    the operator loses every camera because one died. Asserting it here keeps
+    the two policies honest about how they differ.
+    """
+    _declare(pair, StallPolicy.DROP)
+    obs: list[Observation] = []
+    await pair.start()
+    pair.operator.on_observation(lambda o: obs.append(o))
+
+    await _run_cam2_dies(pair, obs, base=2_000_000)
+
+    assert len(obs) == 1, f"only the healthy moment should emit, got {len(obs)}"
+    assert obs[0].frames["cam1"].source is FrameSource.LIVE
+    assert obs[0].frames["cam2"].source is FrameSource.LIVE
+
+
+async def test_freeze_substitutes_the_last_good_frame(pair):
+    """`FREEZE` keeps the moment too, but with real (older) pixels rather than
+    a placeholder — tagged `STALE` so a consumer can tell the difference."""
+    _declare(pair, StallPolicy.FREEZE)
+    obs: list[Observation] = []
+    await pair.start()
+    pair.operator.on_observation(lambda o: obs.append(o))
+
+    await _run_cam2_dies(pair, obs, base=3_000_000)
+
+    assert len(obs) >= 2
+    last = obs[-1]
+    assert last.frames["cam1"].source is FrameSource.LIVE
+    assert last.frames["cam2"].source is FrameSource.STALE
+    assert last.frames["cam2"].timestamp_us == 3_000_000, "cam2's last real frame"
+
+
+async def test_policy_is_per_track_over_the_wire(pair):
+    """Per-track policy is the reason the knob exists: a load-bearing camera
+    can stay strict while a secondary one degrades gracefully."""
+    _declare(pair)
+    for cfg in (pair.robot_cfg, pair.operator_cfg):
+        cfg.set_on_stall(StallPolicy.DROP)
+        cfg.set_track_on_stall("cam2", StallPolicy.OMIT)
+
+    obs: list[Observation] = []
+    await pair.start()
+    pair.operator.on_observation(lambda o: obs.append(o))
+
+    await _run_cam2_dies(pair, obs, base=4_000_000)
+
+    assert len(obs) >= 2, "cam2 is the lenient track, so the moment survives"
+    assert obs[-1].frames["cam2"].source is FrameSource.OMITTED
+
+
+async def test_omission_is_counted_per_track(pair):
+    """Ops need to know *which* camera is down without diffing key sets."""
+    _declare(pair, StallPolicy.OMIT)
+    obs: list[Observation] = []
+    await pair.start()
+    pair.operator.on_observation(lambda o: obs.append(o))
+
+    await _run_cam2_dies(pair, obs, base=5_000_000)
+
+    omitted = pair.operator.metrics().sync.frames_omitted
+    assert omitted.get("cam2", 0) >= 1, f"cam2 omissions not counted: {omitted}"
+    assert omitted.get("cam1", 0) == 0, "healthy camera must not be counted"
+
+
+async def test_recovery_returns_to_live(pair):
+    """A camera coming back must go straight to `LIVE`; the placeholder is not
+    sticky, or a recovered session would look permanently broken."""
+    _declare(pair, StallPolicy.OMIT)
+    obs: list[Observation] = []
+    await pair.start()
+    pair.operator.on_observation(lambda o: obs.append(o))
+
+    base = 6_000_000
+    await _run_cam2_dies(pair, obs, base=base)
+    assert obs[-1].frames["cam2"].source is FrameSource.OMITTED
+
+    # cam2 comes back, in range of a fresh moment.
+    ts = base + 3 * STEP_US
+    pair.robot.send_video_frame("cam1", _frame(seed=5), timestamp_us=ts)
+    pair.robot.send_video_frame("cam2", _frame(seed=6), timestamp_us=ts)
+    pair.robot.send_state({"j": 2.0}, timestamp_us=ts)
+    await asyncio.sleep(SETTLE_S)
+
+    assert obs[-1].frames["cam2"].source is FrameSource.LIVE
+    assert obs[-1].frames["cam1"].source is FrameSource.LIVE

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -25,6 +25,7 @@ from livekit.portal import (
     PortalError,
     RobotConfig,
     Role,
+    StallPolicy,
     VideoCodec,
 )
 
@@ -631,3 +632,31 @@ def test_send_action_passes_in_reply_to_ts_us_through_validator():
         pytest.fail("in_reply_to_ts_us must not affect dtype validation")
     except PortalError:
         pass
+
+
+def test_stall_policy_enum_is_exposed():
+    assert [p.name for p in StallPolicy] == ["DROP", "FREEZE", "OMIT"]
+
+
+def test_stall_setters_accept_global_and_per_track():
+    """The knobs exist on every config wrapper and take the enum, not a
+    string — a typo should be a NameError at author time, not a silent
+    fallback to the default at runtime."""
+    for cfg in (PortalConfig("demo", Role.ROBOT), RobotConfig("demo"), OperatorConfig("demo")):
+        cfg.set_on_stall(StallPolicy.FREEZE)
+        cfg.set_max_lag_ms(200)
+        cfg.set_track_on_stall("scene", StallPolicy.OMIT)
+        cfg.set_track_max_lag_ms("wrist", 20)
+
+
+def test_max_lag_zero_is_accepted():
+    """0 means resolve immediately; it must not be mistaken for unset."""
+    cfg = RobotConfig("demo")
+    cfg.set_max_lag_ms(0)
+
+
+def test_reuse_stale_frames_still_works():
+    """The deprecated alias keeps working for existing callers."""
+    cfg = RobotConfig("demo")
+    cfg.set_reuse_stale_frames(True)
+    assert cfg.reuse_stale_frames is True

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -25,7 +25,7 @@ from livekit.portal import (
     PortalError,
     RobotConfig,
     Role,
-    StallPolicy,
+    StallBehavior,
     VideoCodec,
 )
 
@@ -635,7 +635,7 @@ def test_send_action_passes_in_reply_to_ts_us_through_validator():
 
 
 def test_stall_policy_enum_is_exposed():
-    assert [p.name for p in StallPolicy] == ["DROP", "FREEZE", "OMIT"]
+    assert [p.name for p in StallBehavior] == ["DROP", "FREEZE", "OMIT"]
 
 
 def test_stall_setters_accept_global_and_per_track():
@@ -643,9 +643,9 @@ def test_stall_setters_accept_global_and_per_track():
     string — a typo should be a NameError at author time, not a silent
     fallback to the default at runtime."""
     for cfg in (PortalConfig("demo", Role.ROBOT), RobotConfig("demo"), OperatorConfig("demo")):
-        cfg.set_on_stall(StallPolicy.FREEZE)
+        cfg.set_stall_behavior(StallBehavior.FREEZE)
         cfg.set_max_lag_ms(200)
-        cfg.set_track_on_stall("scene", StallPolicy.OMIT)
+        cfg.set_track_stall_behavior("scene", StallBehavior.OMIT)
         cfg.set_track_max_lag_ms("wrist", 20)
 
 

--- a/python/packages/livekit-portal/tests/test_config_yaml.py
+++ b/python/packages/livekit-portal/tests/test_config_yaml.py
@@ -222,11 +222,11 @@ def test_stall_policy_parses_per_track():
         textwrap.dedent(
             """
             version: 1
-            on_stall: freeze
+            stall_behavior: freeze
             max_lag_ms: 120
             videos:
               - { name: front, codec: h264 }
-              - { name: wrist, codec: h264, on_stall: drop, max_lag_ms: 20 }
+              - { name: wrist, codec: h264, stall_behavior: drop, max_lag_ms: 20 }
             """
         ),
         "demo",
@@ -245,7 +245,7 @@ def test_unknown_stall_policy_is_rejected():
                 """
                 version: 1
                 videos:
-                  - { name: front, codec: h264, on_stall: nope }
+                  - { name: front, codec: h264, stall_behavior: nope }
                 """
             ),
             "demo",

--- a/python/packages/livekit-portal/tests/test_config_yaml.py
+++ b/python/packages/livekit-portal/tests/test_config_yaml.py
@@ -213,3 +213,42 @@ def test_robot_config_from_yaml_file():
         assert cfg.role == Role.ROBOT
     finally:
         os.unlink(path)
+
+
+def test_stall_policy_parses_per_track():
+    """Both knobs parse at either level, and a per-track value overrides the
+    default without disturbing tracks that did not set one."""
+    cfg = PortalConfig.from_yaml_str(
+        textwrap.dedent(
+            """
+            version: 1
+            on_stall: freeze
+            max_lag_ms: 120
+            videos:
+              - { name: front, codec: h264 }
+              - { name: wrist, codec: h264, on_stall: drop, max_lag_ms: 20 }
+            """
+        ),
+        "demo",
+        Role.ROBOT,
+    )
+    assert list(cfg.video_tracks) == ["front", "wrist"]
+
+
+def test_unknown_stall_policy_is_rejected():
+    """A typo must fail loudly rather than silently falling back to the
+    default — a stall policy that quietly reverts is one you cannot trust in
+    an incident."""
+    with pytest.raises(ConfigFileError) as e:
+        PortalConfig.from_yaml_str(
+            textwrap.dedent(
+                """
+                version: 1
+                videos:
+                  - { name: front, codec: h264, on_stall: nope }
+                """
+            ),
+            "demo",
+            Role.ROBOT,
+        )
+    assert "nope" in str(e.value)


### PR DESCRIPTION
Closes #69.

## The problem

We have two cameras, `wrist` and `scene`, at 30fps. Mid-session the `scene` cable works loose and it stops sending. `wrist` is fine and keeps streaming.

Here is what happens today:

```
t=0ms     wrist ✓   scene ✓   state ✓    ->  observation emitted
t=100ms   wrist ✓   scene ✗   state ✓    ->  nothing
t=200ms   wrist ✓   scene ✗   state ✓    ->  nothing
t=300ms   wrist ✓   scene ✗   state ✓    ->  nothing
```

Each moment sits in the sync buffer waiting for a `scene` frame that is never coming, so no observation is emitted at all. The operator's screen freezes on **both** tiles, including the camera that is working perfectly, and the policy stops receiving observations entirely. One dead camera took out the good one.

Eventually the state buffer fills and starts evicting, which converts the hang into a steady stream of drops. Still nothing on screen. And if state output pauses too, eviction never runs and the head waits forever.

## The fix

```python
cfg.set_max_lag_ms(150)
cfg.set_stall_behavior(StallBehavior.OMIT)
```

Same failure, same traffic:

```
t=0ms     wrist ✓   scene ✓   state ✓    ->  observation (wrist LIVE, scene LIVE)
t=100ms   wrist ✓   scene ✗   state ✓    ->  held: 0ms behind, budget is 150ms
t=250ms   wrist ✓                        ->  that moment is now 150ms behind
                                             observation (wrist LIVE, scene OMITTED)
```

**`max_lag` answers "how long do I wait?"** It is measured by how far the other streams have moved on. At `t=250ms` the newest thing received is a `wrist` frame stamped 250ms, and the moment we are stuck on is stamped 100ms, so it is 150ms behind and we stop waiting for `scene`.

That measurement uses stream timestamps, not a wall clock, which is what keeps sync decisions reproducible and testable. It also means this is not a watchdog: it is checked when a packet arrives, so if every stream goes quiet nothing fires, which is harmless because nothing is being emitted then either. The default is `slack / fps`, the point capacity eviction would have reached anyway, so existing setups see the same timing.

**`stall_behavior` answers "what do I do then?"** What the operator actually sees:

| | `scene` tile | `wrist` tile |
|---|---|---|
| `drop` | nothing, the whole observation is discarded | nothing |
| `freeze` | its last real picture, frozen | live |
| `omit` | a magenta NO SIGNAL card naming the track | live |

Each substituted frame is tagged so a policy or recorder can tell it apart: `Live`, `Stale`, or `Omitted`.

Both knobs are per track, which is the point. `wrist` may be load-bearing enough to want `drop`, since no observation beats a confidently wrong one, while `scene` wants `omit` so its failure does not take the rest of the frame set down with it.

## Using it

Per-track overrides ride on the track declaration in Python, next to `codec` and the encoder settings. Both are keyword-only, and `None` on either inherits the config-wide default:

```python
from livekit.portal import OperatorConfig, StallBehavior, FrameSource

cfg = OperatorConfig("session")
cfg.set_stall_behavior(StallBehavior.OMIT)   # defaults for every track
cfg.set_max_lag_ms(150)

cfg.add_video("wrist", stall_behavior=StallBehavior.DROP, max_lag_ms=40)
cfg.add_video("scene")                       # inherits OMIT / 150ms
```

Reading it back on the receiving side:

```python
def on_observation(obs):
    wrist = obs.frames["wrist"]        # always present, whatever happened
    if wrist.source is not FrameSource.LIVE:
        return                          # not a measurement of this moment
```

Rust uses the setters throughout, keeping `add_video` at its existing arity:

```rust
let mut cfg = PortalConfig::new("session", Role::Operator);
cfg.set_stall_behavior(StallBehavior::Omit);
cfg.set_max_lag_ms(150);

cfg.set_track_stall_behavior("wrist", StallBehavior::Drop);
cfg.set_track_max_lag_ms("wrist", 40);
```

YAML takes both at the top level as defaults and on any `videos` entry as an override. Each is independent, so a track can override the behavior, the budget, or both, and anything unset inherits:

```yaml
version: 1

stall_behavior: omit    # drop | freeze | omit. default for every track
max_lag_ms: 150         # omit the key to derive it from slack / fps

videos:
  - { name: wrist, codec: h264, stall_behavior: drop, max_lag_ms: 40 }
  - { name: scene, codec: h264 }
```

An unknown value is rejected at parse time, naming both the track and the bad value.

## Which side reads this

The receiving side, and only that side. `SyncBuffer` is built in `setup_operator` and fed exclusively from the receive paths, so nothing about a stall crosses the wire: a silent camera is by definition sending nothing, which means `omit` cannot be a message. The subscriber synthesizes the stand-in itself, using the geometry of the last frame that track actually delivered.

The practical consequence is that setting these on a `RobotConfig` does nothing, and there is a test asserting exactly that.

## `omit` keeps the key

`frames[name]` is still present for every declared track. The placeholder is substituted; the entry is never removed. Enabling this cannot start raising `KeyError` in code written before it existed.

The placeholder is deliberately not black, which would be indistinguishable from a dark room or a capped lens. It is magenta diagonals with the track name, drawn with an embedded 5x7 bitmap font rather than a font rasterizer dependency. Pixels are cached per `(track, geometry)`, and the frame carries the last real frame's timestamp so `match_delta` reports the true age of the newest real pixels.

## `FrameSource`

`VideoFrameData` gains `source: Live | Stale | Omitted`. The pattern is for whoever is watching the screen; this is what a policy or dataset writer should branch on.

It also closes an existing gap: a reused frame was previously only visible through the process-wide `stale_observations_emitted` counter, so given a single observation there was no way to tell live pixels from a three-second-old substitute.

New per-track `sync.frames_omitted` counter. `drop` and `freeze` keep reporting through `states_dropped` and `stale_observations_emitted`.

## Compatibility

`reuse_stale_frames` is retained as a deprecated alias for `freeze` with a zero budget, and an explicit `set_stall_behavior` always wins over it. The existing reuse tests now run under the new spelling unchanged, which is the backward-compatibility proof.

One behavior change for release notes: a stranded head now resolves when any stream advances, not only when `push_state` overflows. That fixes the hang when state output pauses while a healthy camera keeps sending. Total silence still resolves nothing, on both old and new, since nothing is being emitted then either.

## Testing

145 Rust tests (was 131), 71 Python unit tests, and 7 integration tests against a live LiveKit server. The integration set includes the contrast case: the same camera failure under `drop` yields no observation at all, while under `omit` the healthy camera stays visible.

Docs updated across seven pages, including the "No deadline-based drop" entry in `reference/synchronization.md` under *Design choices not made*, which this implements.

Pre-existing failures on my machine, identical on `main` and unrelated to this change (verified by checking out `main`, rebuilding, and rerunning): `test_webrtc_codecs.py` (7) and `test_frame_video.py::test_mixed_transports_in_one_portal`, all in the WebRTC media path via `on_video_frame`, which does not touch the sync buffer.

## Credit

The stall-deadline idea and the sender-clock framing come from @Rachit2323 in #69 and #72. This takes a different cut: two orthogonal per-track knobs instead of one boolean, and `omit` rather than only `drop`, since dropping bounds the stall but still leaves the operator's screen dark.
