### PR TITLE
refactor(config): one list for every declared video track

### DIFF
--- a/docs/03-portal-api.md
+++ b/docs/03-portal-api.md
@@ -148,8 +148,9 @@ config you loaded from YAML instead of building by hand:
 |---|---|---|
 | `session` | `str` | Session name. |
 | `role` | `Role` | Pinned role. |
-| `video_tracks` | `list[str]` | WebRTC track names. |
-| `frame_video_tracks` | `list[FrameVideoSpec]` | Byte-stream tracks with codec and quality. |
+| `video_tracks` | `list[str]` | Names of every declared track, in declaration order, whatever the codec. |
+| `video_track_specs` | `list[VideoTrackSpec]` | Those same tracks with codec, quality, and encoder options. |
+| `frame_video_tracks` | `list[VideoTrackSpec]` | The byte-stream subset of `video_track_specs`. A filter, not a rival list. |
 | `state_schema` / `action_schema` | `list[FieldSpec]` | Declared schemas, in order. |
 | `action_chunks` | `list[ChunkSpec]` | Declared chunks. |
 | `fps` | `int` | `set_fps`. |

--- a/livekit-portal-ffi/src/lib.rs
+++ b/livekit-portal-ffi/src/lib.rs
@@ -200,16 +200,36 @@ pub struct FieldSpec {
     pub dtype: DType,
 }
 
-/// One declared byte-stream video track: name, codec, and per-codec
-/// quality. Crosses the FFI boundary so bindings can introspect tracks
-/// declared via `PortalConfig.add_video` with a non-`H264` codec.
-/// `quality` is meaningful for `VideoCodec.Mjpeg` (1..=100) and ignored for
-/// `Raw` / `Png`.
+/// One declared video track: name, codec, and the per-codec options.
+///
+/// One record for every track regardless of transport, mirroring the core
+/// `VideoTrackSpec` — `codec` says which transport it rides and therefore
+/// which options apply. `quality` is meaningful for `VideoCodec.Mjpeg`
+/// (1..=100); `max_bitrate_kbps`, `simulcast` and `screencast` are
+/// meaningful for the WebRTC codecs. Each is ignored by the other transport
+/// — the YAML loader rejects a mismatched option outright, while `add_video`
+/// accepts and ignores it, so a spec may carry a value its codec never
+/// reads. `quality` is the exception: it reads back as `0` on every codec
+/// but `Mjpeg`.
 #[derive(Debug, Clone, uniffi::Record)]
