### PR TITLE
ci: install CUDA headers so published Linux x86_64 wheels get NVENC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,23 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y $LINUX_SYSTEM_DEPS
 
+      # NVENC has no cargo feature: webrtc-sys compiles its NVIDIA encoder only
+      # when cuda.h is on disk, so every wheel published before this shipped
+      # software-only H264. cuda.h is all it needs — the NVENC headers are
+      # vendored and the NVIDIA libraries are dlopened, so the wheel still runs
+      # with no GPU. Has to land before the first cargo build.
+      - name: Install CUDA headers for NVENC (Linux x86_64)
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        run: |
+          . /etc/os-release
+          repo="ubuntu${VERSION_ID//./}"  # NVIDIA's naming: ubuntu2204, ubuntu2404
+          curl -fsSL -o /tmp/cuda-keyring.deb \
+            "https://developer.download.nvidia.com/compute/cuda/repos/$repo/x86_64/cuda-keyring_1.1-1_all.deb"
+          sudo dpkg -i /tmp/cuda-keyring.deb
+          sudo apt-get update -y
+          sudo apt-get install -y cuda-cudart-dev-12-6
+          test -f /usr/local/cuda/include/cuda.h
+
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 


### PR DESCRIPTION
Stacked on #111.

`webrtc-sys` has no cargo feature for NVENC — it compiles its NVIDIA H264
encoder only when `cuda.h` is present on disk at build time. The publish
workflow never installed it, so every wheel published so far shipped
software-only H264.

This installs `cuda-cudart-dev-12-6` from NVIDIA's apt repo on the Linux
x86_64 build job, before the first `cargo build`. `cuda.h` is all that's
needed: the NVENC headers are vendored and the NVIDIA libraries are
dlopened at runtime, so the wheel still imports and runs on hosts with no
GPU and no CUDA installed.

The repo name is derived from `/etc/os-release`, so it follows the runner
if the matrix moves from Ubuntu 22.04 to 24.04 (`ubuntu2204` / `ubuntu2404`).
The step is gated on `runner.arch == 'X64'` — NVIDIA publishes no such repo
for the aarch64 runner, and macOS has no NVENC.

`test -f /usr/local/cuda/include/cuda.h` fails the job loudly rather than
silently falling back to a software-only wheel.