-pub struct FrameVideoSpec {
+pub struct VideoTrackSpec {
     pub name: String,
     pub codec: VideoCodec,
     pub quality: u8,
+    pub max_bitrate_kbps: Option<u32>,
+    pub simulcast: bool,
+    pub screencast: bool,
+}
+
+fn videotrackspec_from_core(s: &core::VideoTrackSpec) -> VideoTrackSpec {
+    VideoTrackSpec {
+        name: s.name.clone(),
+        codec: s.codec.into(),
+        quality: s.quality,
+        max_bitrate_kbps: s.max_bitrate_kbps,
+        simulcast: s.simulcast,
+        screencast: s.screencast,
+    }
 }
 
 /// A declared action chunk: name, fixed horizon, ordered field list. The
@@ -791,24 +811,21 @@ impl PortalConfig {
         self.inner.lock().set_action_subscription(enable);
     }
 
-    /// Declared WebRTC video track names (H264).
+    /// Names of every declared video track, in declaration order, whatever
+    /// transport its codec selects.
     pub fn video_tracks(&self) -> Vec<String> {
         self.inner.lock().video_track_names().map(String::from).collect()
     }
 
-    /// Declared byte-stream video tracks (Raw / Png / Mjpeg) with codec
-    /// and per-codec quality.
-    pub fn frame_video_tracks(&self) -> Vec<FrameVideoSpec> {
-        self.inner
-            .lock()
-            .frame_video_tracks()
-            .iter()
-            .map(|s| FrameVideoSpec {
-                name: s.name.clone(),
-                codec: s.codec.into(),
-                quality: s.quality,
-            })
-            .collect()
+    /// Every declared video track with its codec and options, in declaration
+    /// order. The full readback of what `add_video` was given.
+    pub fn video_track_specs(&self) -> Vec<VideoTrackSpec> {
+        self.inner.lock().video_tracks().iter().map(videotrackspec_from_core).collect()
+    }
+
+    /// The byte-stream subset (Raw / Png / Mjpeg) of `video_track_specs`.
+    pub fn frame_video_tracks(&self) -> Vec<VideoTrackSpec> {
+        self.inner.lock().frame_video_tracks().map(videotrackspec_from_core).collect()
     }
 
     /// Declared state schema, in declaration order.
@@ -910,7 +927,7 @@ pub struct Portal {
     state_fields: Vec<String>,
     action_fields: Vec<String>,
     video_tracks: Vec<String>,
-    frame_video_tracks: Vec<FrameVideoSpec>,
+    video_track_specs: Vec<VideoTrackSpec>,
     action_chunks: Vec<ChunkSpec>,
 }
 
@@ -925,15 +942,8 @@ impl Portal {
         let state_fields: Vec<String> = cfg.state_fields().map(String::from).collect();
         let action_fields: Vec<String> = cfg.action_fields().map(String::from).collect();
         let video_tracks: Vec<String> = cfg.video_track_names().map(String::from).collect();
-        let frame_video_tracks: Vec<FrameVideoSpec> = cfg
-            .frame_video_tracks()
-            .iter()
-            .map(|s| FrameVideoSpec {
-                name: s.name.clone(),
-                codec: s.codec.into(),
-                quality: s.quality,
-            })
-            .collect();
+        let video_track_specs: Vec<VideoTrackSpec> =
+            cfg.video_tracks().iter().map(videotrackspec_from_core).collect();
         let action_chunks: Vec<ChunkSpec> =
             cfg.action_chunks().iter().map(chunkspec_from_core).collect();
 
@@ -976,7 +986,7 @@ impl Portal {
         // with WebRTC tracks on the core side, so a single registration
         // surface works for both — the foreign side only sees one
         // `on_video_frame(track, frame)` event stream per Portal.
-        for track in video_tracks.iter().chain(frame_video_tracks.iter().map(|s| &s.name)) {
+        for track in &video_tracks {
             let cb = callbacks.clone();
             let track_name = track.clone();
             inner.on_video_frame(track, move |_name, frame| {
@@ -1010,7 +1020,7 @@ impl Portal {
             state_fields,
             action_fields,
             video_tracks,
-            frame_video_tracks,
+            video_track_specs,
             action_chunks,
         })
     }
@@ -1120,15 +1130,27 @@ impl Portal {
         self.action_fields.clone()
     }
 
+    /// Names of every declared video track, in declaration order, whatever
+    /// transport its codec selects.
     pub fn video_tracks(&self) -> Vec<String> {
         self.video_tracks.clone()
     }
 
-    /// Declared frame-video tracks (name + codec + quality), in declaration
-    /// order. Frame-video tracks ride a byte-stream channel rather than the
-    /// WebRTC media path; the user-facing send/receive API is the same.
-    pub fn frame_video_tracks(&self) -> Vec<FrameVideoSpec> {
-        self.frame_video_tracks.clone()
+    /// Every declared video track with its codec and options, in declaration
+    /// order.
+    pub fn video_track_specs(&self) -> Vec<VideoTrackSpec> {
+        self.video_track_specs.clone()
+    }
+
+    /// The byte-stream subset (Raw / Png / Mjpeg) of `video_track_specs`.
+    /// These ride a byte-stream channel rather than the WebRTC media path;
+    /// the user-facing send/receive API is the same either way.
+    pub fn frame_video_tracks(&self) -> Vec<VideoTrackSpec> {
+        self.video_track_specs
+            .iter()
+            .filter(|s| !core::Codec::from(s.codec).is_webrtc())
+            .cloned()
+            .collect()
     }
 
     pub fn action_chunks(&self) -> Vec<ChunkSpec> {
@@ -1339,7 +1361,11 @@ impl RobotConfig {
         self.inner.video_tracks()
     }
 
-    pub fn frame_video_tracks(&self) -> Vec<FrameVideoSpec> {
+    pub fn video_track_specs(&self) -> Vec<VideoTrackSpec> {
+        self.inner.video_track_specs()
+    }
+
+    pub fn frame_video_tracks(&self) -> Vec<VideoTrackSpec> {
         self.inner.frame_video_tracks()
     }
 
@@ -1530,7 +1556,11 @@ impl OperatorConfig {
         self.inner.video_tracks()
     }
 
-    pub fn frame_video_tracks(&self) -> Vec<FrameVideoSpec> {
+    pub fn video_track_specs(&self) -> Vec<VideoTrackSpec> {
+        self.inner.video_track_specs()
+    }
+
+    pub fn frame_video_tracks(&self) -> Vec<VideoTrackSpec> {
         self.inner.frame_video_tracks()
     }
 
@@ -1660,7 +1690,11 @@ impl Robot {
         self.inner.video_tracks()
     }
 
-    pub fn frame_video_tracks(&self) -> Vec<FrameVideoSpec> {
+    pub fn video_track_specs(&self) -> Vec<VideoTrackSpec> {
+        self.inner.video_track_specs()
+    }
+
+    pub fn frame_video_tracks(&self) -> Vec<VideoTrackSpec> {
         self.inner.frame_video_tracks()
     }
 
@@ -1800,7 +1834,11 @@ impl Operator {
         self.inner.video_tracks()
     }
 
-    pub fn frame_video_tracks(&self) -> Vec<FrameVideoSpec> {
+    pub fn video_track_specs(&self) -> Vec<VideoTrackSpec> {
+        self.inner.video_track_specs()
+    }
+
+    pub fn frame_video_tracks(&self) -> Vec<VideoTrackSpec> {
         self.inner.frame_video_tracks()
     }
 

--- a/livekit-portal/src/config.rs
+++ b/livekit-portal/src/config.rs
@@ -60,49 +60,38 @@ impl From<FieldSpec> for (String, DType) {
     }
 }
 
-/// One byte-stream video track declaration: name, codec, and per-codec
-/// quality.
+/// One declared video track: name, codec, and the per-codec options.
 ///
-/// These tracks bypass the WebRTC media path and ride a reliable byte-stream
-/// channel instead. Each frame is encoded once on the sender (Raw / PNG /
-/// MJPEG) and decoded back to RGB on the receiver. The user-facing API is
-/// identical to WebRTC video — `send_video_frame` / `on_video_frame` /
-/// `get_video_frame` — only the wire transport differs. Selected at config
-/// time by passing a non-`H264` codec to `PortalConfig::add_video`.
+/// One type for every track regardless of transport, because `add_video` is
+/// one method regardless of transport. `codec` is the discriminant: a WebRTC
+/// codec (`H264` / `Vp8` / `Vp9` / `Av1` / `H265`) rides the WebRTC media
+/// path (RTP/SRTP), and a byte-stream codec (`Raw` / `Png` / `Mjpeg`) is
+/// encoded per frame and shipped over a reliable byte stream. The
+/// user-facing API is identical either way — `send_video_frame` /
+/// `on_video_frame` / `get_video_frame` all speak RGB — only the wire
+/// transport differs.
 ///
-/// `quality` is honored for `Mjpeg` (1..=100) and ignored for `Raw` and
-/// `Png`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FrameVideoSpec {
-    pub name: String,
-    pub codec: Codec,
-    pub quality: u8,
-}
-
-impl FrameVideoSpec {
-    pub fn new(name: impl Into<String>, codec: Codec, quality: u8) -> Self {
-        Self { name: name.into(), codec, quality }
-    }
-}
-
-/// One WebRTC video track declaration: name, WebRTC codec, an optional
-/// encoder bitrate ceiling, and the two encoder-behavior toggles.
+/// Each option is honored by the transport its codec selects and ignored by
+/// the other, exactly as `PortalConfig::add_video` documents:
 ///
-/// The WebRTC counterpart to `FrameVideoSpec`. These tracks ride the WebRTC
-/// media path (RTP/SRTP). `codec` is always a WebRTC codec (`H264` / `Vp8` /
-/// `Vp9` / `Av1` / `H265`) — `add_video` routes byte-stream codecs to
-/// `FrameVideoSpec` instead. `max_bitrate_kbps` caps the encoder's peak rate
-/// in kilobits per second; `None` means use `DEFAULT_H264_MAX_BITRATE_KBPS`.
-/// The cap is a ceiling, not a target — libwebrtc still picks a lower
-/// operating bitrate from content. Selected at config time by passing a
-/// WebRTC codec to `PortalConfig::add_video`.
+///   * `quality` — `Mjpeg` only, 1..=100.
+///   * `max_bitrate_kbps` — WebRTC only. Caps the encoder's peak rate in
+///     kilobits per second; a ceiling, not a target. `None` means
+///     `DEFAULT_H264_MAX_BITRATE_KBPS`.
+///   * `simulcast` / `screencast` — WebRTC only, both `false` by default.
+///     See `PortalConfig::add_video` for what each one does.
 ///
-/// `simulcast` and `screencast` both default to `false`. See
-/// `PortalConfig::add_video` for what each one does.
+/// An option set against the wrong transport is rejected by the YAML loader
+/// and ignored by `add_video`, so a spec may carry a value its own codec
+/// never reads. `quality` is the one that is normalized rather than left
+/// dangling, since it is the only option with no natural "unset".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VideoTrackSpec {
     pub name: String,
     pub codec: Codec,
+    /// JPEG quality (1..=100) for `Mjpeg`, and `0` for every other codec —
+    /// nothing else reads it. See `PortalConfig::add_video`.
+    pub quality: u8,
     pub max_bitrate_kbps: Option<u32>,
     /// Publish multiple spatial layers so the SFU can pick per subscriber.
     /// Costs encode CPU and only pays off with several subscribers on
@@ -119,11 +108,19 @@ impl VideoTrackSpec {
     pub fn new(
         name: impl Into<String>,
         codec: Codec,
+        quality: u8,
         max_bitrate_kbps: Option<u32>,
         simulcast: bool,
         screencast: bool,
     ) -> Self {
-        Self { name: name.into(), codec, max_bitrate_kbps, simulcast, screencast }
+        Self { name: name.into(), codec, quality, max_bitrate_kbps, simulcast, screencast }
+    }
+
+    /// Whether this track rides the WebRTC media path. The one question the
+    /// transport-specific code paths ask; everything else treats the list as
+    /// undifferentiated.
+    pub fn is_webrtc(&self) -> bool {
+        self.codec.is_webrtc()
     }
 }
 
@@ -156,8 +153,10 @@ impl ChunkSpec {
 pub struct PortalConfig {
     pub(crate) session: String,
     pub(crate) role: Role,
+    /// Every declared video track, in declaration order, regardless of
+    /// transport. `add_video` is one method, so this is one list; the
+    /// transport-specific paths filter on `VideoTrackSpec::is_webrtc`.
     pub(crate) video_tracks: Vec<VideoTrackSpec>,
-    pub(crate) frame_video_tracks: Vec<FrameVideoSpec>,
     pub(crate) state_schema: Vec<FieldSpec>,
     pub(crate) action_schema: Vec<FieldSpec>,
     pub(crate) action_chunks: Vec<ChunkSpec>,
@@ -201,7 +200,6 @@ impl PortalConfig {
             session: session.into(),
             role,
             video_tracks: Vec::new(),
-            frame_video_tracks: Vec::new(),
             state_schema: Vec::new(),
             action_schema: Vec::new(),
             action_chunks: Vec::new(),
@@ -314,22 +312,23 @@ impl PortalConfig {
         if let Some(kbps) = max_bitrate_kbps {
             assert!(kbps > 0, "max_bitrate_kbps must be > 0, got {kbps}");
         }
-        if codec.is_webrtc() {
-            self.video_tracks.push(VideoTrackSpec::new(
-                name,
-                codec,
-                max_bitrate_kbps,
-                simulcast.unwrap_or(false),
-                screencast.unwrap_or(false),
-            ));
-        } else {
-            self.frame_video_tracks.push(FrameVideoSpec::new(name, codec, quality));
-        }
+        // Only the MJPEG encoder reads `quality`. Canonicalize it to 0
+        // everywhere else so a spec never reports a JPEG quality nothing will
+        // use, and so a YAML-built config compares equal to the same config
+        // built programmatically — the loader already passes 0 here.
+        let quality = if codec == Codec::Mjpeg { quality } else { 0 };
+        self.video_tracks.push(VideoTrackSpec::new(
+            name,
+            codec,
+            quality,
+            max_bitrate_kbps,
+            simulcast.unwrap_or(false),
+            screencast.unwrap_or(false),
+        ));
     }
 
     fn has_track(&self, name: &str) -> bool {
         self.video_tracks.iter().any(|s| s.name == name)
-            || self.frame_video_tracks.iter().any(|s| s.name == name)
     }
 
     /// Declare state fields with per-field dtype. Order is significant and
@@ -567,26 +566,27 @@ impl PortalConfig {
         track_names.iter().map(|n| self.stall_for(n)).collect()
     }
 
-    /// Declared WebRTC (H264) video tracks (name + optional bitrate cap), in
-    /// declaration order.
+    /// Every declared video track, in declaration order, whatever transport
+    /// it rides. A name passed to `add_video` is in here — there is no
+    /// second list, and no codec that opts a track out of this answer.
     pub fn video_tracks(&self) -> &[VideoTrackSpec] {
         &self.video_tracks
     }
 
-    /// WebRTC (H264) video track names, derived from `video_tracks`.
+    /// Names of every declared video track, derived from `video_tracks`.
+    /// Does not allocate.
     pub fn video_track_names(&self) -> impl Iterator<Item = &str> {
         self.video_tracks.iter().map(|s| s.name.as_str())
     }
 
-    /// Declared frame-video tracks (name + codec + quality), in declaration
-    /// order.
-    pub fn frame_video_tracks(&self) -> &[FrameVideoSpec] {
-        &self.frame_video_tracks
-    }
-
-    /// Frame-video track names, derived from `frame_video_tracks`.
-    pub fn frame_video_track_names(&self) -> impl Iterator<Item = &str> {
-        self.frame_video_tracks.iter().map(|s| s.name.as_str())
+    /// The byte-stream subset of `video_tracks` — the tracks that ride a
+    /// per-frame byte stream rather than the WebRTC media path.
+    ///
+    /// A convenience filter for the encode paths, not a second source of
+    /// truth: it can only ever return specs that `video_tracks` also
+    /// returns.
+    pub fn frame_video_tracks(&self) -> impl Iterator<Item = &VideoTrackSpec> {
+        self.video_tracks.iter().filter(|s| !s.is_webrtc())
     }
 
     /// Ordered state field names. Derived from `state_schema`; does not

--- a/livekit-portal/src/config_file.rs
+++ b/livekit-portal/src/config_file.rs
@@ -413,13 +413,16 @@ action_chunks:
     #[test]
     fn full_config_round_trip() {
         let cfg = PortalConfig::from_yaml_str(yaml_full(), "demo", Role::Robot).unwrap();
-        assert_eq!(cfg.video_track_names().collect::<Vec<_>>(), ["front"]);
+        // Every declared track, in declaration order, whatever its codec.
+        assert_eq!(cfg.video_track_names().collect::<Vec<_>>(), ["front", "wrist", "depth"]);
         assert_eq!(cfg.video_tracks()[0].max_bitrate_kbps, Some(4000));
-        assert_eq!(cfg.frame_video_tracks().len(), 2);
-        assert_eq!(cfg.frame_video_tracks()[0].name, "wrist");
-        assert_eq!(cfg.frame_video_tracks()[0].codec, Codec::Mjpeg);
-        assert_eq!(cfg.frame_video_tracks()[0].quality, 80);
-        assert_eq!(cfg.frame_video_tracks()[1].codec, Codec::Png);
+        assert_eq!(cfg.video_tracks()[1].codec, Codec::Mjpeg);
+        assert_eq!(cfg.video_tracks()[1].quality, 80);
+        assert_eq!(cfg.video_tracks()[2].codec, Codec::Png);
+
+        // The byte-stream filter is a view over that same list.
+        let frame: Vec<&str> = cfg.frame_video_tracks().map(|s| s.name.as_str()).collect();
+        assert_eq!(frame, ["wrist", "depth"]);
 
         let state: Vec<&str> = cfg.state_fields().collect();
         assert_eq!(state, vec!["joint_pos", "gripper"]);
@@ -450,7 +453,7 @@ action_chunks:
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
         // Same defaults as `PortalConfig::new`.
         assert_eq!(cfg.video_tracks().len(), 0);
-        assert_eq!(cfg.frame_video_tracks().len(), 0);
+        assert_eq!(cfg.frame_video_tracks().count(), 0);
         assert_eq!(cfg.state_schema().len(), 0);
         assert_eq!(cfg.action_schema().len(), 0);
         assert_eq!(cfg.action_chunks().len(), 0);
@@ -472,7 +475,7 @@ videos:
   - { name: cam, codec: mjpeg }
 "#;
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
-        assert_eq!(cfg.frame_video_tracks()[0].quality, DEFAULT_MJPEG_QUALITY);
+        assert_eq!(cfg.video_tracks()[0].quality, DEFAULT_MJPEG_QUALITY);
     }
 
     #[test]
@@ -499,7 +502,7 @@ videos:
         let cfg = PortalConfig::from_yaml_str(yaml, "demo", Role::Robot).unwrap();
         assert_eq!(cfg.video_track_names().collect::<Vec<_>>(), ["a", "b", "c", "d"]);
         // No byte-stream tracks: every codec here rides the WebRTC path.
-        assert_eq!(cfg.frame_video_tracks().len(), 0);
+        assert_eq!(cfg.frame_video_tracks().count(), 0);
         assert_eq!(cfg.video_tracks()[1].codec, Codec::Vp9);
         assert_eq!(cfg.video_tracks()[1].max_bitrate_kbps, Some(3000));
     }

--- a/livekit-portal/src/frame_video.rs
+++ b/livekit-portal/src/frame_video.rs
@@ -76,7 +76,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::codec::{Codec, decode_frame, encode_frame_into, estimated_encoded_size};
-use crate::config::FrameVideoSpec;
+use crate::config::VideoTrackSpec;
 use crate::error::{PortalError, PortalResult};
 use crate::metrics::TrackMetrics;
 use crate::portal::ObservationSink;
@@ -236,7 +236,7 @@ pub(crate) fn deserialize_frame(bytes: &[u8]) -> Result<DeserializedHeader<'_>, 
 /// the dispatcher needs, so each received frame does one HashMap lookup
 /// instead of three. Built once at `Portal::new` and never mutated.
 pub(crate) struct FrameVideoTrackEntry {
-    pub spec: FrameVideoSpec,
+    pub spec: VideoTrackSpec,
     pub metrics: Arc<TrackMetrics>,
     pub slots: Arc<VideoTrackSlots>,
 }
@@ -250,7 +250,7 @@ pub(crate) struct FrameVideoTrackEntry {
 /// `try_send` boundary (video tolerates loss; latency under load is more
 /// important than fidelity).
 pub(crate) struct FrameVideoPublisher {
-    spec: FrameVideoSpec,
+    spec: VideoTrackSpec,
     tx: mpsc::Sender<Vec<u8>>,
     task: Option<JoinHandle<()>>,
     metrics: Arc<TrackMetrics>,
@@ -258,7 +258,7 @@ pub(crate) struct FrameVideoPublisher {
 
 impl FrameVideoPublisher {
     pub fn new(
-        spec: FrameVideoSpec,
+        spec: VideoTrackSpec,
         local_participant: LocalParticipant,
         metrics: Arc<TrackMetrics>,
     ) -> Self {

--- a/livekit-portal/src/lib.rs
+++ b/livekit-portal/src/lib.rs
@@ -31,8 +31,7 @@ mod video;
 
 pub use codec::Codec;
 pub use config::{
-    ChunkSpec, DEFAULT_H264_MAX_BITRATE_KBPS, FieldSpec, FrameVideoSpec, PortalConfig,
-    VideoTrackSpec,
+    ChunkSpec, DEFAULT_H264_MAX_BITRATE_KBPS, FieldSpec, PortalConfig, VideoTrackSpec,
 };
 pub use config_file::ConfigFileError;
 pub use dtype::DType;

--- a/livekit-portal/src/portal.rs
+++ b/livekit-portal/src/portal.rs
@@ -331,7 +331,7 @@ impl Portal {
         // Slots and metrics cover both transports. Frame-video and WebRTC
         // tracks share the same VideoFrameData / VideoTrackSlots / sync
         // buffer, so the consumer-facing API is identical.
-        let all_track_names = combined_track_names(&config);
+        let all_track_names: Vec<String> = config.video_track_names().map(String::from).collect();
         let video_tracks: HashMap<String, Arc<VideoTrackSlots>> = all_track_names
             .iter()
             .map(|name| (name.clone(), Arc::new(VideoTrackSlots::new())))
@@ -357,8 +357,7 @@ impl Portal {
         // rather than a `String`-cloning map clone.
         let frame_video_entries: Arc<HashMap<String, Arc<FrameVideoTrackEntry>>> = Arc::new(
             config
-                .frame_video_tracks
-                .iter()
+                .frame_video_tracks()
                 .map(|spec| {
                     let slots = video_tracks
                         .get(&spec.name)
@@ -604,8 +603,7 @@ impl Portal {
         // no publisher means "wrong role" — same shape as `send_state` /
         // `send_action_chunk`.
         if self.config.role != Role::Robot
-            && (self.config.video_tracks.iter().any(|s| s.name == track_name)
-                || self.config.frame_video_tracks.iter().any(|s| s.name == track_name))
+            && self.config.video_tracks.iter().any(|s| s.name == track_name)
         {
             return Err(PortalError::WrongRole(self.config.role));
         }
@@ -1224,7 +1222,7 @@ impl Portal {
     async fn setup_robot(&self, room: &Room) -> PortalResult<()> {
         let lp = room.local_participant();
 
-        for spec in &self.config.video_tracks {
+        for spec in self.config.video_tracks.iter().filter(|s| s.is_webrtc()) {
             let track_name = &spec.name;
             let track_metrics =
                 self.metrics.track(track_name).expect("track metrics registered at construction");
@@ -1250,7 +1248,7 @@ impl Portal {
         // Frame-video publishers don't go through `LocalParticipant.publish_track`
         // — they emit one byte stream per frame instead. So no async setup
         // here, just spawn the per-track drainer task.
-        for spec in &self.config.frame_video_tracks {
+        for spec in self.config.frame_video_tracks() {
             let track_metrics =
                 self.metrics.track(&spec.name).expect("track metrics registered at construction");
             let publisher = FrameVideoPublisher::new(spec.clone(), lp.clone(), track_metrics);
@@ -1355,15 +1353,6 @@ impl Portal {
 /// it on the given LocalParticipant. Payload types are converted at the
 /// boundary — the SDK's `RpcInvocationData` / `RpcError` never leak into
 /// caller-facing code.
-/// Names of every video track on a config, regardless of transport. Used
-/// when registering metrics and sync-buffer slots, since the consumer-facing
-/// API doesn't distinguish WebRTC and frame-video tracks.
-fn combined_track_names(config: &PortalConfig) -> Vec<String> {
-    let mut names: Vec<String> = config.video_tracks.iter().map(|s| s.name.clone()).collect();
-    names.extend(config.frame_video_tracks.iter().map(|s| s.name.clone()));
-    names
-}
-
 fn register_handler_on(lp: &LocalParticipant, method: String, handler: RpcHandler) {
     lp.register_rpc_method(method, move |data| {
         let handler = handler.clone();

--- a/python/packages/livekit-portal/livekit/portal/__init__.py
+++ b/python/packages/livekit-portal/livekit/portal/__init__.py
@@ -61,7 +61,10 @@ VideoCodec = _ffi.VideoCodec
 FrameSource = _ffi.FrameSource
 StallBehavior = _ffi.StallBehavior
 FieldSpec = _ffi.FieldSpec
-FrameVideoSpec = _ffi.FrameVideoSpec
+VideoTrackSpec = _ffi.VideoTrackSpec
+# Deprecated alias. `FrameVideoSpec` was the byte-stream-only record; there is
+# now one spec type for every track, and `frame_video_tracks` returns it.
+FrameVideoSpec = VideoTrackSpec
 ChunkSpec = _ffi.ChunkSpec
 VideoFrameData = _ffi.VideoFrame
 PortalMetrics = _ffi.PortalMetrics
@@ -78,19 +81,6 @@ RpcError = _ffi.RpcError
 # Default JPEG quality for `add_video` with `VideoCodec.MJPEG` when no
 # explicit value is given. Mirrors the Rust core's `DEFAULT_MJPEG_QUALITY`.
 DEFAULT_MJPEG_QUALITY: int = 90
-
-# Codecs that ride the WebRTC media path. The rest ride the per-frame
-# byte-stream channel. Mirrors the Rust core's `Codec::is_webrtc`; used to
-# route `add_video` declarations into the right Python-side mirror list.
-_WEBRTC_CODECS = frozenset(
-    {
-        VideoCodec.H264,
-        VideoCodec.VP8,
-        VideoCodec.VP9,
-        VideoCodec.AV1,
-        VideoCodec.H265,
-    }
-)
 
 # A schema entry accepted by add_state_typed/add_action_typed. Either a
 # FieldSpec (record passthrough) or a (name, dtype) tuple — the latter is
@@ -715,8 +705,8 @@ class _RpcHandlerAdapter(_ffi.RpcHandler):
 class PortalConfig:
     """Builder for a Portal session.
 
-    State (`video_tracks`, `state_schema`, `action_schema`) is mirrored in
-    Python for fast lookup — the Rust side owns the authoritative copy.
+    State (`video_track_specs`, `state_schema`, `action_schema`) is mirrored
+    in Python for fast lookup — the Rust side owns the authoritative copy.
     Use `add_state_typed` / `add_action_typed` with `(name, DType)` pairs to
     declare fields.
     """
@@ -725,8 +715,7 @@ class PortalConfig:
         "_inner",
         "_session",
         "_role",
-        "_video_tracks",
-        "_frame_video_tracks",
+        "_video_track_specs",
         "_state_schema",
         "_action_schema",
         "_action_chunks",
@@ -736,8 +725,7 @@ class PortalConfig:
         self._inner = _ffi.PortalConfig(session, role)
         self._session = session
         self._role = role
-        self._video_tracks: List[str] = []
-        self._frame_video_tracks: List[FrameVideoSpec] = []
+        self._video_track_specs: List[VideoTrackSpec] = []
         self._state_schema: List[FieldSpec] = []
         self._action_schema: List[FieldSpec] = []
         self._action_chunks: List[ChunkSpec] = []
@@ -793,8 +781,7 @@ class PortalConfig:
         instance._inner = inner
         instance._session = session
         instance._role = role
-        instance._video_tracks = list(inner.video_tracks())
-        instance._frame_video_tracks = list(inner.frame_video_tracks())
+        instance._video_track_specs = list(inner.video_track_specs())
         instance._state_schema = list(inner.state_schema())
         instance._action_schema = list(inner.action_schema())
         instance._action_chunks = list(inner.action_chunks())
@@ -810,11 +797,33 @@ class PortalConfig:
 
     @property
     def video_tracks(self) -> List[str]:
-        return list(self._video_tracks)
+        """Names of every declared video track, in declaration order.
+
+        Every name passed to `add_video` is here, whatever codec it was
+        given — the codec picks the wire transport, not whether the track
+        counts as declared. For the codecs and encoder options too, see
+        `video_track_specs`.
+        """
+        return [s.name for s in self._video_track_specs]
 
     @property
-    def frame_video_tracks(self) -> List[FrameVideoSpec]:
-        return list(self._frame_video_tracks)
+    def video_track_specs(self) -> List[VideoTrackSpec]:
+        """Every declared video track with its codec and options, in
+        declaration order. The full readback of what `add_video` was given.
+        """
+        return list(self._video_track_specs)
+
+    @property
+    def frame_video_tracks(self) -> List[VideoTrackSpec]:
+        """The byte-stream subset of `video_track_specs` — the tracks whose
+        codec (`RAW` / `PNG` / `MJPEG`) rides a per-frame byte stream rather
+        than the WebRTC media path.
+
+        A filtered view, not a second list: everything here is also in
+        `video_tracks`. Callers that only want to know what was declared
+        want `video_tracks`.
+        """
+        return list(self._inner.frame_video_tracks())
 
     @property
     def state_fields(self) -> List[str]:
@@ -905,6 +914,9 @@ class PortalConfig:
     ) -> None:
         """Declare a video track.
 
+        Every declared track — whatever its codec — comes back from
+        `video_tracks`, `video_track_specs`, and `on_video_frame`.
+
         `codec` picks both the encoding and the wire transport. The
         user-facing send/receive API is identical regardless of codec —
         `send_video_frame` accepts RGB and `on_video_frame` /
@@ -973,12 +985,7 @@ class PortalConfig:
             stall_behavior,
             max_lag_ms,
         )
-        if codec in _WEBRTC_CODECS:
-            self._video_tracks.append(name)
-        else:
-            self._frame_video_tracks.append(
-                FrameVideoSpec(name=name, codec=codec, quality=quality)
-            )
+        self._video_track_specs = list(self._inner.video_track_specs())
 
     def add_state_typed(self, schema: Iterable[SchemaEntry]) -> None:
         """Declare state fields with per-field dtype.
@@ -1532,10 +1539,32 @@ class _RoleConfigBase:
 
     @property
     def video_tracks(self) -> List[str]:
+        """Names of every declared video track, in declaration order.
+
+        Every name passed to `add_video` is here, whatever codec it was
+        given — the codec picks the wire transport, not whether the track
+        counts as declared. For the codecs and encoder options too, see
+        `video_track_specs`.
+        """
         return list(self._inner.video_tracks())
 
     @property
-    def frame_video_tracks(self) -> List[FrameVideoSpec]:
+    def video_track_specs(self) -> List[VideoTrackSpec]:
+        """Every declared video track with its codec and options, in
+        declaration order. The full readback of what `add_video` was given.
+        """
+        return list(self._inner.video_track_specs())
+
+    @property
+    def frame_video_tracks(self) -> List[VideoTrackSpec]:
+        """The byte-stream subset of `video_track_specs` — the tracks whose
+        codec (`RAW` / `PNG` / `MJPEG`) rides a per-frame byte stream rather
+        than the WebRTC media path.
+
+        A filtered view, not a second list: everything here is also in
+        `video_tracks`. Callers that only want to know what was declared
+        want `video_tracks`.
+        """
         return list(self._inner.frame_video_tracks())
 
     @property
@@ -2061,6 +2090,7 @@ __all__ = [
     "FrameSource",
     "StallBehavior",
     "FieldSpec",
+    "VideoTrackSpec",
     "FrameVideoSpec",
     "ChunkSpec",
     "TypedScalar",

--- a/python/packages/livekit-portal/tests/test_config.py
+++ b/python/packages/livekit-portal/tests/test_config.py
@@ -74,8 +74,48 @@ def test_screencast_on_byte_stream_codec_is_ignored_not_rejected():
     # the byte-stream path. Only the YAML loader rejects it outright.
     cfg = PortalConfig("demo", Role.ROBOT)
     cfg.add_video("cam", codec=VideoCodec.MJPEG, quality=80, screencast=True)
-    assert cfg.video_tracks == []
+    assert cfg.video_tracks == ["cam"]
     assert [t.name for t in cfg.frame_video_tracks] == ["cam"]
+
+
+def test_video_tracks_is_codec_independent():
+    # The bug this list shape exists to prevent: swapping one documented
+    # codec for another is a transport change, and must not make a declared
+    # track vanish from the obvious accessor.
+    for codec in (
+        VideoCodec.H264,
+        VideoCodec.VP8,
+        VideoCodec.VP9,
+        VideoCodec.AV1,
+        VideoCodec.H265,
+        VideoCodec.RAW,
+        VideoCodec.PNG,
+        VideoCodec.MJPEG,
+    ):
+        cfg = PortalConfig("demo", Role.ROBOT)
+        cfg.add_video("cam", codec=codec)
+        assert cfg.video_tracks == ["cam"], codec
+        assert [s.name for s in cfg.video_track_specs] == ["cam"], codec
+
+
+def test_video_tracks_keeps_declaration_order_across_transports():
+    cfg = PortalConfig("demo", Role.ROBOT)
+    cfg.add_video("a", codec=VideoCodec.MJPEG, quality=80)
+    cfg.add_video("b")
+    cfg.add_video("c", codec=VideoCodec.PNG)
+    assert cfg.video_tracks == ["a", "b", "c"]
+    # frame_video_tracks is a filter over that same list, not a rival to it.
+    assert [s.name for s in cfg.frame_video_tracks] == ["a", "c"]
+
+
+def test_video_track_specs_read_back_webrtc_options():
+    cfg = PortalConfig("demo", Role.ROBOT)
+    cfg.add_video("cam", max_bitrate_kbps=4000, simulcast=True)
+    (spec,) = cfg.video_track_specs
+    assert spec.codec == VideoCodec.H264
+    assert spec.max_bitrate_kbps == 4000
+    assert spec.simulcast is True
+    assert spec.screencast is False
 
 
 def test_mixed_dtype_schema_is_accepted():

--- a/python/packages/livekit-portal/tests/test_config_yaml.py
+++ b/python/packages/livekit-portal/tests/test_config_yaml.py
@@ -73,8 +73,8 @@ def test_from_yaml_str_mirrors_full_schema():
     assert cfg.session == "demo"
     assert cfg.role == Role.ROBOT
 
-    # H264 videos go on the WebRTC list, frame-video codecs on their own list.
-    assert cfg.video_tracks == ["front"]
+    # Every declared track, in declaration order, whatever its codec.
+    assert cfg.video_tracks == ["front", "wrist", "depth"]
     assert [t.name for t in cfg.frame_video_tracks] == ["wrist", "depth"]
     assert cfg.frame_video_tracks[0].codec == VideoCodec.MJPEG
     assert cfg.frame_video_tracks[0].quality == 80
@@ -89,6 +89,23 @@ def test_from_yaml_str_mirrors_full_schema():
     assert len(cfg.action_chunks) == 1
     assert cfg.action_chunks[0].name == "vla"
     assert cfg.action_chunks[0].horizon == 16
+
+
+def test_yaml_and_programmatic_builds_agree():
+    # The two ways to declare the same tracks now produce identical specs.
+    # They did not before: the loader defaulted `quality` per codec while
+    # the programmatic path stored whatever the caller's default was, and
+    # the difference was invisible because only byte-stream tracks kept a
+    # readable spec at all.
+    from_yaml = PortalConfig.from_yaml_str(YAML_FULL, "demo", Role.ROBOT)
+
+    built = PortalConfig("demo", Role.ROBOT)
+    built.add_video("front")
+    built.add_video("wrist", VideoCodec.MJPEG, 80)
+    built.add_video("depth", VideoCodec.PNG)
+
+    assert built.video_tracks == from_yaml.video_tracks
+    assert built.video_track_specs == from_yaml.video_track_specs
 
 
 def test_from_yaml_str_works_with_minimal_doc():
@@ -147,7 +164,7 @@ def test_from_yaml_file_round_trip():
         path = f.name
     try:
         cfg = PortalConfig.from_yaml_file(path, "demo", Role.ROBOT)
-        assert cfg.video_tracks == ["front"]
+        assert cfg.video_tracks == ["front", "wrist", "depth"]
         assert len(cfg.frame_video_tracks) == 2
         assert len(cfg.action_chunks) == 1
     finally:
@@ -163,7 +180,7 @@ def test_yaml_built_config_drives_portal():
     portal = Portal(cfg)
     assert portal._state_fields == ["joint_pos", "gripper"]
     assert portal._action_fields == ["joint_pos"]
-    assert portal._video_tracks == ["front"]
+    assert portal._video_tracks == ["front", "wrist", "depth"]
     assert "vla" in portal._chunk_schemas
 
 


### PR DESCRIPTION
> Stacked on #110 (`feat/sync-stall-policy`) — base it there, and it needs rebasing onto `main` once that merges. The diff here touches none of #110's sync code.

## The bug

`portal.yaml` presents `codec` as a menu of supported values. Swapping one documented value for another turns video off:

```python
cfg.add_video("wrist", codec=VideoCodec.H264)   # cfg.video_tracks == ["wrist"]
cfg.add_video("wrist", codec=VideoCodec.MJPEG)  # cfg.video_tracks == []
```

The track is still declared, still publishes, still fires `on_video_frame`. It is just missing from the accessor whose name says it lists video tracks. Anything that iterates `video_tracks` to subscribe, budget, or record silently covers 5 of the 8 codecs. Neither property had a docstring, and the only mention of the split was one row in `docs/03-portal-api.md`.

## Why it exists

Not a design decision — an unfinished refactor. In #20 frame video landed as a *separate API*:

```rust
pub fn add_video(&mut self, name: impl Into<String>)        // → video_tracks: Vec<String>
pub fn add_frame_video(&mut self, name, codec, quality)     // → frame_video_tracks: Vec<FrameVideoSpec>
```

Two constructors, two lists, two accessors that mirrored them exactly. `video_tracks` was the complete answer to "what did `add_video` declare?"

Two days later #29 unified the constructors into one codec-driven `add_video` and left the read side alone — its message never mentions the accessors. One door in, still two doors out, and the invariant that made the name correct quietly became false.

The clearest evidence that the split outlived its purpose is `portal.rs`, which has been undoing it ever since:

```rust
/// Names of every video track on a config, regardless of transport. Used
/// when registering metrics and sync-buffer slots, since the consumer-facing
/// API doesn't distinguish WebRTC and frame-video tracks.
fn combined_track_names(config: &PortalConfig) -> Vec<String>
```

Metrics registration, sync-buffer slots, `send_video_frame`'s validation and the FFI's `on_video_frame` loop all want the union. Every internal consumer had already voted.

## The change

Unify the storage, not just the accessor — otherwise the same asymmetry just moves down a layer into `video_tracks() -> &[VideoTrackSpec]`.

One `VideoTrackSpec` for every track, `codec` as the discriminant, one `Vec` on `PortalConfig`:

| | before | after |
|---|---|---|
| `video_tracks` (names) | WebRTC subset | every declared track, in declaration order |
| `video_track_specs` | — | every track with codec + options |
| `frame_video_tracks` | second list | filter over the one list |
| `combined_track_names` | reassembled the union | deleted |
| `has_track`, send validation | two scans | one |

`FrameVideoSpec` merges into `VideoTrackSpec`. `.name` / `.codec` / `.quality` all still resolve, so attribute access is source-compatible; `FrameVideoSpec` stays as a deprecated Python alias.

No `webrtc_video_tracks` accessor. Nothing needs it: the WebRTC-only spec accessor had zero non-test callers, the transport paths read `pub(crate)` fields, and the subset is a one-line filter. `frame_video_tracks` survives only because it *does* have callers, and it can no longer be mistaken for the full answer.

Two things fell out on the way:

- **`quality` is normalized to `0` on codecs that never read it.** Only the MJPEG encoder reads it. The loader already passed `0`, the Python default passed `90`, and nothing noticed because the field was unreadable on WebRTC tracks. Now a YAML-built config compares equal to the same config built in Python — there's a test.
- **`video_track_specs` closes a #76 gap.** `max_bitrate_kbps` / `simulcast` / `screencast` were never readable from the bindings, because `VideoTrackSpec` never crossed the FFI. "Every config field readable back" now holds. Drop this property if you'd rather keep the surface flat; nothing else depends on it.

The Python-side `_WEBRTC_CODECS` frozenset — a hand-maintained copy of `Codec::is_webrtc`, there purely to route declarations into the right mirror list — goes away with the routing, and `PortalConfig.add_video` now mirrors from the FFI rather than reconstructing a spec in Python. Both accessors have docstrings on all four config surfaces.

## Breaking

- **Rust:** `PortalConfig::video_tracks()` returns every track, not the WebRTC subset. `frame_video_tracks()` returns an iterator. `FrameVideoSpec` and `frame_video_track_names()` (zero callers) are gone. `VideoTrackSpec::new` takes `quality`.
- **Python:** `video_tracks` includes byte-stream tracks — the fix. `frame_video_tracks` yields `VideoTrackSpec`; field access is unchanged.
- **FFI checksums change**, so `scripts/build_ffi_python.sh` must rerun. The generated module and cdylib aren't tracked, and CI builds them.

## Testing

145 Rust tests, 75 Python (was 71 + 4 new). New coverage: every one of the 8 codecs keeps its track in `video_tracks`; declaration order holds across mixed transports; WebRTC options read back; YAML and programmatic builds produce identical specs.

Not run: the 7 integration tests needing a live LiveKit server. `cargo clippy --workspace --all-features` is clean — note `--all-targets` reports three pre-existing `approx_constant` errors in `dtype.rs` / `serialization.rs`, untouched here and present on the base branch.

## Follow-up

#110's per-track stall config lives in `HashMap<String, _>` side maps keyed by track name, which is the same workaround from the other direction — there was no single spec to hang per-track config on. Folding those onto `VideoTrackSpec` is the natural next step once #110 lands; left out here to keep this rebasable.
